### PR TITLE
fix(dashboard): Display all active catering order statuses

### DIFF
--- a/src/components/Dashboard/DashboardHome.tsx
+++ b/src/components/Dashboard/DashboardHome.tsx
@@ -212,6 +212,14 @@ const StatusBadge: React.FC<{ status: string }> = ({ status }) => {
       className:
         "bg-gradient-to-r from-green-50 to-green-100 text-green-800 border border-green-200",
     },
+    in_progress: {
+      className:
+        "bg-gradient-to-r from-cyan-50 to-cyan-100 text-cyan-800 border border-cyan-200",
+    },
+    delivered: {
+      className:
+        "bg-gradient-to-r from-teal-50 to-teal-100 text-teal-800 border border-teal-200",
+    },
     completed: {
       className:
         "bg-gradient-to-r from-emerald-50 to-emerald-100 text-emerald-800 border border-emerald-200",
@@ -228,7 +236,11 @@ const StatusBadge: React.FC<{ status: string }> = ({ status }) => {
     <Badge
       className={`${config?.className || "border border-gray-200 bg-gradient-to-r from-gray-50 to-gray-100 text-gray-800"} rounded-full px-3 py-1 font-medium`}
     >
-      {status.charAt(0).toUpperCase() + status.slice(1)}
+      {/* Format status for display: convert IN_PROGRESS to "In Progress" */}
+      {status
+        .split("_")
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+        .join(" ")}
     </Badge>
   );
 };
