### PR TITLE
fix(sms-reminders): Twilio signature, admin auth, idempotency

### DIFF
--- a/src/app/api/admin/sms-reminders/_auth.ts
+++ b/src/app/api/admin/sms-reminders/_auth.ts
@@ -1,0 +1,43 @@
+import { createClient } from "@/utils/supabase/server";
+import type { User } from "@supabase/supabase-js";
+
+export type AdminAuthResult =
+  | { authorized: true; user: User; userType: string }
+  | { authorized: false; status: 401 | 403 };
+
+/**
+ * Authorize an SMS-reminder admin request using the project's canonical
+ * `profiles.type` field. The rest of the codebase (middleware, admin pages)
+ * uses this same pattern; relying on `app_metadata.role` would silently lock
+ * out real admins whose Supabase metadata isn't populated.
+ *
+ * `requireWriteRole`: if true (send route), only admin/super_admin pass;
+ * helpdesk is read-only.
+ */
+export async function authorizeSmsAdmin(
+  requireWriteRole = false,
+): Promise<AdminAuthResult> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return { authorized: false, status: 401 };
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("type")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  const userType = (profile?.type ?? "").toLowerCase();
+  const allowed = requireWriteRole
+    ? ["admin", "super_admin"]
+    : ["admin", "super_admin", "helpdesk"];
+
+  if (!allowed.includes(userType)) {
+    return { authorized: false, status: 403 };
+  }
+
+  return { authorized: true, user, userType };
+}

