### PR TITLE
fix(calculator): restore zeroOrderSettings column write + gate writes by role

### DIFF
--- a/src/app/api/calculator/configurations/route.ts
+++ b/src/app/api/calculator/configurations/route.ts
@@ -13,12 +13,50 @@ import {
   getActiveConfigurations,
   getConfiguration
 } from '@/lib/calculator/client-configurations';
+import type { SupabaseClient } from '@supabase/supabase-js';
 
-// Helper function to convert DB record to ClientDeliveryConfiguration
+// Calculator pricing changes affect every order — gate writes to admin roles
+// only. Middleware excludes /api routes, so this check has to live in-route.
+async function authorizeCalculatorAdmin(
+  supabase: SupabaseClient,
+): Promise<
+  | { authorized: true; userId: string; userEmail: string | undefined }
+  | { authorized: false; status: 401 | 403 }
+> {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { authorized: false, status: 401 };
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('type')
+    .eq('id', user.id)
+    .maybeSingle();
+
+  const userType = (profile?.type ?? '').toLowerCase();
+  if (!['admin', 'super_admin'].includes(userType)) {
+    return { authorized: false, status: 403 };
+  }
+
+  return { authorized: true, userId: user.id, userEmail: user.email };
+}
+
+// Helper function to convert DB record to ClientDeliveryConfiguration.
+// Reads zeroOrderSettings from the dedicated column first; falls back to the
+// nested customSettings location (written by an earlier revision of this PR)
+// and finally to the in-memory default. Keeping the legacy nested read lets us
+// recover any rows that were written during the buggy window without a backfill.
 function dbToConfig(dbConfig: any): ClientDeliveryConfiguration {
-  // Get the in-memory configuration as fallback for legacy records without zeroOrderSettings
   const inMemoryConfig = getConfiguration(dbConfig.configId);
   const customSettings = dbConfig.customSettings as Record<string, any> | null;
+  const zeroOrderSettings =
+    dbConfig.zeroOrderSettings ??
+    customSettings?.zeroOrderSettings ??
+    inMemoryConfig?.zeroOrderSettings;
+
+  // Strip zeroOrderSettings out of customSettings so we don't echo it back as
+  // a nested duplicate after a read.
+  const { zeroOrderSettings: _stripped, ...restCustomSettings } =
+    customSettings ?? {};
 
   return {
     id: dbConfig.configId,
@@ -32,8 +70,11 @@ function dbToConfig(dbConfig: any): ClientDeliveryConfiguration {
     dailyDriveDiscounts: dbConfig.dailyDriveDiscounts as any,
     driverPaySettings: dbConfig.driverPaySettings as any,
     bridgeTollSettings: dbConfig.bridgeTollSettings as any,
-    zeroOrderSettings: customSettings?.zeroOrderSettings || inMemoryConfig?.zeroOrderSettings,
-    customSettings: customSettings as any,
+    zeroOrderSettings,
+    customSettings:
+      Object.keys(restCustomSettings).length > 0
+        ? (restCustomSettings as any)
+        : undefined,
     createdAt: dbConfig.createdAt,
     updatedAt: dbConfig.updatedAt,
     createdBy: dbConfig.createdBy || undefined,
@@ -41,19 +82,15 @@ function dbToConfig(dbConfig: any): ClientDeliveryConfiguration {
   };
 }
 
-// Helper function to convert ClientDeliveryConfiguration to DB format
+// Helper function to convert ClientDeliveryConfiguration to DB format.
+// zeroOrderSettings goes back into its dedicated Prisma column; customSettings
+// stays a separate JSON bag for genuinely custom future fields.
 function configToDb(config: ClientDeliveryConfiguration, userId?: string) {
-  // Store zeroOrderSettings inside customSettings JSON field
-  const customSettings = {
-    ...(config.customSettings as Record<string, any> || {}),
-    ...(config.zeroOrderSettings ? { zeroOrderSettings: config.zeroOrderSettings } : {}),
-  };
-
   return {
     configId: config.id,
     clientName: config.clientName,
     vendorName: config.vendorName,
-    description: config.description,
+    description: config.description ?? null,
     isActive: config.isActive,
     pricingTiers: config.pricingTiers as any,
     mileageRate: config.mileageRate,
@@ -61,9 +98,10 @@ function configToDb(config: ClientDeliveryConfiguration, userId?: string) {
     dailyDriveDiscounts: config.dailyDriveDiscounts as any,
     driverPaySettings: config.driverPaySettings as any,
     bridgeTollSettings: config.bridgeTollSettings as any,
-    customSettings: customSettings as any,
-    createdBy: userId,
-    notes: config.notes,
+    zeroOrderSettings: (config.zeroOrderSettings as any) ?? null,
+    customSettings: (config.customSettings as any) ?? null,
+    createdBy: userId ?? null,
+    notes: config.notes ?? null,
     updatedAt: new Date()
   };
 }
@@ -150,16 +188,15 @@ export async function GET(request: NextRequest) {
   }
 }
 
-// POST: Create/Update configuration
+// POST: Create/Update configuration (admin/super_admin only)
 export async function POST(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-
-    if (!user) {
+    const auth = await authorizeCalculatorAdmin(supabase);
+    if (!auth.authorized) {
       return NextResponse.json(
-        { success: false, error: 'Unauthorized' },
-        { status: 401 }
+        { success: false, error: auth.status === 401 ? 'Unauthorized' : 'Forbidden' },
+        { status: auth.status }
       );
     }
 
@@ -176,7 +213,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Save to database
-    const dbData = configToDb(config, user?.id);
+    const dbData = configToDb(config, auth.userId);
 
     const savedConfig = await prisma.deliveryConfiguration.upsert({
       where: { configId: config.id },
@@ -201,16 +238,15 @@ export async function POST(request: NextRequest) {
   }
 }
 
-// DELETE: Soft-delete a configuration (sets isActive to false)
+// DELETE: Soft-delete a configuration (admin/super_admin only)
 export async function DELETE(request: NextRequest) {
   try {
     const supabase = await createClient();
-    const { data: { user } } = await supabase.auth.getUser();
-
-    if (!user) {
+    const auth = await authorizeCalculatorAdmin(supabase);
+    if (!auth.authorized) {
       return NextResponse.json(
-        { success: false, error: 'Unauthorized' },
-        { status: 401 }
+        { success: false, error: auth.status === 401 ? 'Unauthorized' : 'Forbidden' },
+        { status: auth.status }
       );
     }
 


### PR DESCRIPTION
## Summary
Addresses two review findings against PR #375 before it lands.

- **P1 — `zeroOrderSettings` data-loss.** PR #375 moved `zeroOrderSettings` from its dedicated Prisma column into the `customSettings` JSON bag. The column still exists in `prisma/schema.prisma`. After deploy, existing rows with `zero_order_settings` populated become invisible and new writes never touch the column. Restored top-level read/write. `dbToConfig` still reads from the nested `customSettings.zeroOrderSettings` as a fallback so any row written during the buggy window is recovered without a backfill.
- **P2 — Authz on POST and DELETE.** Middleware excludes `/api` routes (`src/middleware.ts:192`), and the route only checked `if (!user)`. A logged-in driver, client, or vendor could overwrite or soft-delete any pricing configuration. POST was pre-existing; DELETE is new in this PR and materially expands the surface. Added an in-route admin check using the canonical `profiles.type` pattern (`admin` / `super_admin` only).
- **Bonus** — Restored `?? null` defaults on `description`, `notes`, `createdBy` in `configToDb`. Without them, Prisma treats `undefined` as \"no change\" so clearing those fields via the UI silently fails.

Targets `feature/calculator-enhancements` (PR #375) so these land before the feature merges to `development`.

## Test plan
- [ ] Save a config with `zeroOrderSettings` populated; verify the value lands in the `zero_order_settings` column (not `custom_settings`).
- [ ] Read back the same config; verify `zeroOrderSettings` round-trips correctly and `customSettings` doesn't contain a duplicate.
- [ ] Sign in as a `client` profile and POST/DELETE → expect 403.
- [ ] Sign in as an `admin` profile and POST/DELETE → expect 200.
- [ ] Edit a config to clear the \"notes\" field → verify it's actually NULL in the database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)