### PR TITLE
design(m5): gate GA + Metricool behind cookie consent (CCPA/GDPR)

### DIFF
--- a/src/components/Cookies/Banner.tsx
+++ b/src/components/Cookies/Banner.tsx
@@ -22,6 +22,10 @@ interface CookieConsentBannerProps {
 const CookieConsentBanner = ({ metricoolHash, gaMeasurementId }: CookieConsentBannerProps) => {
   const [isVisible, setIsVisible] = useState(false);
   const [isPreferencesModalOpen, setIsPreferencesModalOpen] = useState(false);
+  // consentLoaded gates analytics script mount: we never render GA/Metricool
+  // until we've read the persisted consent. Otherwise their <Script> tags would
+  // boot on first paint, set cookies, and fire pageviews before the user can decide.
+  const [consentLoaded, setConsentLoaded] = useState(false);
   const [consentGiven, setConsentGiven] = useState<CookiePreferences>({
     necessary: true,
     analytics: false,
@@ -30,22 +34,35 @@ const CookieConsentBanner = ({ metricoolHash, gaMeasurementId }: CookieConsentBa
   });
 
   useEffect(() => {
+    // Pre-empt GA: even if its script somehow loads, this flag prevents it from
+    // sending hits or setting cookies until consent is confirmed.
+    if (typeof window !== 'undefined' && gaMeasurementId) {
+      (window as Record<string, unknown>)[`ga-disable-${gaMeasurementId}`] = true;
+    }
+
     const consentStatus = localStorage.getItem('cookieConsentStatus');
     if (!consentStatus) {
       setIsVisible(true);
-    } else {
-      try {
-        const savedPreferences = JSON.parse(localStorage.getItem('cookiePreferences') || '{}');
-        setConsentGiven(savedPreferences);
-        
-        if (window && gaMeasurementId) {
-          window[`ga-disable-${gaMeasurementId}`] = !(savedPreferences.analytics || savedPreferences.marketing);
-        }
-      } catch (error) {
-        console.error('Error parsing cookie preferences:', error);
+      setConsentLoaded(true);
+      return;
+    }
+
+    try {
+      const savedPreferences = JSON.parse(localStorage.getItem('cookiePreferences') || '{}');
+      setConsentGiven(savedPreferences);
+
+      if (window && gaMeasurementId) {
+        window[`ga-disable-${gaMeasurementId}`] = !(savedPreferences.analytics || savedPreferences.marketing);
       }
+    } catch (error) {
+      console.error('Error parsing cookie preferences:', error);
+    } finally {
+      setConsentLoaded(true);
     }
   }, [gaMeasurementId]);
+
+  const analyticsAllowed = consentGiven.analytics || consentGiven.marketing;
+  const canMountAnalytics = consentLoaded && analyticsAllowed;
 
   const handleAcceptAll = () => {
     const preferences: CookiePreferences = {
@@ -129,8 +146,8 @@ const CookieConsentBanner = ({ metricoolHash, gaMeasurementId }: CookieConsentBa
 
   return (
     <>
-      {metricoolHash && <MetricoolScript trackingHash={metricoolHash} />}
-      {gaMeasurementId && <GoogleAnalytics gaId={gaMeasurementId} />}
+      {canMountAnalytics && metricoolHash && <MetricoolScript trackingHash={metricoolHash} />}
+      {canMountAnalytics && gaMeasurementId && <GoogleAnalytics gaId={gaMeasurementId} />}
 
       {isVisible && (
         <div className="fixed bottom-0 left-0 right-0 bg-white/95 backdrop-blur border-t border-gray-200 shadow-lg p-3 md:p-4 z-50">

--- a/src/components/Cookies/__tests__/Banner.test.tsx
+++ b/src/components/Cookies/__tests__/Banner.test.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import CookieConsentBanner from "../Banner";
+
+// Mock the third-party analytics components so we can assert on their *mount*
+jest.mock("@next/third-parties/google", () => ({
+  __esModule: true,
+  GoogleAnalytics: ({ gaId }: { gaId: string }) => (
+    <div data-testid="ga-mount" data-ga-id={gaId} />
+  ),
+}));
+
+jest.mock("@/components/Analytics/MetriCool", () => ({
+  __esModule: true,
+  default: ({ trackingHash }: { trackingHash: string }) => (
+    <div data-testid="metricool-mount" data-hash={trackingHash} />
+  ),
+}));
+
+jest.mock("../CookiePreferencesModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const GA_ID = "G-TEST123";
+const METRICOOL_HASH = "hash-abc";
+
+describe("CookieConsentBanner", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.cookie.split(";").forEach((c) => {
+      document.cookie = c.trim().replace(/=.*/, "=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/;");
+    });
+    delete (window as Record<string, unknown>)[`ga-disable-${GA_ID}`];
+  });
+
+  it("does not mount GA or Metricool on first paint when no consent stored", () => {
+    render(<CookieConsentBanner gaMeasurementId={GA_ID} metricoolHash={METRICOOL_HASH} />);
+    expect(screen.queryByTestId("ga-mount")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("metricool-mount")).not.toBeInTheDocument();
+  });
+
+  it("sets ga-disable flag pre-emptively when no consent stored", () => {
+    render(<CookieConsentBanner gaMeasurementId={GA_ID} metricoolHash={METRICOOL_HASH} />);
+    expect((window as Record<string, unknown>)[`ga-disable-${GA_ID}`]).toBe(true);
+  });
+
+  it("shows the banner when no consent is stored", () => {
+    render(<CookieConsentBanner gaMeasurementId={GA_ID} metricoolHash={METRICOOL_HASH} />);
+    expect(screen.getByTestId("cookie-accept-all")).toBeInTheDocument();
+    expect(screen.getByTestId("cookie-reject-all")).toBeInTheDocument();
+  });
+
+  it("mounts GA + Metricool after Accept All", async () => {
+    const user = userEvent.setup();
+    render(<CookieConsentBanner gaMeasurementId={GA_ID} metricoolHash={METRICOOL_HASH} />);
+
+    await user.click(screen.getByTestId("cookie-accept-all"));
+
+    expect(screen.getByTestId("ga-mount")).toBeInTheDocument();
+    expect(screen.getByTestId("metricool-mount")).toBeInTheDocument();
+    expect((window as Record<string, unknown>)[`ga-disable-${GA_ID}`]).toBe(false);
+    expect(localStorage.getItem("cookieConsentStatus")).toBe("accepted");
+  });
+
+  it("does NOT mount GA after Reject All and clears _ga* cookies", async () => {
+    document.cookie = "_ga=GA1.1.test;path=/";
+    document.cookie = "_gid=GA1.1.test;path=/";
+    document.cookie = "_gat=1;path=/";
+
+    const user = userEvent.setup();
+    render(<CookieConsentBanner gaMeasurementId={GA_ID} metricoolHash={METRICOOL_HASH} />);
+
+    await user.click(screen.getByTestId("cookie-reject-all"));
+
+    expect(screen.queryByTestId("ga-mount")).not.toBeInTheDocument();
+    expect((window as Record<string, unknown>)[`ga-disable-${GA_ID}`]).toBe(true);
+    expect(localStorage.getItem("cookieConsentStatus")).toBe("rejected");
+    expect(document.cookie).not.toMatch(/_ga=GA1\.1\.test/);
+    expect(document.cookie).not.toMatch(/_gid=GA1\.1\.test/);
+    expect(document.cookie).not.toMatch(/_gat=1/);
+  });
+
+  it("mounts GA on next render when consent already stored as accepted", () => {
+    localStorage.setItem("cookieConsentStatus", "accepted");
+    localStorage.setItem(
+      "cookiePreferences",
+      JSON.stringify({ necessary: true, analytics: true, marketing: true, personalization: true })
+    );
+
+    render(<CookieConsentBanner gaMeasurementId={GA_ID} metricoolHash={METRICOOL_HASH} />);
+
+    expect(screen.getByTestId("ga-mount")).toBeInTheDocument();
+    expect(screen.getByTestId("metricool-mount")).toBeInTheDocument();
+    // banner should not show
+    expect(screen.queryByTestId("cookie-accept-all")).not.toBeInTheDocument();
+  });
+
+  it("does NOT mount GA when consent stored as rejected", () => {
+    localStorage.setItem("cookieConsentStatus", "rejected");
+    localStorage.setItem(
+      "cookiePreferences",
+      JSON.stringify({ necessary: true, analytics: false, marketing: false, personalization: false })
+    );
+
+    render(<CookieConsentBanner gaMeasurementId={GA_ID} metricoolHash={METRICOOL_HASH} />);
+
+    expect(screen.queryByTestId("ga-mount")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("metricool-mount")).not.toBeInTheDocument();
+    expect((window as Record<string, unknown>)[`ga-disable-${GA_ID}`]).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

GoogleAnalytics and Metricool were rendering unconditionally inside \`CookieConsentBanner\` — their \`<Script>\` tags fired on first paint, set \`_ga\` cookies, and sent pageviews **before the user could see, let alone respond to, the consent banner**. This PR closes that gap.

### Behavior change
- **Before:** GA loads on first paint; \`window['ga-disable-...']\` is set later from \`useEffect\`, but the script has already booted and may have already sent hits.
- **After:** Neither GA nor Metricool mount until (a) we've read consent from \`localStorage\` and (b) consent is \`accepted\` (or analytics/marketing is true via Manage Preferences). \`window['ga-disable-G-...']\` is also set to \`true\` synchronously in the first effect tick as a belt-and-braces guard.

### Code (\`src/components/Cookies/Banner.tsx\`)
- New \`consentLoaded\` state — gates analytics mount until persisted consent is read
- New \`canMountAnalytics = consentLoaded && (analytics || marketing)\` — single source of truth used for both \`<GoogleAnalytics>\` and \`<MetricoolScript>\`
- Pre-empt: \`window['ga-disable-G-...'] = true\` set in the effect before any script can mount
- Existing \`_ga/_gat/_gid\` cookie cleanup on Reject All / preferences-deny preserved (was already correct)

## Tests (\`src/components/Cookies/__tests__/Banner.test.tsx\`)

7 new specs, all passing:
- ✅ GA + Metricool do not mount on first paint when no consent stored
- ✅ \`ga-disable\` flag is set pre-emptively
- ✅ Banner shows when no consent stored
- ✅ Accept All mounts both, sets \`ga-disable\` to false, persists \`accepted\`
- ✅ Reject All keeps both unmounted, sets \`ga-disable\` to true, clears \`_ga/_gid/_gat\`
- ✅ Stored \`accepted\` mounts on next render; banner hidden
- ✅ Stored \`rejected\` keeps both unmounted

## Manual verification (recommended)
- [ ] Fresh incognito + DevTools Network tab: load \`/\` — \`gtag/js\` script should NOT load before clicking Accept.
- [ ] Click Reject All → reload → \`_ga\` cookie should be absent.
- [ ] Click Accept All → reload → \`_ga\` cookie should be present and GA pageview fired.

Closes: #029, #035

## Test plan

- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm test src/components/Cookies/__tests__/Banner.test.tsx\` — 7/7 pass
- [x] \`pnpm lint:tokens:diff\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)