--- a/src/app/api/admin/sms-reminders/cron/route.ts
+++ b/src/app/api/admin/sms-reminders/cron/route.ts
@@ -1,45 +1,43 @@
 import { NextRequest, NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
-import { createClient } from "@/utils/supabase/server";
 import {
   runSmsReminderBatch,
   type ReminderType,
 } from "@/services/sms-reminders";
+import { authorizeSmsAdmin } from "../_auth";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-interface AppMetadata {
-  role?: string;
-}
-
 export async function GET(request: NextRequest) {
   try {
     const cronSecret = process.env.CRON_SECRET;
+    const authHeader = request.headers.get("authorization");
+    const isValidCronRequest =
+      !!cronSecret && authHeader === `Bearer ${cronSecret}`;
+
     if (process.env.NODE_ENV === "production" && !cronSecret) {
       Sentry.captureMessage(
-        "CRON_SECRET not set in production - SMS reminder cron requires authentication",
-        "warning",
+        "CRON_SECRET not set in production — refusing SMS reminder cron",
+        "error",
+      );
+      return NextResponse.json(
+        { error: "CRON_SECRET not configured" },
+        { status: 500 },
       );
     }
 
-    const authHeader = request.headers.get("authorization");
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    const isValidCronRequest =
-      cronSecret && authHeader === `Bearer ${cronSecret}`;
-    const role = (user?.app_metadata as AppMetadata)?.role;
-    const isAdminUser = user && (role === "admin" || role === "super_admin");
-    const isAuthorized = isValidCronRequest || isAdminUser;
-
-    if (!isAuthorized) {
-      return NextResponse.json(
-        { error: "Unauthorized - admin access or valid cron secret required" },
-        { status: 401 },
-      );
+    if (!isValidCronRequest) {
+      const auth = await authorizeSmsAdmin(true);
+      if (!auth.authorized) {
+        return NextResponse.json(
+          {
+            error:
+              "Unauthorized - admin access or valid cron secret required",
+          },
+          { status: 401 },
+        );
+      }
     }
 
     const { searchParams } = new URL(request.url);
@@ -58,7 +56,6 @@ export async function GET(request: NextRequest) {
     if (type === "next_day") {
       targetDate.setDate(targetDate.getDate() + 1);
     }
-    // Reset time to midnight
     targetDate.setHours(0, 0, 0, 0);
 
     const result = await runSmsReminderBatch(type, targetDate, "cron");

--- a/src/app/api/admin/sms-reminders/history/route.ts
+++ b/src/app/api/admin/sms-reminders/history/route.ts
@@ -1,24 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/utils/supabase/server";
 import { prisma } from "@/lib/prisma";
+import { authorizeSmsAdmin } from "../_auth";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-interface AppMetadata {
-  role?: string;
-}
-
 export async function GET(request: NextRequest) {
   try {
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    const role = (user?.app_metadata as AppMetadata)?.role;
-    if (!user || (role !== "admin" && role !== "super_admin")) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    const auth = await authorizeSmsAdmin();
+    if (!auth.authorized) {
+      return NextResponse.json(
+        { error: auth.status === 401 ? "Unauthorized" : "Forbidden" },
+        { status: auth.status },
+      );
     }
 
     const { searchParams } = new URL(request.url);

--- a/src/app/api/admin/sms-reminders/preview/route.ts
+++ b/src/app/api/admin/sms-reminders/preview/route.ts
@@ -1,27 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/utils/supabase/server";
 import {
   previewSmsReminderBatch,
   type ReminderType,
 } from "@/services/sms-reminders";
+import { authorizeSmsAdmin } from "../_auth";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-interface AppMetadata {
-  role?: string;
-}
-
 export async function POST(request: NextRequest) {
   try {
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    const role = (user?.app_metadata as AppMetadata)?.role;
-    if (!user || (role !== "admin" && role !== "super_admin")) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    const auth = await authorizeSmsAdmin();
+    if (!auth.authorized) {
+      return NextResponse.json(
+        { error: auth.status === 401 ? "Unauthorized" : "Forbidden" },
+        { status: auth.status },
+      );
     }
 
     const body = (await request.json()) as {

--- a/src/app/api/admin/sms-reminders/send/route.ts
+++ b/src/app/api/admin/sms-reminders/send/route.ts
@@ -1,28 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/utils/supabase/server";
 import {
   runSmsReminderBatch,
   type ReminderType,
 } from "@/services/sms-reminders";
+import { authorizeSmsAdmin } from "../_auth";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-interface AppMetadata {
-  role?: string;
-}
-
 export async function POST(request: NextRequest) {
   try {
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    const role = (user?.app_metadata as AppMetadata)?.role;
-    if (!user || (role !== "admin" && role !== "super_admin")) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    const auth = await authorizeSmsAdmin(true);
+    if (!auth.authorized) {
+      return NextResponse.json(
+        { error: auth.status === 401 ? "Unauthorized" : "Forbidden" },
+        { status: auth.status },
+      );
     }
+    const { user } = auth;
 
     const body = (await request.json()) as {
       type?: string;

--- a/src/app/api/webhooks/twilio/route.ts
+++ b/src/app/api/webhooks/twilio/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { validateRequest } from "twilio";
 import { prisma } from "@/lib/prisma";
 
 export const dynamic = "force-dynamic";
@@ -11,12 +12,37 @@ export const runtime = "nodejs";
  * Twilio sends form-encoded POST data with fields:
  * - MessageSid: The unique ID of the message
  * - MessageStatus: queued, sent, delivered, undelivered, failed
+ *
+ * Every request is verified via X-Twilio-Signature (HMAC-SHA1 over URL + sorted params)
+ * using TWILIO_AUTH_TOKEN. Unsigned or mismatched requests are rejected — without this,
+ * any caller could mark messages as delivered/failed and poison our audit trail.
  */
 export async function POST(request: NextRequest) {
   try {
+    const authToken = process.env.TWILIO_AUTH_TOKEN;
+    if (!authToken) {
+      console.error("Twilio webhook: TWILIO_AUTH_TOKEN not set — refusing request");
+      return new NextResponse(null, { status: 500 });
+    }
+
+    const signature = request.headers.get("x-twilio-signature") ?? "";
     const formData = await request.formData();
-    const messageSid = formData.get("MessageSid") as string | null;
-    const messageStatus = formData.get("MessageStatus") as string | null;
+
+    const params: Record<string, string> = {};
+    for (const [key, value] of formData.entries()) {
+      params[key] = typeof value === "string" ? value : "";
+    }
+
+    const webhookUrl =
+      process.env.TWILIO_WEBHOOK_URL ?? request.nextUrl.toString();
+
+    if (!validateRequest(authToken, signature, webhookUrl, params)) {
+      console.warn("Twilio webhook: invalid signature");
+      return new NextResponse(null, { status: 403 });
+    }
+
+    const messageSid = params.MessageSid ?? null;
+    const messageStatus = params.MessageStatus ?? null;
 
     if (!messageSid || !messageStatus) {
       return NextResponse.json(
@@ -25,7 +51,6 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Map Twilio statuses to our status values
     const statusMap: Record<string, string> = {
       delivered: "delivered",
       undelivered: "failed",
@@ -34,7 +59,6 @@ export async function POST(request: NextRequest) {
 
     const newStatus = statusMap[messageStatus];
 
-    // Only update on terminal statuses
     if (newStatus) {
       await prisma.smsReminderLog.updateMany({
         where: { providerMsgId: messageSid },
@@ -48,7 +72,6 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    // Twilio expects 200 response
     return new NextResponse(null, { status: 200 });
   } catch (error) {
     console.error("Twilio webhook error:", error);

--- a/src/services/sms-reminders/index.ts
+++ b/src/services/sms-reminders/index.ts
@@ -128,6 +128,30 @@ export async function runSmsReminderBatch(
   helpdeskAgent: string = DEFAULT_HELPDESK_AGENT,
   driverFilter?: string[],
 ): Promise<BatchSummary> {
+  // Idempotency guard: cron retries and double-clicks must not send duplicate
+  // SMS to drivers. Skip if a batch for this (type, targetDate) is already
+  // in_progress or completed. Failed batches stay retryable.
+  const existing = await prisma.smsReminderBatch.findFirst({
+    where: {
+      type,
+      targetDate,
+      status: { in: ["in_progress", "completed"] },
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  if (existing) {
+    return {
+      batchId: existing.id,
+      type,
+      targetDate: targetDate.toISOString().split("T")[0] ?? "",
+      totalDrivers: existing.totalDrivers,
+      totalSent: existing.totalSent,
+      totalFailed: existing.totalFailed,
+      totalSkipped: existing.totalSkipped,
+    };
+  }
+
   let driverGroups = await fetchAndParseSheet(targetDate);
 
   // Filter to specific drivers if requested


### PR DESCRIPTION
## Summary
Addresses three review findings against PR #373 before it lands.

- **P0 — Twilio webhook signature verification.** `/api/webhooks/twilio` now validates `X-Twilio-Signature` via `twilio.validateRequest()` and refuses requests when `TWILIO_AUTH_TOKEN` is unset. Previously, anyone on the internet could mark messages as delivered/failed and corrupt the audit trail.
- **P1 — Admin auth pattern.** Cron, send, preview, and history routes were reading `user.app_metadata.role`, but the rest of the codebase (`middleware.ts`, admin pages) uses `profiles.type`. Real admins would silently get 401s. Centralized into `_auth.ts` using the canonical pattern. Helpdesk gets read access (preview/history); send and cron require admin/super_admin.
- **P1 — Idempotency.** `runSmsReminderBatch` now short-circuits if an `in_progress` or `completed` batch already exists for `(type, targetDate)`. Cron retries and double-clicks no longer send duplicate SMS to drivers. Failed batches stay retryable.
- **Bonus** — Cron route fails closed (500) if `CRON_SECRET` is unset in production, instead of warning to Sentry and continuing.

Targets `feature/sms-driver-reminders` (PR #373) so these land before the feature merges to `development`.

## Test plan
- [ ] Twilio: send a real status callback in dev; verify it 200s with valid signature, 403s without.
- [ ] Admin auth: sign in as a `helpdesk` profile and confirm preview/history work but send returns 403.
- [ ] Admin auth: sign in as an `admin` profile (with no `app_metadata.role`) and confirm send works.
- [ ] Idempotency: trigger the same batch twice in quick succession, confirm the second call returns the existing batch summary without re-sending.
- [ ] Set `NODE_ENV=production` locally without `CRON_SECRET` and confirm the cron route returns 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)