### PR TITLE
Fix driver status transitions, timestamp persistence, and file access

### DIFF
--- a/src/app/api/orders/[order_number]/files/route.ts
+++ b/src/app/api/orders/[order_number]/files/route.ts
@@ -102,9 +102,24 @@ export async function GET(
       );
     }
 
-    // Check if user has access to the files
+    // Allow drivers assigned to this order to access files
+    let isAssignedDriver = false;
     if (!hasAccess && user.id !== orderUserId) {
-            return NextResponse.json(
+      const dispatch = await prisma.dispatch.findFirst({
+        where: {
+          driverId: user.id,
+          ...(cateringRequest
+            ? { cateringRequestId: orderId }
+            : { onDemandId: orderId }),
+        },
+        select: { id: true },
+      });
+      isAssignedDriver = !!dispatch;
+    }
+
+    // Check if user has access to the files
+    if (!hasAccess && user.id !== orderUserId && !isAssignedDriver) {
+      return NextResponse.json(
         { error: "You do not have permission to access these files" },
         { status: 403 }
       );

--- a/src/app/api/orders/[order_number]/route.ts
+++ b/src/app/api/orders/[order_number]/route.ts
@@ -457,7 +457,19 @@ export async function PATCH(
     // Validate transitions via the centralized state machine; reject illegal
     // transitions with 422. Source of truth: src/lib/state-machine/.
     const currentStatus = ((existingOrder as any).status as OrderStatus | null) ?? null;
-    const currentDriverStatus = ((existingOrder as any).driverStatus as DriverStatus | null) ?? null;
+    let currentDriverStatus = ((existingOrder as any).driverStatus as DriverStatus | null) ?? null;
+
+    // Legacy fix: if driverStatus is null but a driver has been assigned via
+    // Dispatch, treat the current status as ASSIGNED so subsequent transitions
+    // (e.g. EN_ROUTE_TO_VENDOR) are valid.
+    if (currentDriverStatus === null) {
+      const dispatches = (existingOrder as any).dispatches;
+      const hasAssignedDriver =
+        Array.isArray(dispatches) && dispatches.length > 0 && dispatches[0]?.driver;
+      if (hasAssignedDriver) {
+        currentDriverStatus = DriverStatus.ASSIGNED;
+      }
+    }
 
     if (
       driverStatus &&

--- a/src/app/api/orders/assignDriver/route.ts
+++ b/src/app/api/orders/assignDriver/route.ts
@@ -151,6 +151,7 @@ export async function POST(request: Request) {
               currentStatus: (order.status as OrderStatus) ?? null,
               currentDriverStatus: (order.driverStatus as DriverStatusEnum | null) ?? null,
               nextOrderStatus: CateringStatus.ASSIGNED,
+              nextDriverStatus: DriverStatusEnum.ASSIGNED,
             },
             prisma,
           );
@@ -168,6 +169,36 @@ export async function POST(request: Request) {
 
         return { updatedOrder, dispatch };
       });
+
+      // Upsert the Delivery record so the assignedAt timestamp is captured.
+      // Runs outside the transaction (non-critical) — silent failure is acceptable.
+      try {
+        const dbOrderNumber = (result.updatedOrder as any).orderNumber as string;
+        // Resolve Driver model ID from the Profile-based driverId on the dispatch
+        const dispatchDriverProfileId = result.dispatch?.driver?.id as string | undefined;
+        let deliveryDriverId: string | null = null;
+        if (dispatchDriverProfileId) {
+          const driverRecord = await prisma.driver.findFirst({
+            where: { profileId: dispatchDriverProfileId },
+            select: { id: true },
+          });
+          deliveryDriverId = driverRecord?.id ?? null;
+        }
+
+        await prisma.delivery.upsert({
+          where: { orderNumber: dbOrderNumber },
+          update: { assignedAt: new Date() },
+          create: {
+            orderNumber: dbOrderNumber,
+            deliveryAddress: '',
+            driverId: deliveryDriverId,
+            status: 'ASSIGNED',
+            assignedAt: new Date(),
+          },
+        });
+      } catch (deliveryErr) {
+        console.error('Failed to upsert delivery assignedAt:', deliveryErr);
+      }
 
       // Serialize the result before sending the response
       const serializedResult = serializeData(result);


### PR DESCRIPTION
## Summary

Three interconnected bugs prevented drivers from properly updating delivery statuses and accessing order files:

- **422 on status transitions**: When a driver was assigned, the `driverStatus` field on the order record was never set to `ASSIGNED` — it stayed `null`. Subsequent transitions (e.g. `EN_ROUTE_TO_VENDOR`) were rejected by the state machine because `null → EN_ROUTE_TO_VENDOR` is not a valid transition.
- **Missing delivery timestamps on reload**: Because status transitions were failing, the `Delivery` record in the database never received intermediate timestamps (`enRouteToVendorAt`, `arrivedAtVendorAt`, etc.). Timestamps appeared in-session (via frontend fallback) but disappeared on page refresh.
- **403 on order files for drivers**: The `/api/orders/[order_number]/files` endpoint only authorized admin/helpdesk roles and the order creator — assigned drivers were blocked.

## Changed Files

| File | Change |
|------|--------|
| `src/app/api/orders/assignDriver/route.ts` | Added `nextDriverStatus: ASSIGNED` to `transitionOrder()` call; added Delivery upsert to capture `assignedAt` timestamp |
| `src/app/api/orders/[order_number]/route.ts` | Legacy fallback: infer `driverStatus = ASSIGNED` from Dispatch when stored value is `null` |
| `src/app/api/orders/[order_number]/files/route.ts` | Added Dispatch table lookup to authorize assigned drivers for file access |

## Root Cause Analysis

### 1. Driver Status Transition Failure (422)

**Before fix**: `assignDriver/route.ts` called `transitionOrder()` with `nextOrderStatus: ASSIGNED` but omitted `nextDriverStatus`. The order's status changed to `ASSIGNED`, and a Dispatch record was created, but `CateringRequest.driverStatus` remained `null`.

When the driver later clicked "En Route to Resto", the PATCH handler read `currentDriverStatus = null` and validated `canTransitionDriver(null, EN_ROUTE_TO_VENDOR)` → `false` (only `null → ASSIGNED` is allowed).

**After fix**: `nextDriverStatus: DriverStatusEnum.ASSIGNED` is now passed to `transitionOrder()`, setting the field atomically with the order status.

### 2. Legacy Orders with null driverStatus

Orders assigned before this fix have `driverStatus: null` in the database. A backwards-compatible fallback in the PATCH handler now checks: if `driverStatus` is `null` but `dispatches[0].driver` exists, treat current status as `ASSIGNED`.

### 3. Missing assignedAt Timestamp

The `assignDriver` endpoint now upserts a `Delivery` record with `assignedAt` set, ensuring the full delivery lifecycle is captured from the moment a driver is assigned.

### 4. Driver File Access (403)

The files endpoint now checks the `Dispatch` table to see if the authenticated user is the assigned driver for the order. The DB query only runs when the user is not already authorized by role or ownership.

## Testing Performed

- **ESLint**: `pnpm lint` passes — no warnings in changed files (3 pre-existing warnings in unrelated files)
- **TypeScript**: `tsc --noEmit` with 8GB heap — zero new type errors in changed files (3 pre-existing errors in calculator module)
- **Database verification**: Queried `deliveries` table via Prisma script:
  - **Test 042523** (before fix): Only `arrivedAtClientAt` and `deliveredAt` saved — confirms intermediate timestamps were lost
  - **Test 042524** (after fix): All 6 timestamps (`enRouteToVendorAt` through `deliveredAt`) correctly persisted — **confirms fix works**
- **Manual testing**:
  - Assigned a driver → `driverStatus` set to `ASSIGNED` on order record ✅
  - Progressed through all 7 statuses (Assigned → Delivered) → all timestamps saved ✅
  - Refreshed page → all timestamps persist ✅
  - Logged out and back in → timestamps still visible ✅
  - Driver can access order files → no more 403 ✅
  - Legacy order (null driverStatus) → status transitions work via dispatch fallback ✅

## Database Migrations

**None** — all changes are application-level logic. No schema changes required.

The `Delivery` table already has all required timestamp columns (`assigned_at`, `en_route_to_vendor_at`, etc.) and the `order_number` unique index used by the upsert.

## Breaking Changes

**None** — all changes are backwards compatible:
- The `nextDriverStatus` addition is an optional field on `TransitionRequest`
- The dispatch-based fallback only activates when `driverStatus` is `null` (legacy state)
- The driver file access check is additive (no existing access is removed)

## Reviewer Checklist

- [ ] **State machine consistency**: Verify that setting `nextDriverStatus: ASSIGNED` in `assignDriver` aligns with `DRIVER_TRANSITIONS` in `src/lib/state-machine/driver-state.ts` (should allow `null → ASSIGNED`)
- [ ] **Legacy fallback scope**: Confirm the dispatch-based `ASSIGNED` inference in the PATCH handler only runs when `currentDriverStatus === null` — should not affect orders with an explicit driverStatus
- [ ] **Delivery upsert in assignDriver**: The upsert runs outside the `$transaction` — verify this is acceptable (non-critical, silent failure logged)
- [ ] **File access authorization**: Confirm the Dispatch query correctly scopes to the requesting user's `id` as `driverId` and the specific order (via `cateringRequestId`/`onDemandId`)
- [ ] **Soft-delete compatibility**: The `prisma.driver.findFirst` call in the Delivery upsert goes through the soft-delete extension — confirm soft-deleted drivers are correctly excluded
- [ ] **No N+1 queries**: The dispatch lookup in the files route is a single `findFirst` with `select: { id: true }` — minimal overhead, only runs for non-admin/non-owner users

🤖 Generated with [Claude Code](https://claude.com/claude-code)