### PR TITLE
fix(drives-pipeline): zod-validate write payload + use RAW value input

### DIFF
--- a/src/app/api/drives-pipeline/write/route.ts
+++ b/src/app/api/drives-pipeline/write/route.ts
@@ -1,10 +1,54 @@
 import { NextRequest, NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
+import { z } from "zod";
 import { createClient } from "@/utils/supabase/server";
 import {
   writeCalculationsToSheet,
   type DriveCalculationResult,
 } from "@/lib/google-sheets/drives-pipeline";
+
+const DriveOutputSchema = z.object({
+  totalMileage: z.number().finite(),
+  mileageRate: z.number().finite(),
+  totalMileagePay: z.number().finite(),
+  driverTotalBasePay: z.number().finite(),
+  bonusVariance: z.number().finite(),
+  readySetFee: z.number().finite(),
+  readySetAddonFee: z.number().finite(),
+  readySetMileageRate: z.number().finite(),
+  readySetTotalFee: z.number().finite(),
+  toll: z.number().finite(),
+  tip: z.number().finite(),
+  driverBonusPay: z.number().finite(),
+  adjustment: z.number().finite(),
+  totalDriverPay: z.number().finite(),
+});
+
+const DriveResultSchema = z.object({
+  rowIndex: z.number().int().positive(),
+  status: z.enum(["calculated", "skipped", "error"]),
+  reason: z.string().optional(),
+  vendorName: z.string(),
+  driverName: z.string(),
+  client: z.string(),
+  date: z.string(),
+  headcount: z.number(),
+  foodCost: z.number(),
+  configId: z.string().nullable(),
+  output: DriveOutputSchema.optional(),
+});
+
+const MAX_RESULTS_PER_REQUEST = 5000;
+
+const WriteRequestSchema = z.object({
+  results: z
+    .array(DriveResultSchema)
+    .min(1, "No results to write")
+    .max(
+      MAX_RESULTS_PER_REQUEST,
+      `Too many results (max ${MAX_RESULTS_PER_REQUEST} per request)`,
+    ),
+});
 
 export async function POST(request: NextRequest) {
   try {
@@ -37,14 +81,17 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const results: DriveCalculationResult[] = body.results;
+    const parsed = WriteRequestSchema.safeParse(body);
 
-    if (!Array.isArray(results) || results.length === 0) {
+    if (!parsed.success) {
+      const errors = parsed.error.issues.map((i) => i.message).join(", ");
       return NextResponse.json(
-        { success: false, error: "No results to write" },
+        { success: false, error: `Validation error: ${errors}` },
         { status: 400 },
       );
     }
+
+    const results: DriveCalculationResult[] = parsed.data.results;
 
     const writeResult = await writeCalculationsToSheet(results);
 

--- a/src/lib/google-sheets/client.ts
+++ b/src/lib/google-sheets/client.ts
@@ -85,7 +85,11 @@ export async function updateSheetData(
   await client.spreadsheets.values.update({
     spreadsheetId,
     range: fullRange,
-    valueInputOption: "USER_ENTERED",
+    // RAW (not USER_ENTERED) so values starting with `= + - @` are stored as
+    // literal text instead of evaluated as formulas. Defuses sheet-side
+    // formula injection if any string-typed field is ever added to the write
+    // path. Numeric outputs round-trip identically under either mode.
+    valueInputOption: "RAW",
     requestBody: { values },
   });
 }
@@ -107,7 +111,11 @@ export async function batchUpdateSheetData(
   await client.spreadsheets.values.batchUpdate({
     spreadsheetId,
     requestBody: {
-      valueInputOption: "USER_ENTERED",
+      // RAW (not USER_ENTERED) so values starting with `= + - @` are stored as
+    // literal text instead of evaluated as formulas. Defuses sheet-side
+    // formula injection if any string-typed field is ever added to the write
+    // path. Numeric outputs round-trip identically under either mode.
+    valueInputOption: "RAW",
       data,
     },
   });


### PR DESCRIPTION
## Summary
Addresses two defensive review findings against PR #374.

- **P3 — Write payload validation.** The preview route already uses Zod (`PreviewRequestSchema`), but the write route trusted `body.results` directly. Added matching `DriveResultSchema` + `DriveOutputSchema` and capped requests at 5,000 results so a runaway client can't blow past the Vercel function timeout.
- **P3 — Formula injection defense.** Sheet writes used `valueInputOption: \"USER_ENTERED\"`, which evaluates any value starting with `= + - @` as a formula. Today only numeric output fields are written so there's no live exploit, but the day someone adds a string-typed field to `OUTPUT_FIELDS`, an admin-supplied `=IMPORTDATA(...)` lands as a live formula. Switched to `RAW`. Numbers round-trip identically.

Targets `feature/drives-calculator-automation` (PR #374) so these land before the feature merges to `development`.

## Test plan
- [ ] Send a write request with malformed `results` (missing fields, wrong types) → expect 400 with descriptive error.
- [ ] Send a write request with 5,001 results → expect 400.
- [ ] Send a normal calculated batch and confirm numbers land correctly in the sheet (RAW mode shouldn't change numeric behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)