### PR TITLE
chore(deps): disable Dependabot version-update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,11 @@
 version: 2
+# Dependabot version-update PRs are disabled (open-pull-requests-limit: 0).
+# Security advisories and Dependabot security-update PRs are unaffected —
+# they are controlled in Settings → Code security and still run.
+# To re-enable routine version bumps, raise open-pull-requests-limit above 0.
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 5
-    groups:
-      all-dependencies:
-        update-types:
-          - "major"
-          - "minor"
-          - "patch"
-    ignore:
-      # Ignore major version updates for Next.js - requires manual migration
-      - dependency-name: "next"
-        update-types: ["version-update:semver-major"]
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Summary

- Set `open-pull-requests-limit: 0` so Dependabot stops opening routine version-bump PRs
- Security advisories and security-update PRs remain active (controlled separately in Settings → Code security), so CVE fixes still surface
- Dropped the grouped/ignore config since it's no longer relevant at limit 0

## Rationale

The weekly/monthly version bump PRs (#359, #362, and prior) are noise — we were resolving the real security issues via targeted PRs (#358, f2b2525, #356) while the bot PRs sat stale and conflicted. Keeping security-update PRs on means critical CVEs still get surfaced automatically.

## Follow-up

- Close open Dependabot version PRs (#359, #362) after this lands.
- To re-enable scheduled version bumps later, raise `open-pull-requests-limit` above 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)