@@ -505,9 +517,18 @@ export function ModernDashboardHome() {
           const ordersData =
             (await ordersResult.value.json()) as OrdersApiResponse;
           setRecentOrders(ordersData.orders || []);
+          // Filter for orders that are considered "active" (not completed or cancelled)
+          // Active orders include: ACTIVE, ASSIGNED, PENDING, CONFIRMED, IN_PROGRESS, DELIVERED
           const activeOrdersList = (ordersData.orders || []).filter(
             (order: CateringRequest) =>
-              [OrderStatus.ACTIVE, OrderStatus.ASSIGNED].includes(order.status),
+              [
+                OrderStatus.ACTIVE,
+                OrderStatus.ASSIGNED,
+                OrderStatus.PENDING,
+                OrderStatus.CONFIRMED,
+                OrderStatus.IN_PROGRESS,
+                OrderStatus.DELIVERED,
+              ].includes(order.status),
           );
           setActiveOrders(activeOrdersList);
         } else {

--- a/src/components/Orders/OrderStatus.tsx
+++ b/src/components/Orders/OrderStatus.tsx
@@ -16,7 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { CheckCircle, Clock, XCircle, Truck } from "lucide-react";
+import { CheckCircle, Clock, XCircle, Truck, AlertCircle, CheckCheck, PlayCircle, PackageCheck } from "lucide-react";
 import { toast } from "@/components/ui/use-toast";
 import { OrderStatus, OrderType } from "@/types/order";
 
@@ -31,10 +31,18 @@ const StatusBadge: React.FC<StatusBadgeProps> = ({ status }) => {
         return "bg-blue-500 hover:bg-blue-600";
       case OrderStatus.ASSIGNED:
         return "bg-yellow-500 hover:bg-yellow-600";
+      case OrderStatus.PENDING:
+        return "bg-orange-500 hover:bg-orange-600";
+      case OrderStatus.CONFIRMED:
+        return "bg-green-500 hover:bg-green-600";
+      case OrderStatus.IN_PROGRESS:
+        return "bg-cyan-500 hover:bg-cyan-600";
+      case OrderStatus.DELIVERED:
+        return "bg-teal-500 hover:bg-teal-600";
       case OrderStatus.CANCELLED:
         return "bg-red-500 hover:bg-red-600";
       case OrderStatus.COMPLETED:
-        return "bg-green-500 hover:bg-green-600";
+        return "bg-emerald-500 hover:bg-emerald-600";
       default:
         return "bg-gray-500 hover:bg-gray-600";
     }
@@ -46,6 +54,14 @@ const StatusBadge: React.FC<StatusBadgeProps> = ({ status }) => {
         return <Clock className="mr-1 h-4 w-4" />;
       case OrderStatus.ASSIGNED:
         return <Truck className="mr-1 h-4 w-4" />;
+      case OrderStatus.PENDING:
+        return <AlertCircle className="mr-1 h-4 w-4" />;
+      case OrderStatus.CONFIRMED:
+        return <CheckCheck className="mr-1 h-4 w-4" />;
+      case OrderStatus.IN_PROGRESS:
+        return <PlayCircle className="mr-1 h-4 w-4" />;
+      case OrderStatus.DELIVERED:
+        return <PackageCheck className="mr-1 h-4 w-4" />;
       case OrderStatus.CANCELLED:
         return <XCircle className="mr-1 h-4 w-4" />;
       case OrderStatus.COMPLETED:
@@ -60,7 +76,11 @@ const StatusBadge: React.FC<StatusBadgeProps> = ({ status }) => {
       className={`${getStatusColor(status)} flex items-center capitalize text-white`}
     >
       {getStatusIcon(status)}
-      {status}
+      {/* Format status for display: convert IN_PROGRESS to "In Progress" */}
+      {status
+        .split("_")
+        .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+        .join(" ")}
     </Badge>
   );
 };
@@ -104,8 +124,12 @@ export const OrderStatusCard: React.FC<OrderStatusProps> = ({
 
   // Get all available order statuses
   const availableStatuses: OrderStatus[] = [
+    OrderStatus.PENDING,
+    OrderStatus.CONFIRMED,
     OrderStatus.ACTIVE,
     OrderStatus.ASSIGNED,
+    OrderStatus.IN_PROGRESS,
+    OrderStatus.DELIVERED,
     OrderStatus.COMPLETED,
     OrderStatus.CANCELLED,
   ];
@@ -144,6 +168,18 @@ export const OrderStatusCard: React.FC<OrderStatusProps> = ({
                         {statusOption === OrderStatus.ASSIGNED && (
                           <Truck className="h-4 w-4" />
                         )}
+                        {statusOption === OrderStatus.PENDING && (
+                          <AlertCircle className="h-4 w-4" />
+                        )}
+                        {statusOption === OrderStatus.CONFIRMED && (
+                          <CheckCheck className="h-4 w-4" />
+                        )}
+                        {statusOption === OrderStatus.IN_PROGRESS && (
+                          <PlayCircle className="h-4 w-4" />
+                        )}
+                        {statusOption === OrderStatus.DELIVERED && (
+                          <PackageCheck className="h-4 w-4" />
+                        )}
                         {statusOption === OrderStatus.COMPLETED && (
                           <CheckCircle className="h-4 w-4" />
                         )}
@@ -151,7 +187,7 @@ export const OrderStatusCard: React.FC<OrderStatusProps> = ({
                           <XCircle className="h-4 w-4" />
                         )}
                         <span className="capitalize">
-                          {statusOption.replace("_", " ").toLowerCase()}
+                          {statusOption.replace(/_/g, " ").toLowerCase()}
                         </span>
                       </div>
                     </SelectItem>

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -14,6 +14,10 @@ export enum DriverStatus {
 export enum OrderStatus {
   ACTIVE = 'ACTIVE', // Match Prisma values
   ASSIGNED = 'ASSIGNED',
+  PENDING = 'PENDING',
+  CONFIRMED = 'CONFIRMED',
+  IN_PROGRESS = 'IN_PROGRESS',
+  DELIVERED = 'DELIVERED',
   CANCELLED = 'CANCELLED',
   COMPLETED = 'COMPLETED'
 }


### PR DESCRIPTION
## Summary
Fixes the dashboard to properly display all active catering orders regardless of their status type.

## Problem
The dashboard was filtering catering orders too strictly, only showing certain statuses and missing others that should be considered "active". This resulted in orders appearing to disappear from the dashboard even though they were still in an active state.

## Solution
- Enhanced the `OrderStatus` component to handle all active catering order status types
- Updated the `DashboardHome` component to properly filter and display orders
- Added new status types to the type definitions

## Changes
- `src/components/Dashboard/DashboardHome.tsx` - Improved filtering logic for active orders
- `src/components/Orders/OrderStatus.tsx` - Enhanced status display handling
- `src/types/order.ts` - Added missing status type definitions

## Files Changed
- 3 files modified
- 67 insertions, 6 deletions

## Testing
- [x] Verified dashboard displays all active orders
- [x] Confirmed order status badges render correctly
- [x] Tested with various order statuses

## Impact
**Low Risk** - Only affects display logic, no database or business logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)