### PR TITLE
chore(deps): disable Dependabot version-update PRs on main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,11 @@
 version: 2
+# Dependabot version-update PRs are disabled (open-pull-requests-limit: 0).
+# Security advisories and Dependabot security-update PRs are unaffected —
+# they are controlled in Settings → Code security and still run.
+# To re-enable routine version bumps, raise open-pull-requests-limit above 0.
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "monthly"
-    open-pull-requests-limit: 5
-    groups:
-      all-dependencies:
-        update-types:
-          - "major"
-          - "minor"
-          - "patch"
-    ignore:
-      # Ignore major version updates for Next.js - requires manual migration
-      - dependency-name: "next"
-        update-types: ["version-update:semver-major"]
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Summary
- Brings the dependabot disable config (already landed in `development` via #363) into `main`, which is the default branch Dependabot reads from
- Sets `open-pull-requests-limit: 0` so routine version bumps stop; security-update PRs remain unaffected
- Fixes the reason #364 (dompurify bump) was opened — main's config still had `limit: 5`

## Context
Cherry-picked from commit 35fec18 on `development`. Only `.github/dependabot.yml` changes — no code touched.

## Test plan
- [ ] Confirm no new non-security Dependabot PRs open after next scheduled run
- [ ] Security advisory PRs (Settings → Code security) still come through

🤖 Generated with [Claude Code](https://claude.com/claude-code)