### PR TITLE
chore: Add .vercel to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ test-results/
 
 # Documentation markdown files
 docs/markdown/
+.vercel


### PR DESCRIPTION
## Summary
Adds `.vercel` directory to `.gitignore` to prevent Vercel deployment artifacts from being committed to the repository.

## Changes
- Added `.vercel` entry to `.gitignore`

## Why
The `.vercel` directory is automatically generated during Vercel deployments and contains deployment metadata and configuration. This directory should not be version controlled as it's deployment-specific and can contain sensitive information.

## Impact
**No Risk** - Only affects what files are tracked by git. No code changes.

## Files Changed
- `.gitignore` - 1 line added

🤖 Generated with [Claude Code](https://claude.com/claude-code)