### PR TITLE
security(partner-api): Phase 1 hardening — auth, webhook, data integrity, observability

### DIFF
--- a/src/__tests__/api/cater-valley-status.test.ts
+++ b/src/__tests__/api/cater-valley-status.test.ts
@@ -73,7 +73,11 @@ describe('/api/cater-valley/status API', () => {
       expect(data.database.caterValleyOrderCount).toBe(0);
     });
 
-    it('should report environment configuration status', async () => {
+    it('does NOT leak environment configuration to public callers', async () => {
+      // Phase 1 hardening removed `data.environment` from the public response
+      // because the apiKeyConfigured / webhookUrlConfigured booleans were a
+      // deployment fingerprint signal for attackers. Operators should query
+      // logs / Sentry instead.
       (prisma.cateringRequest.count as jest.Mock).mockResolvedValue(0);
       process.env.CATERVALLEY_API_KEY = 'configured-key';
       process.env.CATERVALLEY_WEBHOOK_URL = 'https://webhook.url';
@@ -84,23 +88,7 @@ describe('/api/cater-valley/status API', () => {
       const data = await response.json();
 
       expect(response.status).toBe(200);
-      expect(data.environment.apiKeyConfigured).toBe(true);
-      expect(data.environment.webhookUrlConfigured).toBe(true);
-    });
-
-    it('should report missing environment variables', async () => {
-      (prisma.cateringRequest.count as jest.Mock).mockResolvedValue(0);
-      delete process.env.CATERVALLEY_API_KEY;
-      delete process.env.CATERVALLEY_WEBHOOK_URL;
-
-      const request = createGetRequest('http://localhost:3000/api/cater-valley/status');
-
-      const response = await GET(request);
-      const data = await response.json();
-
-      expect(response.status).toBe(200);
-      expect(data.environment.apiKeyConfigured).toBe(false);
-      expect(data.environment.webhookUrlConfigured).toBe(false);
+      expect(data).not.toHaveProperty('environment');
     });
 
     it('should include endpoint documentation', async () => {
@@ -117,7 +105,7 @@ describe('/api/cater-valley/status API', () => {
         method: 'POST',
         path: '/api/cater-valley/orders/draft',
         description: 'Create a new draft order with pricing calculation',
-        authentication: 'Required: partner: catervalley, x-api-key',
+        authentication: 'Required: partner + x-api-key headers',
       });
 
       expect(data.endpoints).toHaveProperty('update');

--- a/src/__tests__/api/cater-valley/auth-utils.test.ts
+++ b/src/__tests__/api/cater-valley/auth-utils.test.ts
@@ -1,0 +1,99 @@
+// src/__tests__/api/cater-valley/auth-utils.test.ts
+
+import { validateCaterValleyAuth } from '@/app/api/cater-valley/_lib/auth-utils';
+import { NextRequest } from 'next/server';
+
+function createRequest(headers: Record<string, string>): NextRequest {
+  return new NextRequest('http://localhost:3000/api/cater-valley/orders/draft', {
+    method: 'POST',
+    headers,
+  });
+}
+
+describe('validateCaterValleyAuth', () => {
+  const ORIGINAL_KEY = process.env.CATERVALLEY_API_KEY;
+
+  beforeEach(() => {
+    process.env.CATERVALLEY_API_KEY = 'super-secret-test-key-1234567890';
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_KEY === undefined) {
+      delete process.env.CATERVALLEY_API_KEY;
+    } else {
+      process.env.CATERVALLEY_API_KEY = ORIGINAL_KEY;
+    }
+  });
+
+  it('rejects requests with wrong partner header', () => {
+    const req = createRequest({
+      partner: 'someoneelse',
+      'x-api-key': 'super-secret-test-key-1234567890',
+    });
+    expect(validateCaterValleyAuth(req)).toBe(false);
+  });
+
+  it('rejects requests with missing partner header', () => {
+    const req = createRequest({ 'x-api-key': 'super-secret-test-key-1234567890' });
+    expect(validateCaterValleyAuth(req)).toBe(false);
+  });
+
+  it('rejects requests with missing api key when env key is configured', () => {
+    const req = createRequest({ partner: 'catervalley' });
+    expect(validateCaterValleyAuth(req)).toBe(false);
+  });
+
+  it('rejects requests with wrong api key', () => {
+    const req = createRequest({
+      partner: 'catervalley',
+      'x-api-key': 'super-secret-test-key-WRONG_VALUE',
+    });
+    expect(validateCaterValleyAuth(req)).toBe(false);
+  });
+
+  it('rejects requests with api key of different length', () => {
+    const req = createRequest({
+      partner: 'catervalley',
+      'x-api-key': 'short',
+    });
+    expect(validateCaterValleyAuth(req)).toBe(false);
+  });
+
+  it('accepts requests with correct partner + api key', () => {
+    const req = createRequest({
+      partner: 'catervalley',
+      'x-api-key': 'super-secret-test-key-1234567890',
+    });
+    expect(validateCaterValleyAuth(req)).toBe(true);
+  });
+
+  it('accepts requests when env key is unset (local dev fallback)', () => {
+    delete process.env.CATERVALLEY_API_KEY;
+    const req = createRequest({
+      partner: 'catervalley',
+      'x-api-key': 'whatever',
+    });
+    expect(validateCaterValleyAuth(req)).toBe(true);
+  });
+
+  it('uses constant-time comparison (no early-exit on first byte mismatch)', () => {
+    // Sanity test for timing-safe behavior: keys differing in the first
+    // byte vs the last byte should both reject without observable
+    // branch divergence beyond what the runtime allows. This isn't a
+    // strict timing assertion (Jest can't measure ns reliably) but
+    // verifies neither path throws and both return false.
+    const requests = [
+      createRequest({
+        partner: 'catervalley',
+        'x-api-key': 'Xuper-secret-test-key-1234567890',
+      }),
+      createRequest({
+        partner: 'catervalley',
+        'x-api-key': 'super-secret-test-key-123456789X',
+      }),
+    ];
+    for (const req of requests) {
+      expect(validateCaterValleyAuth(req)).toBe(false);
+    }
+  });
+});

--- a/src/__tests__/api/cater-valley/auth-utils.test.ts
+++ b/src/__tests__/api/cater-valley/auth-utils.test.ts
@@ -12,6 +12,7 @@ function createRequest(headers: Record<string, string>): NextRequest {
 
 describe('validateCaterValleyAuth', () => {
   const ORIGINAL_KEY = process.env.CATERVALLEY_API_KEY;
+  const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
 
   beforeEach(() => {
     process.env.CATERVALLEY_API_KEY = 'super-secret-test-key-1234567890';
@@ -23,6 +24,7 @@ describe('validateCaterValleyAuth', () => {
     } else {
       process.env.CATERVALLEY_API_KEY = ORIGINAL_KEY;
     }
+    process.env.NODE_ENV = ORIGINAL_NODE_ENV;
   });
 
   it('rejects requests with wrong partner header', () => {
@@ -67,13 +69,27 @@ describe('validateCaterValleyAuth', () => {
     expect(validateCaterValleyAuth(req)).toBe(true);
   });
 
-  it('accepts requests when env key is unset (local dev fallback)', () => {
+  it('accepts requests when env key is unset in non-production (local dev fallback)', () => {
     delete process.env.CATERVALLEY_API_KEY;
+    process.env.NODE_ENV = 'development';
     const req = createRequest({
       partner: 'catervalley',
       'x-api-key': 'whatever',
     });
     expect(validateCaterValleyAuth(req)).toBe(true);
+  });
+
+  it('rejects requests when env key is unset in production (fail-closed)', () => {
+    delete process.env.CATERVALLEY_API_KEY;
+    process.env.NODE_ENV = 'production';
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const req = createRequest({
+      partner: 'catervalley',
+      'x-api-key': 'whatever',
+    });
+    expect(validateCaterValleyAuth(req)).toBe(false);
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
   });
 
   it('uses constant-time comparison (no early-exit on first byte mismatch)', () => {

--- a/src/__tests__/api/cater-valley/catch-all.test.ts
+++ b/src/__tests__/api/cater-valley/catch-all.test.ts
@@ -28,8 +28,8 @@ describe('GET/POST/PUT/PATCH/DELETE /api/cater-valley/[...slug] - CaterValley Ca
       const data = await response.json();
       expect(data.method).toBe('GET');
       expect(data.slug).toEqual(['unknown', 'path']);
-      expect(data.message).toContain('does not exist');
-      expect(data.availableEndpoints).toHaveLength(3);
+      expect(data.message).toContain('not found');
+      expect(data.availableEndpoints.length).toBeGreaterThanOrEqual(3);
     });
 
     it('should include request details in GET response', async () => {
@@ -45,7 +45,6 @@ describe('GET/POST/PUT/PATCH/DELETE /api/cater-valley/[...slug] - CaterValley Ca
       const data = await response.json();
 
       expect(data.method).toBe('GET');
-      expect(data.url).toContain('/api/cater-valley/test');
       expect(data.searchParams).toEqual({ param: 'value' });
       expect(data.headers).toHaveProperty('x-custom', 'header');
       expect(data.timestamp).toBeDefined();
@@ -90,7 +89,7 @@ describe('GET/POST/PUT/PATCH/DELETE /api/cater-valley/[...slug] - CaterValley Ca
       const data = await response.json();
       expect(data.method).toBe('POST');
       expect(data.body).toEqual({ test: 'data' });
-      expect(data.message).toContain('does not exist');
+      expect(data.message).toContain('not found');
     });
 
     it('should capture POST body in response', async () => {
@@ -212,7 +211,7 @@ describe('GET/POST/PUT/PATCH/DELETE /api/cater-valley/[...slug] - CaterValley Ca
       const response = await PATCH(request, context);
       const data = await response.json();
 
-      expect(data.availableEndpoints).toHaveLength(3);
+      expect(data.availableEndpoints.length).toBeGreaterThanOrEqual(3);
       expect(data.availableEndpoints[0]).toContain('draft');
     });
   });
@@ -232,12 +231,13 @@ describe('GET/POST/PUT/PATCH/DELETE /api/cater-valley/[...slug] - CaterValley Ca
       expect(data.slug).toEqual(['unknown']);
     });
 
-    it('should include headers in DELETE response', async () => {
+    it('should redact sensitive headers in DELETE response', async () => {
       const request = createNextRequest('http://localhost:3000/api/cater-valley/test', {
         method: 'DELETE',
         headers: {
           'x-api-key': 'test-key',
           'partner': 'test-partner',
+          'x-custom': 'safe',
         },
       });
       const context = { params: Promise.resolve({ slug: ['test'] }) };
@@ -245,8 +245,9 @@ describe('GET/POST/PUT/PATCH/DELETE /api/cater-valley/[...slug] - CaterValley Ca
       const response = await DELETE(request, context);
       const data = await response.json();
 
-      expect(data.headers).toHaveProperty('x-api-key', 'test-key');
-      expect(data.headers).toHaveProperty('partner', 'test-partner');
+      expect(data.headers).toHaveProperty('x-api-key', '<redacted>');
+      expect(data.headers).toHaveProperty('partner', '<redacted>');
+      expect(data.headers).toHaveProperty('x-custom', 'safe');
     });
 
     it('should handle DELETE with multiple slug segments', async () => {
@@ -339,8 +340,61 @@ describe('GET/POST/PUT/PATCH/DELETE /api/cater-valley/[...slug] - CaterValley Ca
       const data = await response.json();
 
       expect(data.method).toBe('PUT');
-      // When no body is provided, body parsing may return null, empty object, or error
-      expect(data.body).toBeDefined();
+      // body may be null when no payload is provided
+      expect(data).toHaveProperty('body');
+    });
+  });
+
+  describe('🔒 Production hardening', () => {
+    const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+    afterEach(() => {
+      process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+    });
+
+    it('does not echo headers, body, or slug to anonymous callers in production', async () => {
+      process.env.NODE_ENV = 'production';
+      const request = createNextRequest('http://localhost:3000/api/cater-valley/wrong/path', {
+        method: 'POST',
+        headers: {
+          'x-api-key': 'leaked-key',
+          partner: 'catervalley',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ secret: 'value' }),
+      });
+      const context = { params: Promise.resolve({ slug: ['wrong', 'path'] }) };
+
+      const response = await POST(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data.method).toBe('POST');
+      expect(data.message).toContain('not found');
+      expect(data.availableEndpoints.length).toBeGreaterThanOrEqual(3);
+      // Production must NOT leak any of these:
+      expect(data).not.toHaveProperty('headers');
+      expect(data).not.toHaveProperty('body');
+      expect(data).not.toHaveProperty('slug');
+      expect(data).not.toHaveProperty('searchParams');
+      expect(JSON.stringify(data)).not.toContain('leaked-key');
+    });
+
+    it('still includes debug context in non-production', async () => {
+      process.env.NODE_ENV = 'development';
+      const request = createNextRequest('http://localhost:3000/api/cater-valley/wrong', {
+        method: 'POST',
+        body: JSON.stringify({ test: 'data' }),
+      });
+      const context = { params: Promise.resolve({ slug: ['wrong'] }) };
+
+      const response = await POST(request, context);
+      const data = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(data).toHaveProperty('headers');
+      expect(data).toHaveProperty('body');
+      expect(data).toHaveProperty('slug', ['wrong']);
     });
   });
 });

--- a/src/__tests__/api/cater-valley/debug.test.ts
+++ b/src/__tests__/api/cater-valley/debug.test.ts
@@ -44,8 +44,9 @@ describe('GET/POST/PUT/PATCH /api/cater-valley/debug - CaterValley Debug Endpoin
       const response = await GET(request);
       const data = await expectSuccessResponse(response, 200);
 
-      expect(data.headers).toHaveProperty('x-api-key', 'test-key');
-      expect(data.headers).toHaveProperty('partner', 'test-partner');
+      // Sensitive headers must be redacted; non-sensitive ones pass through
+      expect(data.headers).toHaveProperty('x-api-key', '<redacted>');
+      expect(data.headers).toHaveProperty('partner', '<redacted>');
       expect(data.headers).toHaveProperty('user-agent', 'test-agent');
     });
 
@@ -106,8 +107,8 @@ describe('GET/POST/PUT/PATCH /api/cater-valley/debug - CaterValley Debug Endpoin
       const response = await POST(request);
       const data = await expectSuccessResponse(response, 200);
 
-      expect(data.headers).toHaveProperty('x-api-key', 'secret-key');
-      expect(data.headers).toHaveProperty('partner', 'catervalley');
+      expect(data.headers).toHaveProperty('x-api-key', '<redacted>');
+      expect(data.headers).toHaveProperty('partner', '<redacted>');
       expect(data.headers).toHaveProperty('content-type', 'application/json');
     });
 
@@ -219,7 +220,7 @@ describe('GET/POST/PUT/PATCH /api/cater-valley/debug - CaterValley Debug Endpoin
 
       expect(data.method).toBe('PATCH');
       expect(data.headers).toHaveProperty('x-custom-header', 'custom-value');
-      expect(data.headers).toHaveProperty('authorization', 'Bearer token123');
+      expect(data.headers).toHaveProperty('authorization', '<redacted>');
       expect(data.body).toEqual({ patch: 'data' });
     });
   });
@@ -281,7 +282,7 @@ describe('GET/POST/PUT/PATCH /api/cater-valley/debug - CaterValley Debug Endpoin
       expect(data.body).toBeDefined();
     });
 
-    it('should handle PATCH when body parsing fails completely', async () => {
+    it('should handle PATCH when body is empty/missing', async () => {
       const request = new Request('http://localhost:3000/api/cater-valley/debug', {
         method: 'PATCH',
       });
@@ -290,7 +291,9 @@ describe('GET/POST/PUT/PATCH /api/cater-valley/debug - CaterValley Debug Endpoin
       const data = await expectSuccessResponse(response, 200);
 
       expect(data.method).toBe('PATCH');
-      expect(data.body).toHaveProperty('error', 'Could not parse body');
+      // Empty body parses to null in the new implementation rather than
+      // an error sentinel object — both forms are equivalently safe.
+      expect(data).toHaveProperty('body');
     });
 
     it('should preserve timestamp format', async () => {
@@ -300,6 +303,37 @@ describe('GET/POST/PUT/PATCH /api/cater-valley/debug - CaterValley Debug Endpoin
       const data = await expectSuccessResponse(response, 200);
 
       expect(data.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    });
+  });
+
+  describe('🔒 Production hardening', () => {
+    const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+
+    afterEach(() => {
+      process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+    });
+
+    it('returns plain 404 in production with no header/body echo', async () => {
+      process.env.NODE_ENV = 'production';
+      const request = new Request('http://localhost:3000/api/cater-valley/debug', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': 'leaked-key',
+          authorization: 'Bearer secret',
+        },
+        body: JSON.stringify({ secret: 'should-not-leak' }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(404);
+
+      const data = await response.json();
+      expect(data).not.toHaveProperty('headers');
+      expect(data).not.toHaveProperty('body');
+      expect(data).not.toHaveProperty('searchParams');
+      expect(JSON.stringify(data)).not.toContain('leaked-key');
+      expect(JSON.stringify(data)).not.toContain('should-not-leak');
     });
   });
 });

--- a/src/__tests__/api/cater-valley/orders-draft.test.ts
+++ b/src/__tests__/api/cater-valley/orders-draft.test.ts
@@ -10,9 +10,11 @@ import {
   expectErrorResponse,
 } from '@/__tests__/helpers/api-test-helpers';
 
-// Mock dependencies
-jest.mock('@/lib/db/prisma', () => ({
-  prisma: {
+// Mock dependencies. `$transaction` invokes the callback with the same
+// mock client so any `tx.foo.bar()` calls inside the route hit the same
+// jest.fn instances as bare `prisma.foo.bar()` calls.
+jest.mock('@/lib/db/prisma', () => {
+  const mockPrisma: any = {
     profile: {
       upsert: jest.fn(),
     },
@@ -24,8 +26,10 @@ jest.mock('@/lib/db/prisma', () => ({
       findUnique: jest.fn(),
       create: jest.fn(),
     },
-  },
-}));
+  };
+  mockPrisma.$transaction = jest.fn((callback: (tx: any) => unknown) => callback(mockPrisma));
+  return { prisma: mockPrisma };
+});
 
 jest.mock('@/lib/services/pricingService', () => ({
   calculatePickupTime: jest.fn(),
@@ -627,6 +631,75 @@ describe('POST /api/cater-valley/orders/draft - Create Draft Order', () => {
           }),
         })
       );
+    });
+  });
+
+  describe('🔒 Phase 1 hardening', () => {
+    it('rejects bodies above the 1MB limit with 413', async () => {
+      const request = new Request('http://localhost:3000/api/cater-valley/orders/draft', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': 'test-api-key',
+          partner: 'catervalley',
+          'content-length': '2000000',
+        },
+        body: JSON.stringify(validOrderData),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(413);
+      // Auth is checked AFTER body size; both should pass-through cleanly
+      expect(prisma.cateringRequest.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('treats a soft-deleted order as not-conflicting (allows reuse of orderCode)', async () => {
+      (prisma.cateringRequest.findUnique as jest.Mock).mockResolvedValueOnce({
+        id: 'old-order-id',
+        deletedAt: new Date('2025-01-01'),
+      });
+
+      const request = new Request('http://localhost:3000/api/cater-valley/orders/draft', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': 'test-api-key',
+          partner: 'catervalley',
+        },
+        body: JSON.stringify(validOrderData),
+      });
+
+      const response = await POST(request);
+      // Soft-deleted match must NOT block — still 201/SUCCESS path.
+      expect(response.status).toBe(201);
+      expect(prisma.cateringRequest.create).toHaveBeenCalled();
+    });
+
+    it('returns 409 when DB unique-violation races our fast-path check', async () => {
+      // Fast-path says no existing order, but the DB raises P2002 at insert
+      // (a concurrent partner request beat us between the find and create).
+      (prisma.cateringRequest.findUnique as jest.Mock).mockResolvedValueOnce(null);
+      const { Prisma } = await import('@prisma/client');
+      const p2002 = new Prisma.PrismaClientKnownRequestError(
+        'Unique constraint failed on the constraint: `cateringRequest_orderNumber_key`',
+        { code: 'P2002', clientVersion: 'test' }
+      );
+      (prisma.cateringRequest.create as jest.Mock).mockRejectedValueOnce(p2002);
+
+      const request = new Request('http://localhost:3000/api/cater-valley/orders/draft', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': 'test-api-key',
+          partner: 'catervalley',
+        },
+        body: JSON.stringify(validOrderData),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(409);
+      const data = await response.json();
+      expect(data.message).toMatch(/already exists/i);
     });
   });
 });

--- a/src/__tests__/api/cater-valley/orders-update.test.ts
+++ b/src/__tests__/api/cater-valley/orders-update.test.ts
@@ -6,13 +6,17 @@ import * as pricingService from '@/lib/services/pricingService';
 import * as pricingHelper from '@/app/api/cater-valley/_lib/pricing-helper';
 import { expectSuccessResponse, expectErrorResponse } from '@/__tests__/helpers/api-test-helpers';
 
-// Mock dependencies
-jest.mock('@/lib/db/prisma', () => ({
-  prisma: {
+// Mock dependencies. `$transaction` invokes the callback with the same
+// mock client so `tx.foo.bar()` calls inside the route hit the same
+// jest.fn instances as bare `prisma.foo.bar()` calls.
+jest.mock('@/lib/db/prisma', () => {
+  const mockPrisma: any = {
     address: { findFirst: jest.fn(), create: jest.fn() },
     cateringRequest: { findUnique: jest.fn(), findFirst: jest.fn(), update: jest.fn() },
-  },
-}));
+  };
+  mockPrisma.$transaction = jest.fn((callback: (tx: any) => unknown) => callback(mockPrisma));
+  return { prisma: mockPrisma };
+});
 
 jest.mock('@/lib/services/pricingService', () => ({
   calculatePickupTime: jest.fn(),

--- a/src/__tests__/api/cater-valley/status.test.ts
+++ b/src/__tests__/api/cater-valley/status.test.ts
@@ -44,12 +44,13 @@ describe('GET/POST /api/cater-valley/status - CaterValley Integration Status', (
       expect(data).toHaveProperty('version', '1.0.0');
       expect(data).toHaveProperty('timestamp');
       expect(data).toHaveProperty('database');
-      expect(data).toHaveProperty('environment');
       expect(data).toHaveProperty('endpoints');
       expect(data).toHaveProperty('statusMapping');
       expect(data).toHaveProperty('pricing');
       expect(data).toHaveProperty('businessHours');
       expect(data).toHaveProperty('contact');
+      // Environment configuration is intentionally NOT advertised publicly.
+      expect(data).not.toHaveProperty('environment');
     });
 
     it('should show database connectivity status', async () => {
@@ -63,15 +64,18 @@ describe('GET/POST /api/cater-valley/status - CaterValley Integration Status', (
       expect(data.database.caterValleyOrderCount).toBe(15);
     });
 
-    it('should show environment configuration', async () => {
+    it('should not advertise environment configuration in the public response', async () => {
       (prisma.cateringRequest.count as jest.Mock).mockResolvedValue(0);
 
       const request = createGetRequest('http://localhost:3000/api/cater-valley/status');
       const response = await GET(request);
       const data = await expectSuccessResponse(response, 200);
 
-      expect(data.environment.apiKeyConfigured).toBe(true);
-      expect(data.environment.webhookUrlConfigured).toBe(true);
+      // Previously this endpoint exposed booleans like `apiKeyConfigured`
+      // which fingerprinted whether secrets were set on the server.
+      expect(data).not.toHaveProperty('environment');
+      expect(JSON.stringify(data)).not.toContain('apiKeyConfigured');
+      expect(JSON.stringify(data)).not.toContain('webhookUrlConfigured');
     });
 
     it('should list available endpoints', async () => {
@@ -88,7 +92,7 @@ describe('GET/POST /api/cater-valley/status - CaterValley Integration Status', (
 
       expect(data.endpoints.draft.method).toBe('POST');
       expect(data.endpoints.draft.path).toBe('/api/cater-valley/orders/draft');
-      expect(data.endpoints.draft.authentication).toContain('catervalley');
+      expect(data.endpoints.draft.authentication).toMatch(/x-api-key/);
     });
 
     it('should show status mapping for order states', async () => {
@@ -195,7 +199,7 @@ describe('GET/POST /api/cater-valley/status - CaterValley Integration Status', (
       expect(data.database.status).toBe('connected');
     });
 
-    it('should handle missing environment variables', async () => {
+    it('does not change response shape when env vars are missing', async () => {
       delete process.env.CATERVALLEY_API_KEY;
       delete process.env.CATERVALLEY_WEBHOOK_URL;
 
@@ -205,8 +209,9 @@ describe('GET/POST /api/cater-valley/status - CaterValley Integration Status', (
       const response = await GET(request);
       const data = await expectSuccessResponse(response, 200);
 
-      expect(data.environment.apiKeyConfigured).toBe(false);
-      expect(data.environment.webhookUrlConfigured).toBe(false);
+      // Status endpoint must not leak whether env vars are configured.
+      expect(data).not.toHaveProperty('environment');
+      expect(data.database.caterValleyOrderCount).toBe(10);
     });
 
     it('should handle POST with invalid JSON gracefully', async () => {
@@ -225,7 +230,7 @@ describe('GET/POST /api/cater-valley/status - CaterValley Integration Status', (
       expect(data.service).toBe('Ready Set CaterValley Integration');
     });
 
-    it('should include webhook URL from environment', async () => {
+    it('does not leak the configured webhook URL in the public response', async () => {
       const customWebhookUrl = 'https://custom.catervalley.com/webhook';
       process.env.CATERVALLEY_WEBHOOK_URL = customWebhookUrl;
 
@@ -235,7 +240,10 @@ describe('GET/POST /api/cater-valley/status - CaterValley Integration Status', (
       const response = await GET(request);
       const data = await expectSuccessResponse(response, 200);
 
-      expect(data.endpoints.webhook.url).toBe(customWebhookUrl);
+      // Previously the webhook URL was echoed back to anonymous callers.
+      // That was a fingerprinting vector and is now suppressed.
+      expect(data.endpoints.webhook).not.toHaveProperty('url');
+      expect(JSON.stringify(data)).not.toContain(customWebhookUrl);
     });
 
     it('should include contact information', async () => {

--- a/src/__tests__/api/cater-valley/update-order-status-hmac.test.ts
+++ b/src/__tests__/api/cater-valley/update-order-status-hmac.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 // src/__tests__/api/cater-valley/update-order-status-hmac.test.ts
 
 import { POST } from '@/app/api/cater-valley/update-order-status/route';
@@ -86,7 +89,7 @@ describe('POST /api/cater-valley/update-order-status — HMAC verification', () 
 
     it('does not warn when signature is valid', async () => {
       const body = { orderNumber: 'CV-1', status: 'READY' };
-      const sig = signPayload(SHARED_SECRET, JSON.stringify(body));
+      const sig = await signPayload(SHARED_SECRET, JSON.stringify(body));
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
       const response = await POST(createRequest(body, { [SIGNATURE_HEADER]: sig }));
       expect(response.status).toBe(200);
@@ -122,7 +125,7 @@ describe('POST /api/cater-valley/update-order-status — HMAC verification', () 
 
     it('accepts requests with valid signature', async () => {
       const body = { orderNumber: 'CV-1', status: 'READY' };
-      const sig = signPayload(SHARED_SECRET, JSON.stringify(body));
+      const sig = await signPayload(SHARED_SECRET, JSON.stringify(body));
       const response = await POST(createRequest(body, { [SIGNATURE_HEADER]: sig }));
       expect(response.status).toBe(200);
       expect(caterValleyService.updateCaterValleyOrderStatus).toHaveBeenCalledWith('CV-1', 'READY');
@@ -130,7 +133,7 @@ describe('POST /api/cater-valley/update-order-status — HMAC verification', () 
 
     it('rejects requests where body has been tampered with after signing', async () => {
       const originalBody = { orderNumber: 'CV-1', status: 'READY' };
-      const sig = signPayload(SHARED_SECRET, JSON.stringify(originalBody));
+      const sig = await signPayload(SHARED_SECRET, JSON.stringify(originalBody));
       const tamperedRequest = new Request(
         'http://localhost:3000/api/cater-valley/update-order-status',
         {

--- a/src/__tests__/api/cater-valley/update-order-status-hmac.test.ts
+++ b/src/__tests__/api/cater-valley/update-order-status-hmac.test.ts
@@ -1,0 +1,147 @@
+// src/__tests__/api/cater-valley/update-order-status-hmac.test.ts
+
+import { POST } from '@/app/api/cater-valley/update-order-status/route';
+import * as caterValleyService from '@/services/caterValleyService';
+import { signPayload, SIGNATURE_HEADER } from '@/lib/security/hmac';
+
+jest.mock('@/services/caterValleyService', () => ({
+  updateCaterValleyOrderStatus: jest.fn(),
+  ALLOWED_STATUSES: ['CONFIRM', 'READY', 'ON_THE_WAY', 'COMPLETED', 'CANCELLED', 'REFUNDED'],
+}));
+
+describe('POST /api/cater-valley/update-order-status — HMAC verification', () => {
+  const ORIGINAL = {
+    secret: process.env.CATERVALLEY_INBOUND_WEBHOOK_SECRET,
+    enforce: process.env.ENFORCE_INBOUND_WEBHOOK_HMAC,
+  };
+  const SHARED_SECRET = 'inbound-webhook-shared-secret';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (caterValleyService.updateCaterValleyOrderStatus as jest.Mock).mockResolvedValue({
+      success: true,
+      orderFound: true,
+      response: {},
+    });
+  });
+
+  afterEach(() => {
+    if (ORIGINAL.secret === undefined) delete process.env.CATERVALLEY_INBOUND_WEBHOOK_SECRET;
+    else process.env.CATERVALLEY_INBOUND_WEBHOOK_SECRET = ORIGINAL.secret;
+    if (ORIGINAL.enforce === undefined) delete process.env.ENFORCE_INBOUND_WEBHOOK_HMAC;
+    else process.env.ENFORCE_INBOUND_WEBHOOK_HMAC = ORIGINAL.enforce;
+  });
+
+  function createRequest(body: object, headers: Record<string, string> = {}): Request {
+    return new Request('http://localhost:3000/api/cater-valley/update-order-status', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body: JSON.stringify(body),
+    });
+  }
+
+  describe('no secret configured (initial rollout state)', () => {
+    beforeEach(() => {
+      delete process.env.CATERVALLEY_INBOUND_WEBHOOK_SECRET;
+    });
+
+    it('accepts requests without signature header (back-compat)', async () => {
+      const response = await POST(createRequest({ orderNumber: 'CV-1', status: 'READY' }));
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe('secret configured, log-only mode (ENFORCE=false)', () => {
+    beforeEach(() => {
+      process.env.CATERVALLEY_INBOUND_WEBHOOK_SECRET = SHARED_SECRET;
+      process.env.ENFORCE_INBOUND_WEBHOOK_HMAC = 'false';
+    });
+
+    it('still processes request when signature is missing', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const response = await POST(createRequest({ orderNumber: 'CV-1', status: 'READY' }));
+      expect(response.status).toBe(200);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('log-only'),
+        expect.any(Object)
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('still processes request when signature is wrong', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const response = await POST(
+        createRequest(
+          { orderNumber: 'CV-1', status: 'READY' },
+          { [SIGNATURE_HEADER]: 'a'.repeat(64) }
+        )
+      );
+      expect(response.status).toBe(200);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('log-only'),
+        expect.objectContaining({ result: 'mismatch' })
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('does not warn when signature is valid', async () => {
+      const body = { orderNumber: 'CV-1', status: 'READY' };
+      const sig = signPayload(SHARED_SECRET, JSON.stringify(body));
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const response = await POST(createRequest(body, { [SIGNATURE_HEADER]: sig }));
+      expect(response.status).toBe(200);
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('secret configured, enforced mode (ENFORCE=true)', () => {
+    beforeEach(() => {
+      process.env.CATERVALLEY_INBOUND_WEBHOOK_SECRET = SHARED_SECRET;
+      process.env.ENFORCE_INBOUND_WEBHOOK_HMAC = 'true';
+    });
+
+    it('rejects requests with no signature header (401)', async () => {
+      const response = await POST(createRequest({ orderNumber: 'CV-1', status: 'READY' }));
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.message).toMatch(/signature/i);
+      expect(caterValleyService.updateCaterValleyOrderStatus).not.toHaveBeenCalled();
+    });
+
+    it('rejects requests with wrong signature (401)', async () => {
+      const response = await POST(
+        createRequest(
+          { orderNumber: 'CV-1', status: 'READY' },
+          { [SIGNATURE_HEADER]: 'b'.repeat(64) }
+        )
+      );
+      expect(response.status).toBe(401);
+      expect(caterValleyService.updateCaterValleyOrderStatus).not.toHaveBeenCalled();
+    });
+
+    it('accepts requests with valid signature', async () => {
+      const body = { orderNumber: 'CV-1', status: 'READY' };
+      const sig = signPayload(SHARED_SECRET, JSON.stringify(body));
+      const response = await POST(createRequest(body, { [SIGNATURE_HEADER]: sig }));
+      expect(response.status).toBe(200);
+      expect(caterValleyService.updateCaterValleyOrderStatus).toHaveBeenCalledWith('CV-1', 'READY');
+    });
+
+    it('rejects requests where body has been tampered with after signing', async () => {
+      const originalBody = { orderNumber: 'CV-1', status: 'READY' };
+      const sig = signPayload(SHARED_SECRET, JSON.stringify(originalBody));
+      const tamperedRequest = new Request(
+        'http://localhost:3000/api/cater-valley/update-order-status',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', [SIGNATURE_HEADER]: sig },
+          body: JSON.stringify({ orderNumber: 'CV-1', status: 'CANCELLED' }),
+        }
+      );
+      const response = await POST(tamperedRequest);
+      expect(response.status).toBe(401);
+      expect(caterValleyService.updateCaterValleyOrderStatus).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/lib/security/body-size-limit.test.ts
+++ b/src/__tests__/lib/security/body-size-limit.test.ts
@@ -1,0 +1,58 @@
+// src/__tests__/lib/security/body-size-limit.test.ts
+
+import {
+  enforceBodySizeLimit,
+  DEFAULT_MAX_BODY_BYTES,
+} from '@/lib/security/body-size-limit';
+
+function makeRequest(headers: Record<string, string> = {}): Request {
+  return new Request('http://localhost:3000/api/cater-valley/orders/draft', {
+    method: 'POST',
+    headers,
+  });
+}
+
+describe('enforceBodySizeLimit', () => {
+  it('exposes a 1MB default limit', () => {
+    expect(DEFAULT_MAX_BODY_BYTES).toBe(1_000_000);
+  });
+
+  it('allows requests with no Content-Length header', () => {
+    expect(enforceBodySizeLimit(makeRequest())).toBeNull();
+  });
+
+  it('allows requests within the limit', () => {
+    expect(enforceBodySizeLimit(makeRequest({ 'content-length': '500' }))).toBeNull();
+    expect(
+      enforceBodySizeLimit(makeRequest({ 'content-length': String(DEFAULT_MAX_BODY_BYTES) }))
+    ).toBeNull();
+  });
+
+  it('rejects requests over the limit with 413', async () => {
+    const response = enforceBodySizeLimit(
+      makeRequest({ 'content-length': String(DEFAULT_MAX_BODY_BYTES + 1) })
+    );
+    expect(response?.status).toBe(413);
+    const body = await response!.json();
+    expect(body.status).toBe('ERROR');
+    expect(body.message).toMatch(/too large/i);
+    expect(body.maxBytes).toBe(DEFAULT_MAX_BODY_BYTES);
+  });
+
+  it('rejects negative or non-numeric Content-Length with 400', async () => {
+    const negResponse = enforceBodySizeLimit(makeRequest({ 'content-length': '-1' }));
+    expect(negResponse?.status).toBe(400);
+
+    const nanResponse = enforceBodySizeLimit(makeRequest({ 'content-length': 'abc' }));
+    expect(nanResponse?.status).toBe(400);
+  });
+
+  it('respects an explicit per-route limit', async () => {
+    const customLimit = 100;
+    const tooBig = enforceBodySizeLimit(makeRequest({ 'content-length': '101' }), customLimit);
+    expect(tooBig?.status).toBe(413);
+
+    const fine = enforceBodySizeLimit(makeRequest({ 'content-length': '50' }), customLimit);
+    expect(fine).toBeNull();
+  });
+});

--- a/src/__tests__/lib/security/hmac.test.ts
+++ b/src/__tests__/lib/security/hmac.test.ts
@@ -1,0 +1,58 @@
+// src/__tests__/lib/security/hmac.test.ts
+
+import { signPayload, verifySignature, SIGNATURE_HEADER } from '@/lib/security/hmac';
+
+describe('signPayload + verifySignature', () => {
+  const secret = 'shared-secret-between-readyset-and-partner';
+  const body = JSON.stringify({ orderNumber: 'CV-ABC123', status: 'DELIVERED' });
+
+  it('exposes the canonical signature header name', () => {
+    expect(SIGNATURE_HEADER).toBe('x-readyset-signature');
+  });
+
+  it('produces a deterministic hex signature', () => {
+    const a = signPayload(secret, body);
+    const b = signPayload(secret, body);
+    expect(a).toEqual(b);
+    expect(a).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('verifies a valid signature', () => {
+    const sig = signPayload(secret, body);
+    expect(verifySignature(secret, body, sig)).toBe(true);
+  });
+
+  it('rejects when body has been tampered with', () => {
+    const sig = signPayload(secret, body);
+    const tampered = body.replace('DELIVERED', 'CANCELLED');
+    expect(verifySignature(secret, tampered, sig)).toBe(false);
+  });
+
+  it('rejects when secret differs', () => {
+    const sig = signPayload(secret, body);
+    expect(verifySignature('different-secret', body, sig)).toBe(false);
+  });
+
+  it('rejects null/missing signature', () => {
+    expect(verifySignature(secret, body, null)).toBe(false);
+    expect(verifySignature(secret, body, undefined)).toBe(false);
+    expect(verifySignature(secret, body, '')).toBe(false);
+  });
+
+  it('rejects when secret is empty', () => {
+    const sig = signPayload(secret, body);
+    expect(verifySignature('', body, sig)).toBe(false);
+  });
+
+  it('rejects malformed hex signatures without throwing', () => {
+    expect(verifySignature(secret, body, 'not-hex-at-all')).toBe(false);
+    expect(verifySignature(secret, body, 'abc123')).toBe(false); // wrong length
+  });
+
+  it('verifies signatures over Buffer bodies identically to string bodies', () => {
+    const sigFromString = signPayload(secret, body);
+    const sigFromBuffer = signPayload(secret, Buffer.from(body, 'utf8'));
+    expect(sigFromString).toEqual(sigFromBuffer);
+    expect(verifySignature(secret, Buffer.from(body, 'utf8'), sigFromString)).toBe(true);
+  });
+});

--- a/src/__tests__/lib/security/hmac.test.ts
+++ b/src/__tests__/lib/security/hmac.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 // src/__tests__/lib/security/hmac.test.ts
 
 import { signPayload, verifySignature, SIGNATURE_HEADER } from '@/lib/security/hmac';
@@ -10,49 +13,50 @@ describe('signPayload + verifySignature', () => {
     expect(SIGNATURE_HEADER).toBe('x-readyset-signature');
   });
 
-  it('produces a deterministic hex signature', () => {
-    const a = signPayload(secret, body);
-    const b = signPayload(secret, body);
+  it('produces a deterministic hex signature', async () => {
+    const a = await signPayload(secret, body);
+    const b = await signPayload(secret, body);
     expect(a).toEqual(b);
     expect(a).toMatch(/^[a-f0-9]{64}$/);
   });
 
-  it('verifies a valid signature', () => {
-    const sig = signPayload(secret, body);
-    expect(verifySignature(secret, body, sig)).toBe(true);
+  it('verifies a valid signature', async () => {
+    const sig = await signPayload(secret, body);
+    expect(await verifySignature(secret, body, sig)).toBe(true);
   });
 
-  it('rejects when body has been tampered with', () => {
-    const sig = signPayload(secret, body);
+  it('rejects when body has been tampered with', async () => {
+    const sig = await signPayload(secret, body);
     const tampered = body.replace('DELIVERED', 'CANCELLED');
-    expect(verifySignature(secret, tampered, sig)).toBe(false);
+    expect(await verifySignature(secret, tampered, sig)).toBe(false);
   });
 
-  it('rejects when secret differs', () => {
-    const sig = signPayload(secret, body);
-    expect(verifySignature('different-secret', body, sig)).toBe(false);
+  it('rejects when secret differs', async () => {
+    const sig = await signPayload(secret, body);
+    expect(await verifySignature('different-secret', body, sig)).toBe(false);
   });
 
-  it('rejects null/missing signature', () => {
-    expect(verifySignature(secret, body, null)).toBe(false);
-    expect(verifySignature(secret, body, undefined)).toBe(false);
-    expect(verifySignature(secret, body, '')).toBe(false);
+  it('rejects null/missing signature', async () => {
+    expect(await verifySignature(secret, body, null)).toBe(false);
+    expect(await verifySignature(secret, body, undefined)).toBe(false);
+    expect(await verifySignature(secret, body, '')).toBe(false);
   });
 
-  it('rejects when secret is empty', () => {
-    const sig = signPayload(secret, body);
-    expect(verifySignature('', body, sig)).toBe(false);
+  it('rejects when secret is empty', async () => {
+    const sig = await signPayload(secret, body);
+    expect(await verifySignature('', body, sig)).toBe(false);
   });
 
-  it('rejects malformed hex signatures without throwing', () => {
-    expect(verifySignature(secret, body, 'not-hex-at-all')).toBe(false);
-    expect(verifySignature(secret, body, 'abc123')).toBe(false); // wrong length
+  it('rejects malformed hex signatures without throwing', async () => {
+    expect(await verifySignature(secret, body, 'not-hex-at-all')).toBe(false);
+    expect(await verifySignature(secret, body, 'abc123')).toBe(false); // wrong length
   });
 
-  it('verifies signatures over Buffer bodies identically to string bodies', () => {
-    const sigFromString = signPayload(secret, body);
-    const sigFromBuffer = signPayload(secret, Buffer.from(body, 'utf8'));
-    expect(sigFromString).toEqual(sigFromBuffer);
-    expect(verifySignature(secret, Buffer.from(body, 'utf8'), sigFromString)).toBe(true);
+  it('verifies signatures over Uint8Array bodies identically to string bodies', async () => {
+    const encoder = new TextEncoder();
+    const sigFromString = await signPayload(secret, body);
+    const sigFromBytes = await signPayload(secret, encoder.encode(body));
+    expect(sigFromString).toEqual(sigFromBytes);
+    expect(await verifySignature(secret, encoder.encode(body), sigFromString)).toBe(true);
   });
 });

--- a/src/__tests__/lib/security/ssrf-guard.test.ts
+++ b/src/__tests__/lib/security/ssrf-guard.test.ts
@@ -56,6 +56,22 @@ describe('checkOutboundUrl', () => {
     });
   });
 
+  describe('IPv4-mapped and -compatible IPv6', () => {
+    it.each([
+      '::ffff:127.0.0.1',
+      '::ffff:10.0.0.1',
+      '::ffff:192.168.1.1',
+      '::ffff:169.254.169.254',
+    ])('rejects IPv4-mapped IPv6 to private space: %s', (host) => {
+      const result = checkOutboundUrl(`http://[${host}]/`);
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects IPv4-compatible IPv6 to loopback', () => {
+      expect(checkOutboundUrl('http://[::127.0.0.1]/').ok).toBe(false);
+    });
+  });
+
   describe('production https enforcement', () => {
     it('rejects http URLs in production', () => {
       process.env.NODE_ENV = 'production';

--- a/src/__tests__/lib/security/ssrf-guard.test.ts
+++ b/src/__tests__/lib/security/ssrf-guard.test.ts
@@ -1,0 +1,102 @@
+// src/__tests__/lib/security/ssrf-guard.test.ts
+
+import { checkOutboundUrl, assertSafeOutboundUrl } from '@/lib/security/ssrf-guard';
+
+describe('checkOutboundUrl', () => {
+  const ORIGINAL_ENV = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = ORIGINAL_ENV;
+  });
+
+  describe('public hostnames', () => {
+    it('allows public https URLs', () => {
+      expect(checkOutboundUrl('https://api.catervalley.com/webhook')).toEqual({ ok: true });
+      expect(checkOutboundUrl('https://api.catercow.com/v1/webhooks/readyset')).toEqual({
+        ok: true,
+      });
+    });
+
+    it('allows http URLs in non-production', () => {
+      process.env.NODE_ENV = 'development';
+      expect(checkOutboundUrl('http://api.example.com/webhook')).toEqual({ ok: true });
+    });
+  });
+
+  describe('blocked literals', () => {
+    it.each(['localhost', '127.0.0.1', '0.0.0.0', '::1'])('rejects %s', (host) => {
+      const result = checkOutboundUrl(`https://${host.includes(':') ? `[${host}]` : host}/x`);
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects metadata.google.internal (cloud SSRF target)', () => {
+      const result = checkOutboundUrl('http://metadata.google.internal/computeMetadata/v1/');
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe('private IPv4 ranges', () => {
+    it.each([
+      '10.0.0.1',
+      '10.255.255.255',
+      '172.16.0.1',
+      '172.31.255.255',
+      '192.168.0.1',
+      '192.168.1.1',
+      '169.254.169.254', // AWS metadata
+      '100.64.0.1', // CGNAT
+    ])('rejects %s', (host) => {
+      expect(checkOutboundUrl(`https://${host}/`).ok).toBe(false);
+    });
+
+    it('does NOT reject public addresses inside boundary octets', () => {
+      expect(checkOutboundUrl('https://172.15.0.1/').ok).toBe(true);
+      expect(checkOutboundUrl('https://172.32.0.1/').ok).toBe(true);
+      expect(checkOutboundUrl('https://192.169.0.1/').ok).toBe(true);
+    });
+  });
+
+  describe('production https enforcement', () => {
+    it('rejects http URLs in production', () => {
+      process.env.NODE_ENV = 'production';
+      const result = checkOutboundUrl('http://api.example.com/webhook');
+      expect(result.ok).toBe(false);
+      expect(result.reason).toMatch(/HTTPS required/i);
+    });
+
+    it('allows https URLs in production', () => {
+      process.env.NODE_ENV = 'production';
+      expect(checkOutboundUrl('https://api.catervalley.com/webhook').ok).toBe(true);
+    });
+
+    it('option requireHttps overrides env', () => {
+      process.env.NODE_ENV = 'development';
+      const result = checkOutboundUrl('http://api.example.com/webhook', { requireHttps: true });
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe('protocol filtering', () => {
+    it.each(['file:///etc/passwd', 'gopher://x.com', 'ftp://x.com'])(
+      'rejects non-http protocol: %s',
+      (url) => {
+        expect(checkOutboundUrl(url).ok).toBe(false);
+      }
+    );
+  });
+
+  it('rejects malformed URLs', () => {
+    expect(checkOutboundUrl('not a url').ok).toBe(false);
+    expect(checkOutboundUrl('').ok).toBe(false);
+  });
+
+  describe('assertSafeOutboundUrl', () => {
+    it('throws on rejection', () => {
+      expect(() => assertSafeOutboundUrl('http://localhost:8080/')).toThrow(/SSRF/i);
+    });
+
+    it('does not throw on safe URLs', () => {
+      expect(() => assertSafeOutboundUrl('https://api.catervalley.com/')).not.toThrow();
+    });
+  });
+});

--- a/src/__tests__/services/caterValleyService.outbound.test.ts
+++ b/src/__tests__/services/caterValleyService.outbound.test.ts
@@ -1,0 +1,96 @@
+// src/__tests__/services/caterValleyService.outbound.test.ts
+//
+// Verifies outbound webhook hardening added in Phase 1:
+// - HMAC signing on the outbound POST when secret is configured
+// - SSRF guard rejects unsafe URLs configured via env
+
+import { updateCaterValleyOrderStatus } from '@/services/caterValleyService';
+import { signPayload, SIGNATURE_HEADER } from '@/lib/security/hmac';
+
+describe('updateCaterValleyOrderStatus — outbound webhook security', () => {
+  const ORIGINAL = {
+    url: process.env.CATERVALLEY_WEBHOOK_URL,
+    secret: process.env.CATERVALLEY_OUTBOUND_WEBHOOK_SECRET,
+    nodeEnv: process.env.NODE_ENV,
+  };
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    process.env.CATERVALLEY_WEBHOOK_URL = 'https://api.catervalley.com/webhook';
+    process.env.NODE_ENV = 'test';
+    delete process.env.CATERVALLEY_OUTBOUND_WEBHOOK_SECRET;
+
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ result: true, message: 'ok', data: {} }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    if (ORIGINAL.url === undefined) delete process.env.CATERVALLEY_WEBHOOK_URL;
+    else process.env.CATERVALLEY_WEBHOOK_URL = ORIGINAL.url;
+    if (ORIGINAL.secret === undefined) delete process.env.CATERVALLEY_OUTBOUND_WEBHOOK_SECRET;
+    else process.env.CATERVALLEY_OUTBOUND_WEBHOOK_SECRET = ORIGINAL.secret;
+    process.env.NODE_ENV = ORIGINAL.nodeEnv;
+  });
+
+  it('does not send signature header when no outbound secret is configured', async () => {
+    await updateCaterValleyOrderStatus('CV-ABC123', 'CONFIRM');
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers[SIGNATURE_HEADER]).toBeUndefined();
+  });
+
+  it('signs the body with HMAC-SHA256 when outbound secret is configured', async () => {
+    process.env.CATERVALLEY_OUTBOUND_WEBHOOK_SECRET = 'shared-secret-with-catervalley';
+
+    await updateCaterValleyOrderStatus('CV-ABC123', 'COMPLETED');
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    const sentBody = init.body as string;
+
+    expect(headers[SIGNATURE_HEADER]).toBeDefined();
+    expect(headers[SIGNATURE_HEADER]).toMatch(/^[a-f0-9]{64}$/);
+
+    const expected = signPayload('shared-secret-with-catervalley', sentBody);
+    expect(headers[SIGNATURE_HEADER]).toBe(expected);
+  });
+
+  it('rejects without sending when CATERVALLEY_WEBHOOK_URL points at localhost', async () => {
+    process.env.CATERVALLEY_WEBHOOK_URL = 'http://localhost:8080/webhook';
+    const result = await updateCaterValleyOrderStatus('CV-ABC123', 'CONFIRM');
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Refusing to call CaterValley webhook/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects without sending when URL points at AWS metadata IP', async () => {
+    process.env.CATERVALLEY_WEBHOOK_URL = 'http://169.254.169.254/latest/meta-data/';
+    const result = await updateCaterValleyOrderStatus('CV-ABC123', 'CONFIRM');
+    expect(result.success).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects http URL in production', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.CATERVALLEY_WEBHOOK_URL = 'http://api.catervalley.com/webhook';
+    const result = await updateCaterValleyOrderStatus('CV-ABC123', 'CONFIRM');
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/HTTPS required/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('passes through https public URLs', async () => {
+    process.env.CATERVALLEY_WEBHOOK_URL = 'https://api.catervalley.com/v1/status';
+    const result = await updateCaterValleyOrderStatus('CV-ABC123', 'CONFIRM');
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://api.catervalley.com/v1/status',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/__tests__/services/caterValleyService.outbound.test.ts
+++ b/src/__tests__/services/caterValleyService.outbound.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 // src/__tests__/services/caterValleyService.outbound.test.ts
 //
 // Verifies outbound webhook hardening added in Phase 1:
@@ -56,7 +59,7 @@ describe('updateCaterValleyOrderStatus — outbound webhook security', () => {
     expect(headers[SIGNATURE_HEADER]).toBeDefined();
     expect(headers[SIGNATURE_HEADER]).toMatch(/^[a-f0-9]{64}$/);
 
-    const expected = signPayload('shared-secret-with-catervalley', sentBody);
+    const expected = await signPayload('shared-secret-with-catervalley', sentBody);
     expect(headers[SIGNATURE_HEADER]).toBe(expected);
   });
 

--- a/src/app/api/cater-valley/[...slug]/route.ts
+++ b/src/app/api/cater-valley/[...slug]/route.ts
@@ -1,165 +1,123 @@
 /**
- * Catch-all debug endpoint for CaterValley API requests
- * This captures any requests that don't match existing endpoints
+ * Catch-all endpoint for unmatched CaterValley API requests.
+ *
+ * Returns a stable 404 with the list of valid endpoints so partner clients
+ * can self-diagnose typos. Never echoes request headers or body — the
+ * previous version returned full headers (including x-api-key) in the
+ * JSON response, which was a credential disclosure surface.
+ *
+ * In non-production, additional context (slug, search params, body)
+ * is included to aid local debugging.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 
-export async function GET(request: NextRequest, { params }: { params: Promise<{ slug: string[] }> }) {
-  const resolvedParams = await params;
+import { isDebugEnabled, redactHeaders } from '../_lib/debug-guard';
+
+const AVAILABLE_ENDPOINTS = [
+  'POST /api/cater-valley/orders/draft',
+  'POST /api/cater-valley/orders/update',
+  'POST /api/cater-valley/orders/confirm',
+  'POST /api/cater-valley/update-order-status',
+];
+
+const NOT_FOUND_MESSAGE = 'Endpoint not found.';
+
+async function readBodySafely(request: NextRequest): Promise<unknown> {
+  try {
+    return await request.json();
+  } catch {
+    try {
+      const text = await request.text();
+      return text ? { raw: text } : null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+function basePayload(method: string) {
+  return {
+    method,
+    message: NOT_FOUND_MESSAGE,
+    availableEndpoints: AVAILABLE_ENDPOINTS,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+async function debugContext(
+  request: NextRequest,
+  slug: string[],
+  includeBody: boolean
+): Promise<Record<string, unknown>> {
+  if (!isDebugEnabled()) return {};
   const headers = Object.fromEntries(request.headers.entries());
-  const url = request.url;
-  // Use nextUrl.searchParams if available, otherwise fall back to URL parsing
   const searchParams = request.nextUrl?.searchParams
     ? Object.fromEntries(request.nextUrl.searchParams.entries())
-    : Object.fromEntries(new URL(url).searchParams.entries());
-  const slug = resolvedParams.slug;
+    : Object.fromEntries(new URL(request.url).searchParams.entries());
 
-            
-  return NextResponse.json({
-    method: 'GET',
-    url,
+  const ctx: Record<string, unknown> = {
     slug,
-    headers,
+    headers: redactHeaders(headers),
     searchParams,
-    message: 'Catch-all debug endpoint - request logged. This endpoint does not exist.',
-    availableEndpoints: [
-      'POST /api/cater-valley/orders/draft',
-      'POST /api/cater-valley/orders/update',
-      'POST /api/cater-valley/orders/confirm'
-    ],
-    timestamp: new Date().toISOString(),
-  }, { status: 404 });
-}
-
-export async function POST(request: NextRequest, { params }: { params: Promise<{ slug: string[] }> }) {
-  const resolvedParams = await params;
-  const headers = Object.fromEntries(request.headers.entries());
-  const url = request.url;
-  // Use nextUrl.searchParams if available, otherwise fall back to URL parsing
-  const searchParams = request.nextUrl?.searchParams
-    ? Object.fromEntries(request.nextUrl.searchParams.entries())
-    : Object.fromEntries(new URL(url).searchParams.entries());
-  const slug = resolvedParams.slug;
-  
-  let body = null;
-  try {
-    body = await request.json();
-  } catch (error) {
-    try {
-      const text = await request.text();
-      body = { raw: text };
-    } catch (textError) {
-      body = { error: 'Could not parse body' };
-    }
+  };
+  if (includeBody) {
+    ctx.body = await readBodySafely(request);
   }
-
-              
-  return NextResponse.json({
-    method: 'POST',
-    url,
-    slug,
-    headers,
-    searchParams,
-    body,
-    message: 'Catch-all debug endpoint - request logged. This endpoint does not exist.',
-    availableEndpoints: [
-      'POST /api/cater-valley/orders/draft',
-      'POST /api/cater-valley/orders/update',
-      'POST /api/cater-valley/orders/confirm'
-    ],
-    timestamp: new Date().toISOString(),
-  }, { status: 404 });
+  return ctx;
 }
 
-export async function PUT(request: NextRequest, { params }: { params: Promise<{ slug: string[] }> }) {
-  const resolvedParams = await params;
-  const headers = Object.fromEntries(request.headers.entries());
-  const url = request.url;
-  const slug = resolvedParams.slug;
-  
-  let body = null;
-  try {
-    body = await request.json();
-  } catch (error) {
-    try {
-      const text = await request.text();
-      body = { raw: text };
-    } catch (textError) {
-      body = { error: 'Could not parse body' };
-    }
-  }
-
-            
-  return NextResponse.json({
-    method: 'PUT',
-    url,
-    slug,
-    headers,
-    body,
-    message: 'Catch-all debug endpoint - request logged. This endpoint does not exist.',
-    availableEndpoints: [
-      'POST /api/cater-valley/orders/draft',
-      'POST /api/cater-valley/orders/update',
-      'POST /api/cater-valley/orders/confirm'
-    ],
-    timestamp: new Date().toISOString(),
-  }, { status: 404 });
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string[] }> }
+) {
+  const { slug } = await params;
+  return NextResponse.json(
+    { ...basePayload('GET'), ...(await debugContext(request, slug, false)) },
+    { status: 404 }
+  );
 }
 
-export async function PATCH(request: NextRequest, { params }: { params: Promise<{ slug: string[] }> }) {
-  const resolvedParams = await params;
-  const headers = Object.fromEntries(request.headers.entries());
-  const url = request.url;
-  const slug = resolvedParams.slug;
-  
-  let body = null;
-  try {
-    body = await request.json();
-  } catch (error) {
-    try {
-      const text = await request.text();
-      body = { raw: text };
-    } catch (textError) {
-      body = { error: 'Could not parse body' };
-    }
-  }
-
-            
-  return NextResponse.json({
-    method: 'PATCH',
-    url,
-    slug,
-    headers,
-    body,
-    message: 'Catch-all debug endpoint - request logged. This endpoint does not exist.',
-    availableEndpoints: [
-      'POST /api/cater-valley/orders/draft',
-      'POST /api/cater-valley/orders/update',
-      'POST /api/cater-valley/orders/confirm'
-    ],
-    timestamp: new Date().toISOString(),
-  }, { status: 404 });
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string[] }> }
+) {
+  const { slug } = await params;
+  return NextResponse.json(
+    { ...basePayload('POST'), ...(await debugContext(request, slug, true)) },
+    { status: 404 }
+  );
 }
 
-export async function DELETE(request: NextRequest, { params }: { params: Promise<{ slug: string[] }> }) {
-  const resolvedParams = await params;
-  const headers = Object.fromEntries(request.headers.entries());
-  const url = request.url;
-  const slug = resolvedParams.slug;
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string[] }> }
+) {
+  const { slug } = await params;
+  return NextResponse.json(
+    { ...basePayload('PUT'), ...(await debugContext(request, slug, true)) },
+    { status: 404 }
+  );
+}
 
-          
-  return NextResponse.json({
-    method: 'DELETE',
-    url,
-    slug,
-    headers,
-    message: 'Catch-all debug endpoint - request logged. This endpoint does not exist.',
-    availableEndpoints: [
-      'POST /api/cater-valley/orders/draft',
-      'POST /api/cater-valley/orders/update',
-      'POST /api/cater-valley/orders/confirm'
-    ],
-    timestamp: new Date().toISOString(),
-  }, { status: 404 });
-} 
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string[] }> }
+) {
+  const { slug } = await params;
+  return NextResponse.json(
+    { ...basePayload('PATCH'), ...(await debugContext(request, slug, true)) },
+    { status: 404 }
+  );
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string[] }> }
+) {
+  const { slug } = await params;
+  return NextResponse.json(
+    { ...basePayload('DELETE'), ...(await debugContext(request, slug, false)) },
+    { status: 404 }
+  );
+}

--- a/src/app/api/cater-valley/_lib/address-utils.ts
+++ b/src/app/api/cater-valley/_lib/address-utils.ts
@@ -4,6 +4,7 @@
  */
 
 import { prisma } from '@/lib/db/prisma';
+import type { PrismaExecutor } from './order-utils';
 
 /**
  * Location data structure for address operations
@@ -35,18 +36,22 @@ export function extractZipFromAddress(address: string): string {
 }
 
 /**
- * Creates or finds an address in the database
- * First attempts to find an existing address, creates new one if not found
+ * Creates or finds an address in the database.
+ * Tries to find an existing match first, creates a new row if none exists.
  *
  * @param location - Location data containing address details
- * @returns Object with the address ID
+ * @param executor - Optional Prisma client/transaction client. Defaults to the
+ *   global client. Pass `tx` so the lookup-or-create participates in the
+ *   caller's transaction; otherwise an order-create rollback can leave a
+ *   newly inserted address orphaned.
  */
-export async function ensureAddress(location: LocationData): Promise<{ id: string }> {
-  // Parse ZIP from address if not provided separately
+export async function ensureAddress(
+  location: LocationData,
+  executor: PrismaExecutor = prisma
+): Promise<{ id: string }> {
   const zipCode = location.zip || extractZipFromAddress(location.address);
 
-  // First, try to find an existing address
-  const existingAddress = await prisma.address.findFirst({
+  const existingAddress = await executor.address.findFirst({
     where: {
       street1: location.address,
       city: location.city,
@@ -60,8 +65,7 @@ export async function ensureAddress(location: LocationData): Promise<{ id: strin
     return existingAddress;
   }
 
-  // Create new address if not found
-  const newAddress = await prisma.address.create({
+  return executor.address.create({
     data: {
       street1: location.address,
       city: location.city,
@@ -72,6 +76,4 @@ export async function ensureAddress(location: LocationData): Promise<{ id: strin
     },
     select: { id: true },
   });
-
-  return newAddress;
 }

--- a/src/app/api/cater-valley/_lib/auth-utils.ts
+++ b/src/app/api/cater-valley/_lib/auth-utils.ts
@@ -30,6 +30,15 @@ export function validateCaterValleyAuth(request: NextRequest): boolean {
 
   const expectedApiKey = process.env.CATERVALLEY_API_KEY;
   if (!expectedApiKey) {
+    // Fail closed in production: a missing key is a deploy/config error,
+    // not a bypass. In non-production we keep fail-open so local dev and
+    // tests can hit these endpoints without provisioning the secret.
+    if (process.env.NODE_ENV === 'production') {
+      console.error(
+        '[CaterValley] CATERVALLEY_API_KEY is not configured — rejecting request.'
+      );
+      return false;
+    }
     return true;
   }
 

--- a/src/app/api/cater-valley/_lib/auth-utils.ts
+++ b/src/app/api/cater-valley/_lib/auth-utils.ts
@@ -3,29 +3,36 @@
  * Shared authentication logic for CaterValley API endpoints
  */
 
+import { timingSafeEqual } from 'node:crypto';
 import { NextRequest } from 'next/server';
+
+function safeCompare(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, 'utf8');
+  const bBuf = Buffer.from(b, 'utf8');
+  if (aBuf.length !== bBuf.length) return false;
+  return timingSafeEqual(aBuf, bBuf);
+}
 
 /**
  * Validates CaterValley API request authentication
- * Checks for valid partner header and API key
+ * Checks for valid partner header and API key.
  *
- * @param request - The incoming Next.js request
- * @returns true if authenticated, false otherwise
+ * Uses constant-time comparison on the API key to prevent timing attacks
+ * (an attacker measuring response latency cannot infer correct key bytes).
  */
 export function validateCaterValleyAuth(request: NextRequest): boolean {
   const apiKey = request.headers.get('x-api-key');
   const partner = request.headers.get('partner');
 
-  // Check for CaterValley-specific partner header
   if (partner !== 'catervalley') {
     return false;
   }
 
-  // In production, validate the API key against stored credentials
   const expectedApiKey = process.env.CATERVALLEY_API_KEY;
-  if (expectedApiKey && apiKey !== expectedApiKey) {
-    return false;
+  if (!expectedApiKey) {
+    return true;
   }
 
-  return true;
+  if (!apiKey) return false;
+  return safeCompare(apiKey, expectedApiKey);
 }

--- a/src/app/api/cater-valley/_lib/debug-guard.ts
+++ b/src/app/api/cater-valley/_lib/debug-guard.ts
@@ -1,0 +1,38 @@
+/**
+ * Helpers for the CaterValley debug + catch-all routes.
+ *
+ * The original versions echoed every request header (including x-api-key)
+ * and the full body back in the JSON response. In production that's a
+ * credential disclosure surface — anyone who can reach the URL can see
+ * what credentials another caller used. These helpers keep the routes
+ * useful for local development while neutralizing them in production.
+ */
+
+const REDACTED = '<redacted>';
+const SENSITIVE_HEADERS = new Set<string>([
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-api-key',
+  'x-readyset-signature',
+  'partner',
+  'proxy-authorization',
+]);
+
+export function isDebugEnabled(): boolean {
+  return process.env.NODE_ENV !== 'production';
+}
+
+/**
+ * Returns headers safe to echo back. Sensitive header values are replaced
+ * with `<redacted>`, and the rest are passed through. Used only in the
+ * non-production branch of debug routes — production never echoes
+ * headers at all.
+ */
+export function redactHeaders(headers: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    out[key] = SENSITIVE_HEADERS.has(key.toLowerCase()) ? REDACTED : value;
+  }
+  return out;
+}

--- a/src/app/api/cater-valley/_lib/order-utils.ts
+++ b/src/app/api/cater-valley/_lib/order-utils.ts
@@ -4,6 +4,14 @@
  */
 
 import { prisma } from '@/lib/db/prisma';
+import type { Prisma, PrismaClient } from '@prisma/client';
+
+/**
+ * Either the global Prisma client or a transaction client. Helpers accept
+ * this so callers can opt-in to transactional execution by passing the
+ * `tx` argument from `prisma.$transaction(async (tx) => ...)`.
+ */
+export type PrismaExecutor = PrismaClient | Prisma.TransactionClient;
 
 /**
  * Normalizes order number with CV- prefix
@@ -19,13 +27,15 @@ export function normalizeOrderNumber(orderCode: string): string {
 }
 
 /**
- * Creates or finds the CaterValley system user
- * Used as the owner for all CaterValley orders
+ * Creates or finds the CaterValley system user.
+ * Used as the owner for all CaterValley orders.
  *
- * @returns The CaterValley system user profile
+ * @param executor - Optional Prisma client/transaction client. Defaults to the
+ *   global client. Pass `tx` from `prisma.$transaction(async (tx) => ...)` so
+ *   the upsert participates in the same transaction as the order create.
  */
-export async function ensureCaterValleySystemUser() {
-  return await prisma.profile.upsert({
+export async function ensureCaterValleySystemUser(executor: PrismaExecutor = prisma) {
+  return executor.profile.upsert({
     where: { email: 'system@catervalley.com' },
     update: {
       updatedAt: new Date(),

--- a/src/app/api/cater-valley/_lib/pricing-helper.ts
+++ b/src/app/api/cater-valley/_lib/pricing-helper.ts
@@ -67,14 +67,16 @@ export async function calculateCaterValleyPricing(
   try {
     distance = await calculateDistance(pickupAddress, dropoffAddress);
   } catch (error) {
-    // Track distance calculation failure in Sentry for operational visibility
+    // Track distance calculation failure in Sentry for operational visibility.
+    // Full street addresses are PII; redact to city/state granularity which
+    // is enough for operational triage of "this region failed to geocode".
     captureException(error as Error, {
       action: 'calculate_distance',
       feature: feature,
       metadata: {
         orderCode: orderCode,
-        pickupAddress: pickupAddress,
-        dropoffAddress: dropoffAddress
+        pickupCityState: `${pickupLocation.city}, ${pickupLocation.state}`,
+        dropoffCityState: `${dropOffLocation.city}, ${dropOffLocation.state}`,
       }
     });
 

--- a/src/app/api/cater-valley/debug/route.ts
+++ b/src/app/api/cater-valley/debug/route.ts
@@ -1,120 +1,75 @@
 /**
- * Debug endpoint to capture CaterValley API requests
- * This will help identify what URLs CaterValley is actually calling
+ * Debug endpoint to capture CaterValley API requests.
+ *
+ * Only active in non-production environments. In production it returns 404
+ * with no body details — echoing request headers/body to anonymous callers
+ * was leaking the x-api-key and partner header values previously.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 
-export async function GET(request: NextRequest) {
-  const headers = Object.fromEntries(request.headers.entries());
+import { isDebugEnabled, redactHeaders } from '../_lib/debug-guard';
+
+const PRODUCTION_404 = NextResponse.json({ error: 'Not Found' }, { status: 404 });
+
+function notFoundIfProd(): NextResponse | null {
+  return isDebugEnabled() ? null : PRODUCTION_404;
+}
+
+async function readBodySafely(request: NextRequest): Promise<unknown> {
+  try {
+    return await request.json();
+  } catch {
+    try {
+      const text = await request.text();
+      return text ? { raw: text } : null;
+    } catch {
+      return { error: 'Could not parse body' };
+    }
+  }
+}
+
+function describe(request: NextRequest, method: string, body: unknown = undefined) {
   const url = request.url;
+  const headers = Object.fromEntries(request.headers.entries());
   const searchParams = request.nextUrl
     ? Object.fromEntries(request.nextUrl.searchParams.entries())
     : Object.fromEntries(new URL(url).searchParams.entries());
 
-          
-  return NextResponse.json({
-    method: 'GET',
+  return {
+    method,
     url,
-    headers,
+    headers: redactHeaders(headers),
     searchParams,
-    message: 'Debug endpoint - request logged',
+    ...(body !== undefined ? { body } : {}),
+    message: 'Debug endpoint - request logged (sensitive headers redacted)',
     timestamp: new Date().toISOString(),
-  });
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const blocked = notFoundIfProd();
+  if (blocked) return blocked;
+  return NextResponse.json(describe(request, 'GET'));
 }
 
 export async function POST(request: NextRequest) {
-  const headers = Object.fromEntries(request.headers.entries());
-  const url = request.url;
-  const searchParams = request.nextUrl
-    ? Object.fromEntries(request.nextUrl.searchParams.entries())
-    : Object.fromEntries(new URL(url).searchParams.entries());
-  
-  let body = null;
-  try {
-    body = await request.json();
-  } catch (error) {
-    try {
-      const text = await request.text();
-      body = { raw: text };
-    } catch (textError) {
-      body = { error: 'Could not parse body' };
-    }
-  }
-
-            
-  return NextResponse.json({
-    method: 'POST',
-    url,
-    headers,
-    searchParams,
-    body,
-    message: 'Debug endpoint - request logged',
-    timestamp: new Date().toISOString(),
-  });
+  const blocked = notFoundIfProd();
+  if (blocked) return blocked;
+  const body = await readBodySafely(request);
+  return NextResponse.json(describe(request, 'POST', body));
 }
 
 export async function PUT(request: NextRequest) {
-  const headers = Object.fromEntries(request.headers.entries());
-  const url = request.url;
-  const searchParams = request.nextUrl
-    ? Object.fromEntries(request.nextUrl.searchParams.entries())
-    : Object.fromEntries(new URL(url).searchParams.entries());
-
-  let body = null;
-  try {
-    body = await request.json();
-  } catch (error) {
-    try {
-      const text = await request.text();
-      body = { raw: text };
-    } catch (textError) {
-      body = { error: 'Could not parse body' };
-    }
-  }
-
-          
-  return NextResponse.json({
-    method: 'PUT',
-    url,
-    headers,
-    searchParams,
-    body,
-    message: 'Debug endpoint - request logged',
-    timestamp: new Date().toISOString(),
-  });
+  const blocked = notFoundIfProd();
+  if (blocked) return blocked;
+  const body = await readBodySafely(request);
+  return NextResponse.json(describe(request, 'PUT', body));
 }
 
 export async function PATCH(request: NextRequest) {
-  const headers = Object.fromEntries(request.headers.entries());
-  const url = request.url;
-  const searchParams = request.nextUrl
-    ? Object.fromEntries(request.nextUrl.searchParams.entries())
-    : Object.fromEntries(new URL(url).searchParams.entries());
-
-  let body: Record<string, unknown> | null = null;
-  try {
-    const jsonBody = await request.json();
-    // Ensure we always get an object with content
-    body = jsonBody !== null && jsonBody !== undefined && Object.keys(jsonBody).length > 0
-      ? jsonBody
-      : { error: 'Could not parse body' };
-  } catch (error) {
-    try {
-      const text = await request.text();
-      body = text ? { raw: text } : { error: 'Could not parse body' };
-    } catch (textError) {
-      body = { error: 'Could not parse body' };
-    }
-  }
-
-  return NextResponse.json({
-    method: 'PATCH',
-    url,
-    headers,
-    searchParams,
-    body,
-    message: 'Debug endpoint - request logged',
-    timestamp: new Date().toISOString(),
-  });
-} 
+  const blocked = notFoundIfProd();
+  if (blocked) return blocked;
+  const body = await readBodySafely(request);
+  return NextResponse.json(describe(request, 'PATCH', body));
+}

--- a/src/app/api/cater-valley/orders/confirm/route.ts
+++ b/src/app/api/cater-valley/orders/confirm/route.ts
@@ -6,6 +6,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { prisma } from '@/lib/db/prisma';
+import { enforceBodySizeLimit } from '@/lib/security/body-size-limit';
 import {
   validateCaterValleyAuth,
   isOrderEditable,
@@ -68,12 +69,16 @@ function calculateEstimatedDeliveryTime(pickupDateTime: Date): string {
 
 export async function POST(request: NextRequest) {
   try {
+    // 0. Reject oversized bodies before doing any work.
+    const sizeReject = enforceBodySizeLimit(request);
+    if (sizeReject) return sizeReject;
+
     // 1. Authentication
     if (!validateCaterValleyAuth(request)) {
       return NextResponse.json(
-        { 
+        {
           status: 'ERROR',
-          message: 'Unauthorized - Invalid API key or partner header' 
+          message: 'Unauthorized - Invalid API key or partner header'
         },
         { status: 401 }
       );
@@ -107,7 +112,9 @@ export async function POST(request: NextRequest) {
 
     const validatedData = validationResult.data;
 
-    // 3. Check if order exists and belongs to CaterValley
+    // 3. Check if order exists and belongs to CaterValley.
+    //    Soft-deleted orders are treated as not-found so partners can't
+    //    confirm an order that's been removed.
     const existingOrder = await prisma.cateringRequest.findUnique({
       where: { id: validatedData.id },
       include: {
@@ -117,7 +124,7 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    if (!existingOrder) {
+    if (!existingOrder || existingOrder.deletedAt) {
       return NextResponse.json(
         {
           status: 'ERROR',

--- a/src/app/api/cater-valley/orders/draft/route.ts
+++ b/src/app/api/cater-valley/orders/draft/route.ts
@@ -5,8 +5,10 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
+import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/db/prisma';
 import { calculatePickupTime, isDeliveryTimeAvailable } from '@/lib/services/pricingService';
+import { enforceBodySizeLimit } from '@/lib/security/body-size-limit';
 import {
   validateCaterValleyAuth,
   ensureAddress,
@@ -67,12 +69,16 @@ interface DraftOrderResponse {
 
 export async function POST(request: NextRequest) {
   try {
+    // 0. Reject oversized bodies before doing any work.
+    const sizeReject = enforceBodySizeLimit(request);
+    if (sizeReject) return sizeReject;
+
     // 1. Authentication
     if (!validateCaterValleyAuth(request)) {
       return NextResponse.json(
-        { 
+        {
           status: 'ERROR',
-          message: 'Unauthorized - Invalid API key or partner header' 
+          message: 'Unauthorized - Invalid API key or partner header'
         },
         { status: 401 }
       );
@@ -117,13 +123,18 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // 4. Check for duplicate orders
+    // 4. Fast-path duplicate check (also catches soft-deleted orders to
+    //    prevent resurrection by partner retry). Note: this is a UX
+    //    nicety — the authoritative duplicate check is the unique
+    //    constraint enforced by the DB at create time (step 7), which
+    //    closes the read-then-write race window.
     const normalizedOrderNumber = normalizeOrderNumber(validatedData.orderCode);
     const existingOrder = await prisma.cateringRequest.findUnique({
       where: { orderNumber: normalizedOrderNumber },
+      select: { id: true, deletedAt: true },
     });
 
-    if (existingOrder) {
+    if (existingOrder && !existingOrder.deletedAt) {
       return NextResponse.json(
         {
           status: 'ERROR',
@@ -162,48 +173,71 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // 7. Create database entities
-    const [systemUser, pickupAddressRecord, deliveryAddressRecord] = await Promise.all([
-      ensureCaterValleySystemUser(),
-      ensureAddress(validatedData.pickupLocation),
-      ensureAddress(validatedData.dropOffLocation),
-    ]);
-
-    // 8. Create the draft order
-    // Import timezone utility for proper conversion
+    // 7. Create database entities atomically. The system user upsert,
+    //    both address lookups/inserts, and the order create all run
+    //    inside a single transaction so a failure at any step rolls
+    //    back the whole thing — no orphaned addresses or half-created
+    //    orders.
     const { localTimeToUtc } = await import('@/lib/utils/timezone');
     const deliveryDateTime = new Date(localTimeToUtc(validatedData.deliveryDate, validatedData.deliveryTime));
     const pickupTime = calculatePickupTime(validatedData.deliveryDate, validatedData.deliveryTime);
 
-    const draftOrder = await prisma.cateringRequest.create({
-      data: {
-        orderNumber: normalizedOrderNumber,
-        status: 'ACTIVE',
-        userId: systemUser.id,
-        pickupAddressId: pickupAddressRecord.id,
-        deliveryAddressId: deliveryAddressRecord.id,
-        headcount: validatedData.totalItem,
-        orderTotal: validatedData.priceTotal,
-        pickupDateTime: new Date(pickupTime),
-        arrivalDateTime: deliveryDateTime,
-        clientAttention: validatedData.dropOffLocation.recipient.name,
-        pickupNotes: `CaterValley Order - Pickup from: ${validatedData.pickupLocation.name}`,
-        specialNotes: usedFallbackDistance
-          ? `${validatedData.dropOffLocation.instructions || ''}\n[FALLBACK DISTANCE: ${distance}mi - Manual review needed]`.trim()
-          : validatedData.dropOffLocation.instructions || '',
-        brokerage: 'CaterValley',
-        // Store delivery cost and distance for transparency
-        deliveryCost: pricingResult.deliveryFee,
-        deliveryDistance: distance,
-        // Store additional metadata in a JSON field if your schema supports it
-        guid: `cv-${validatedData.orderCode}-${Date.now()}`,
-      },
-      include: {
-        pickupAddress: true,
-        deliveryAddress: true,
-        user: true,
-      },
-    });
+    let draftOrder;
+    try {
+      draftOrder = await prisma.$transaction(async (tx) => {
+        const [systemUser, pickupAddressRecord, deliveryAddressRecord] = await Promise.all([
+          ensureCaterValleySystemUser(tx),
+          ensureAddress(validatedData.pickupLocation, tx),
+          ensureAddress(validatedData.dropOffLocation, tx),
+        ]);
+
+        return tx.cateringRequest.create({
+          data: {
+            orderNumber: normalizedOrderNumber,
+            status: 'ACTIVE',
+            userId: systemUser.id,
+            pickupAddressId: pickupAddressRecord.id,
+            deliveryAddressId: deliveryAddressRecord.id,
+            headcount: validatedData.totalItem,
+            orderTotal: validatedData.priceTotal,
+            pickupDateTime: new Date(pickupTime),
+            arrivalDateTime: deliveryDateTime,
+            clientAttention: validatedData.dropOffLocation.recipient.name,
+            pickupNotes: `CaterValley Order - Pickup from: ${validatedData.pickupLocation.name}`,
+            specialNotes: usedFallbackDistance
+              ? `${validatedData.dropOffLocation.instructions || ''}\n[FALLBACK DISTANCE: ${distance}mi - Manual review needed]`.trim()
+              : validatedData.dropOffLocation.instructions || '',
+            brokerage: 'CaterValley',
+            deliveryCost: pricingResult.deliveryFee,
+            deliveryDistance: distance,
+            guid: `cv-${validatedData.orderCode}-${Date.now()}`,
+          },
+          include: {
+            pickupAddress: true,
+            deliveryAddress: true,
+            user: true,
+          },
+        });
+      });
+    } catch (error) {
+      // Race-safe: if a concurrent request created the same orderNumber
+      // between our fast-path check and this insert, Prisma raises
+      // P2002 (unique constraint). Convert to a deterministic 409 instead
+      // of a 500.
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        return NextResponse.json(
+          {
+            status: 'ERROR',
+            message: `Order with code ${validatedData.orderCode} already exists`,
+          },
+          { status: 409 }
+        );
+      }
+      throw error;
+    }
 
     // 9. Return success response
     const response: DraftOrderResponse = {

--- a/src/app/api/cater-valley/orders/update/route.ts
+++ b/src/app/api/cater-valley/orders/update/route.ts
@@ -5,8 +5,10 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
+import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/db/prisma';
 import { calculatePickupTime, isDeliveryTimeAvailable } from '@/lib/services/pricingService';
+import { enforceBodySizeLimit } from '@/lib/security/body-size-limit';
 import {
   validateCaterValleyAuth,
   ensureAddress,
@@ -68,12 +70,16 @@ interface UpdateOrderResponse {
 
 export async function POST(request: NextRequest) {
   try {
+    // 0. Reject oversized bodies before doing any work.
+    const sizeReject = enforceBodySizeLimit(request);
+    if (sizeReject) return sizeReject;
+
     // 1. Authentication
     if (!validateCaterValleyAuth(request)) {
       return NextResponse.json(
-        { 
+        {
           status: 'ERROR',
-          message: 'Unauthorized - Invalid API key or partner header' 
+          message: 'Unauthorized - Invalid API key or partner header'
         },
         { status: 401 }
       );
@@ -107,7 +113,9 @@ export async function POST(request: NextRequest) {
 
     const validatedData = validationResult.data;
 
-    // 3. Check if order exists and belongs to CaterValley
+    // 3. Check if order exists and belongs to CaterValley.
+    //    Soft-deleted orders return 404 (rather than letting partner clients
+    //    "resurrect" deleted orders by updating them).
     const existingOrder = await prisma.cateringRequest.findUnique({
       where: { id: validatedData.id },
       include: {
@@ -117,7 +125,7 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    if (!existingOrder) {
+    if (!existingOrder || existingOrder.deletedAt) {
       return NextResponse.json(
         {
           status: 'ERROR',
@@ -160,14 +168,18 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // 5. Check for duplicate order codes (excluding current order)
+    // 5. Fast-path duplicate check on rename (excluding current order and
+    //    soft-deleted rows). The DB unique constraint at update time is
+    //    the authoritative race-safe guard (handled in catch block below).
     const normalizedOrderNumber = normalizeOrderNumber(validatedData.orderCode);
     if (normalizedOrderNumber !== existingOrder.orderNumber) {
       const duplicateOrder = await prisma.cateringRequest.findFirst({
-        where: { 
+        where: {
           orderNumber: normalizedOrderNumber,
           id: { not: validatedData.id },
+          deletedAt: null,
         },
+        select: { id: true },
       });
 
       if (duplicateOrder) {
@@ -210,44 +222,64 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // 6. Update or create addresses
-    const [pickupAddressRecord, deliveryAddressRecord] = await Promise.all([
-      ensureAddress(validatedData.pickupLocation),
-      ensureAddress(validatedData.dropOffLocation),
-    ]);
-
-    // 7. Update the order
-    // Import timezone utility for proper conversion
+    // 6. Address upserts and order update run in a single transaction so
+    //    a newly inserted address can't be left orphaned by a failed
+    //    order update.
     const { localTimeToUtc } = await import('@/lib/utils/timezone');
     const deliveryDateTime = new Date(localTimeToUtc(validatedData.deliveryDate, validatedData.deliveryTime));
     const pickupTime = calculatePickupTime(validatedData.deliveryDate, validatedData.deliveryTime);
 
-    const updatedOrder = await prisma.cateringRequest.update({
-      where: { id: validatedData.id },
-      data: {
-        orderNumber: normalizedOrderNumber,
-        pickupAddressId: pickupAddressRecord.id,
-        deliveryAddressId: deliveryAddressRecord.id,
-        headcount: validatedData.totalItem,
-        orderTotal: validatedData.priceTotal,
-        pickupDateTime: new Date(pickupTime),
-        arrivalDateTime: deliveryDateTime,
-        clientAttention: validatedData.dropOffLocation.recipient.name,
-        pickupNotes: `CaterValley Order - Pickup from: ${validatedData.pickupLocation.name}`,
-        specialNotes: usedFallbackDistance
-          ? `${validatedData.dropOffLocation.instructions || ''}\n[FALLBACK DISTANCE: ${distance}mi - Manual review needed]`.trim()
-          : validatedData.dropOffLocation.instructions || '',
-        // Update delivery cost and distance for transparency
-        deliveryCost: pricingResult.deliveryFee,
-        deliveryDistance: distance,
-        updatedAt: new Date(),
-      },
-      include: {
-        pickupAddress: true,
-        deliveryAddress: true,
-        user: true,
-      },
-    });
+    let updatedOrder;
+    try {
+      updatedOrder = await prisma.$transaction(async (tx) => {
+        const [pickupAddressRecord, deliveryAddressRecord] = await Promise.all([
+          ensureAddress(validatedData.pickupLocation, tx),
+          ensureAddress(validatedData.dropOffLocation, tx),
+        ]);
+
+        return tx.cateringRequest.update({
+          where: { id: validatedData.id },
+          data: {
+            orderNumber: normalizedOrderNumber,
+            pickupAddressId: pickupAddressRecord.id,
+            deliveryAddressId: deliveryAddressRecord.id,
+            headcount: validatedData.totalItem,
+            orderTotal: validatedData.priceTotal,
+            pickupDateTime: new Date(pickupTime),
+            arrivalDateTime: deliveryDateTime,
+            clientAttention: validatedData.dropOffLocation.recipient.name,
+            pickupNotes: `CaterValley Order - Pickup from: ${validatedData.pickupLocation.name}`,
+            specialNotes: usedFallbackDistance
+              ? `${validatedData.dropOffLocation.instructions || ''}\n[FALLBACK DISTANCE: ${distance}mi - Manual review needed]`.trim()
+              : validatedData.dropOffLocation.instructions || '',
+            deliveryCost: pricingResult.deliveryFee,
+            deliveryDistance: distance,
+            updatedAt: new Date(),
+          },
+          include: {
+            pickupAddress: true,
+            deliveryAddress: true,
+            user: true,
+          },
+        });
+      });
+    } catch (error) {
+      // Race-safe: a concurrent request may have claimed the new orderNumber
+      // between our fast-path check and the update.
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        return NextResponse.json(
+          {
+            status: 'ERROR',
+            message: `Order with code ${validatedData.orderCode} already exists`,
+          },
+          { status: 409 }
+        );
+      }
+      throw error;
+    }
 
     // 8. Return success response
     const response: UpdateOrderResponse = {

--- a/src/app/api/cater-valley/status/route.ts
+++ b/src/app/api/cater-valley/status/route.ts
@@ -1,6 +1,11 @@
 /**
  * CaterValley Integration Status Endpoint
- * Provides information about the integration status and available endpoints
+ * Provides information about the integration status and available endpoints.
+ *
+ * The public response intentionally does NOT advertise environment
+ * configuration (whether API keys or webhook URLs are set) — that signal
+ * helped attackers fingerprint a deployment. Operators who need that
+ * detail should query application logs or Sentry instead.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -8,27 +13,23 @@ import { prisma } from '@/lib/db/prisma';
 
 export async function GET(request: NextRequest) {
   try {
-    // Check database connectivity
+    // Check database connectivity. Soft-deleted orders are excluded so the
+    // public count reflects active CaterValley traffic.
     let dbStatus = 'connected';
     let orderCount = 0;
     try {
       orderCount = await prisma.cateringRequest.count({
         where: {
           orderNumber: {
-            startsWith: 'CV-'
-          }
-        }
+            startsWith: 'CV-',
+          },
+          deletedAt: null,
+        },
       });
     } catch (error) {
       dbStatus = 'error';
       console.error('Database connectivity check failed:', error);
     }
-
-    // Check environment configuration
-    const envStatus = {
-      apiKeyConfigured: !!process.env.CATERVALLEY_API_KEY,
-      webhookUrlConfigured: !!process.env.CATERVALLEY_WEBHOOK_URL,
-    };
 
     const status = {
       service: 'Ready Set CaterValley Integration',
@@ -39,31 +40,29 @@ export async function GET(request: NextRequest) {
         status: dbStatus,
         caterValleyOrderCount: orderCount,
       },
-      environment: envStatus,
       endpoints: {
         draft: {
           method: 'POST',
           path: '/api/cater-valley/orders/draft',
           description: 'Create a new draft order with pricing calculation',
-          authentication: 'Required: partner: catervalley, x-api-key',
+          authentication: 'Required: partner + x-api-key headers',
         },
         update: {
           method: 'POST',
           path: '/api/cater-valley/orders/update',
           description: 'Update an existing draft order and recalculate pricing',
-          authentication: 'Required: partner: catervalley, x-api-key',
+          authentication: 'Required: partner + x-api-key headers',
         },
         confirm: {
           method: 'POST',
           path: '/api/cater-valley/orders/confirm',
           description: 'Confirm or cancel an order',
-          authentication: 'Required: partner: catervalley, x-api-key',
+          authentication: 'Required: partner + x-api-key headers',
         },
         webhook: {
           method: 'POST',
-          url: process.env.CATERVALLEY_WEBHOOK_URL || 'https://api.catervalley.com/api/operation/order/update-order-status',
-          description: 'Ready Set sends status updates to CaterValley',
-          authentication: 'Required: partner: ready-set',
+          description:
+            'Ready Set sends status updates to CaterValley (HMAC-signed when configured)',
         },
       },
       statusMapping: {

--- a/src/app/api/cater-valley/update-order-status/route.ts
+++ b/src/app/api/cater-valley/update-order-status/route.ts
@@ -7,6 +7,7 @@ import {
   type OrderStatus,
   type CaterValleyUpdateResult,
 } from '@/services/caterValleyService'; // Import from the service file
+import { verifySignature, SIGNATURE_HEADER } from '@/lib/security/hmac';
 
 // Interface for the request body expected by this route handler
 interface UpdateStatusRequestBody {
@@ -14,6 +15,15 @@ interface UpdateStatusRequestBody {
   status: OrderStatus;
   // Add any other internal identifiers if needed, e.g., your internal order ID
   // internalOrderId?: string;
+}
+
+type HmacResult = 'ok' | 'no-secret-configured' | 'missing-signature' | 'mismatch';
+
+function verifyInboundHmac(rawBody: string, providedSig: string | null): HmacResult {
+  const secret = process.env.CATERVALLEY_INBOUND_WEBHOOK_SECRET;
+  if (!secret) return 'no-secret-configured';
+  if (!providedSig) return 'missing-signature';
+  return verifySignature(secret, rawBody, providedSig) ? 'ok' : 'mismatch';
 }
 
 // --- API Route Handler ---
@@ -28,14 +38,51 @@ export async function POST(request: NextRequest) {
         );
     }
 
-    let requestBody: UpdateStatusRequestBody;
+    // Read raw body once so we can both verify the HMAC over the exact bytes
+    // and parse JSON from the same payload. `request.json()` consumes the
+    // stream, so we can't call it after .text().
+    let rawBody: string;
     try {
-        requestBody = await request.json();
+      rawBody = await request.text();
     } catch (e) {
-        console.error("Error parsing JSON body:", e);
-        return NextResponse.json({ message: 'Invalid JSON body' }, { status: 400 });
+      console.error('Error reading request body:', e);
+      return NextResponse.json({ message: 'Could not read request body' }, { status: 400 });
     }
 
+    // HMAC verification — additive rollout.
+    // ENFORCE_INBOUND_WEBHOOK_HMAC=true rejects unsigned/mismatched requests
+    // with 401. When false (initial rollout while CaterValley adds signing on
+    // their side), failures are logged but the request still processes.
+    const enforceHmac = process.env.ENFORCE_INBOUND_WEBHOOK_HMAC === 'true';
+    const providedSig = request.headers.get(SIGNATURE_HEADER);
+    const hmacResult = verifyInboundHmac(rawBody, providedSig);
+
+    if (hmacResult !== 'ok' && hmacResult !== 'no-secret-configured') {
+      const detail = {
+        result: hmacResult,
+        enforced: enforceHmac,
+        hasSignatureHeader: providedSig !== null,
+      };
+      if (enforceHmac) {
+        console.warn('[CaterValley] Inbound webhook HMAC failed — rejecting:', detail);
+        return NextResponse.json(
+          { message: 'Invalid or missing webhook signature' },
+          { status: 401 }
+        );
+      }
+      console.warn(
+        '[CaterValley] Inbound webhook HMAC failed — log-only mode (request still processed):',
+        detail
+      );
+    }
+
+    let requestBody: UpdateStatusRequestBody;
+    try {
+      requestBody = JSON.parse(rawBody);
+    } catch (e) {
+      console.error('Error parsing JSON body:', e);
+      return NextResponse.json({ message: 'Invalid JSON body' }, { status: 400 });
+    }
 
     // 2. Validate Input
     const { orderNumber, status } = requestBody;
@@ -52,10 +99,6 @@ export async function POST(request: NextRequest) {
             { status: 400 }
         );
     }
-
-    // --- Security Note ---
-    // Add authentication/authorization checks here if this endpoint
-    // needs to be protected. Verify the caller has permission to update this order.
 
 
     // 3. Call the External API via the service function

--- a/src/app/api/cater-valley/update-order-status/route.ts
+++ b/src/app/api/cater-valley/update-order-status/route.ts
@@ -19,11 +19,11 @@ interface UpdateStatusRequestBody {
 
 type HmacResult = 'ok' | 'no-secret-configured' | 'missing-signature' | 'mismatch';
 
-function verifyInboundHmac(rawBody: string, providedSig: string | null): HmacResult {
+async function verifyInboundHmac(rawBody: string, providedSig: string | null): Promise<HmacResult> {
   const secret = process.env.CATERVALLEY_INBOUND_WEBHOOK_SECRET;
   if (!secret) return 'no-secret-configured';
   if (!providedSig) return 'missing-signature';
-  return verifySignature(secret, rawBody, providedSig) ? 'ok' : 'mismatch';
+  return (await verifySignature(secret, rawBody, providedSig)) ? 'ok' : 'mismatch';
 }
 
 // --- API Route Handler ---
@@ -55,7 +55,7 @@ export async function POST(request: NextRequest) {
     // their side), failures are logged but the request still processes.
     const enforceHmac = process.env.ENFORCE_INBOUND_WEBHOOK_HMAC === 'true';
     const providedSig = request.headers.get(SIGNATURE_HEADER);
-    const hmacResult = verifyInboundHmac(rawBody, providedSig);
+    const hmacResult = await verifyInboundHmac(rawBody, providedSig);
 
     if (hmacResult !== 'ok' && hmacResult !== 'no-secret-configured') {
       const detail = {

--- a/src/lib/security/body-size-limit.ts
+++ b/src/lib/security/body-size-limit.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const DEFAULT_MAX_BODY_BYTES = 1_000_000; // 1 MB
+
+/**
+ * Reject requests whose Content-Length exceeds the limit. Returns a
+ * 413 NextResponse if the limit is breached, or null if the request is
+ * within bounds (caller continues).
+ *
+ * This is a defense-in-depth check — Vercel and most edge proxies have
+ * their own body limits, but we want a predictable, application-level
+ * rejection for partner traffic so callers get a structured error
+ * envelope instead of a transparent gateway error.
+ *
+ * Note: only checks the declared Content-Length header. A malicious
+ * client could lie about it; pair this with a runtime cap on .text()
+ * length if the threat model requires it.
+ */
+export function enforceBodySizeLimit(
+  request: Request | NextRequest,
+  maxBytes: number = DEFAULT_MAX_BODY_BYTES
+): NextResponse | null {
+  const header = request.headers.get('content-length');
+  if (!header) return null;
+
+  const declared = Number(header);
+  if (!Number.isFinite(declared) || declared < 0) {
+    return NextResponse.json(
+      { status: 'ERROR', message: 'Invalid Content-Length header' },
+      { status: 400 }
+    );
+  }
+
+  if (declared > maxBytes) {
+    return NextResponse.json(
+      {
+        status: 'ERROR',
+        message: `Request body too large (max ${maxBytes} bytes)`,
+        maxBytes,
+      },
+      { status: 413 }
+    );
+  }
+  return null;
+}

--- a/src/lib/security/hmac.ts
+++ b/src/lib/security/hmac.ts
@@ -1,16 +1,71 @@
-import { createHmac, timingSafeEqual } from 'node:crypto';
+/**
+ * HMAC-SHA256 utilities built on the Web Crypto API.
+ *
+ * We deliberately avoid `node:crypto` here because this module is reachable
+ * from a client component (`SingleOrder.tsx` → `brokerSyncService` →
+ * `caterValleyService` re-exports). Webpack can't bundle `node:` URIs for
+ * the browser, so the build breaks the moment a client-reachable graph
+ * touches Node built-ins. Web Crypto (`globalThis.crypto.subtle`) is
+ * available in both Node 18+ and modern browsers, so the same code works
+ * in either environment.
+ */
 
 export const SIGNATURE_HEADER = 'x-readyset-signature';
+
+const encoder = new TextEncoder();
+
+function toBytes(body: string | Uint8Array): ArrayBuffer {
+  const view = typeof body === 'string' ? encoder.encode(body) : body;
+  // Slice yields a fresh ArrayBuffer (not SharedArrayBuffer) which the
+  // Web Crypto API typings require.
+  return view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength) as ArrayBuffer;
+}
+
+function bytesToHex(bytes: ArrayBuffer | Uint8Array): string {
+  const view = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  let hex = '';
+  for (let i = 0; i < view.length; i++) {
+    hex += view[i]!.toString(16).padStart(2, '0');
+  }
+  return hex;
+}
+
+function hexToBytes(hex: string): Uint8Array | null {
+  if (hex.length === 0 || hex.length % 2 !== 0) return null;
+  if (!/^[0-9a-fA-F]+$/.test(hex)) return null;
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.substr(i * 2, 2), 16);
+  }
+  return out;
+}
+
+async function importHmacKey(secret: string): Promise<CryptoKey> {
+  const keyBytes = encoder.encode(secret);
+  const keyBuffer = keyBytes.buffer.slice(
+    keyBytes.byteOffset,
+    keyBytes.byteOffset + keyBytes.byteLength
+  ) as ArrayBuffer;
+  return globalThis.crypto.subtle.importKey(
+    'raw',
+    keyBuffer,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign', 'verify']
+  );
+}
 
 /**
  * Compute an HMAC-SHA256 hex signature over the given body using the secret.
  *
- * Use the raw request body (string or Buffer) — JSON.stringify-then-sign is
- * fine as long as both sides agree on the canonical form. Prefer signing the
- * already-serialized body you're about to send.
+ * Use the raw request body — JSON.stringify-then-sign is fine as long as
+ * both sides agree on the canonical form. Prefer signing the already-
+ * serialized body you're about to send.
  */
-export function signPayload(secret: string, body: string | Buffer): string {
-  return createHmac('sha256', secret).update(body).digest('hex');
+export async function signPayload(secret: string, body: string | Uint8Array): Promise<string> {
+  const key = await importHmacKey(secret);
+  const sig = await globalThis.crypto.subtle.sign('HMAC', key, toBytes(body));
+  return bytesToHex(sig);
 }
 
 /**
@@ -20,28 +75,26 @@ export function signPayload(secret: string, body: string | Buffer): string {
  * hex, length mismatch, missing values — so callers can treat all failure
  * modes uniformly. A throw here would leak timing information about *which*
  * branch failed.
+ *
+ * Verification uses `crypto.subtle.verify`, which is implemented in
+ * constant time on every platform we target.
  */
-export function verifySignature(
+export async function verifySignature(
   secret: string,
-  body: string | Buffer,
+  body: string | Uint8Array,
   providedSignature: string | null | undefined
-): boolean {
+): Promise<boolean> {
   if (!secret || !providedSignature) return false;
-
-  const expected = signPayload(secret, body);
-
-  let providedBuf: Buffer;
-  let expectedBuf: Buffer;
+  const sigBytes = hexToBytes(providedSignature);
+  if (!sigBytes) return false;
+  const sigBuffer = sigBytes.buffer.slice(
+    sigBytes.byteOffset,
+    sigBytes.byteOffset + sigBytes.byteLength
+  ) as ArrayBuffer;
   try {
-    providedBuf = Buffer.from(providedSignature, 'hex');
-    expectedBuf = Buffer.from(expected, 'hex');
+    const key = await importHmacKey(secret);
+    return await globalThis.crypto.subtle.verify('HMAC', key, sigBuffer, toBytes(body));
   } catch {
     return false;
   }
-
-  if (providedBuf.length === 0 || providedBuf.length !== expectedBuf.length) {
-    return false;
-  }
-
-  return timingSafeEqual(providedBuf, expectedBuf);
 }

--- a/src/lib/security/hmac.ts
+++ b/src/lib/security/hmac.ts
@@ -1,0 +1,47 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+export const SIGNATURE_HEADER = 'x-readyset-signature';
+
+/**
+ * Compute an HMAC-SHA256 hex signature over the given body using the secret.
+ *
+ * Use the raw request body (string or Buffer) — JSON.stringify-then-sign is
+ * fine as long as both sides agree on the canonical form. Prefer signing the
+ * already-serialized body you're about to send.
+ */
+export function signPayload(secret: string, body: string | Buffer): string {
+  return createHmac('sha256', secret).update(body).digest('hex');
+}
+
+/**
+ * Constant-time verify of a hex-encoded HMAC-SHA256 signature.
+ *
+ * Returns false (rather than throwing) for any malformed input — invalid
+ * hex, length mismatch, missing values — so callers can treat all failure
+ * modes uniformly. A throw here would leak timing information about *which*
+ * branch failed.
+ */
+export function verifySignature(
+  secret: string,
+  body: string | Buffer,
+  providedSignature: string | null | undefined
+): boolean {
+  if (!secret || !providedSignature) return false;
+
+  const expected = signPayload(secret, body);
+
+  let providedBuf: Buffer;
+  let expectedBuf: Buffer;
+  try {
+    providedBuf = Buffer.from(providedSignature, 'hex');
+    expectedBuf = Buffer.from(expected, 'hex');
+  } catch {
+    return false;
+  }
+
+  if (providedBuf.length === 0 || providedBuf.length !== expectedBuf.length) {
+    return false;
+  }
+
+  return timingSafeEqual(providedBuf, expectedBuf);
+}

--- a/src/lib/security/ssrf-guard.ts
+++ b/src/lib/security/ssrf-guard.ts
@@ -37,11 +37,49 @@ function isPrivateIPv4(host: string): boolean {
   return false;
 }
 
+/**
+ * Decode the trailing 32 bits of an IPv6 address (last two hex groups, or a
+ * dotted IPv4 tail) into dotted-quad form. Returns null if the input doesn't
+ * look like one of those embedded forms.
+ *
+ * Note: the WHATWG URL parser normalizes `[::ffff:127.0.0.1]` to
+ * `[::ffff:7f00:1]`, so we must accept both the dotted and the hex
+ * representations.
+ */
+function decodeEmbeddedIPv4(tail: string): string | null {
+  if (/^[0-9.]+$/.test(tail)) return tail;
+  const hexMatch = tail.match(/^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (!hexMatch || !hexMatch[1] || !hexMatch[2]) return null;
+  const hi = parseInt(hexMatch[1], 16);
+  const lo = parseInt(hexMatch[2], 16);
+  if (Number.isNaN(hi) || Number.isNaN(lo)) return null;
+  const a = (hi >> 8) & 0xff;
+  const b = hi & 0xff;
+  const c = (lo >> 8) & 0xff;
+  const d = lo & 0xff;
+  return `${a}.${b}.${c}.${d}`;
+}
+
 function isPrivateIPv6(host: string): boolean {
   const lower = host.toLowerCase().replace(/^\[|\]$/g, '');
   if (lower === '::' || lower === '::1') return true;
   if (lower.startsWith('fc') || lower.startsWith('fd')) return true;
   if (lower.startsWith('fe80:')) return true;
+  // IPv4-mapped IPv6 (::ffff:a.b.c.d, normalized to ::ffff:H:H) — without
+  // this, a URL like http://[::ffff:127.0.0.1]/ slips past every other
+  // check and resolves to loopback through the IPv6 stack.
+  const v4MapMatch = lower.match(/^::ffff:(.+)$/);
+  if (v4MapMatch && v4MapMatch[1]) {
+    const decoded = decodeEmbeddedIPv4(v4MapMatch[1]);
+    if (decoded && isPrivateIPv4(decoded)) return true;
+  }
+  // IPv4-compatible IPv6 (::a.b.c.d, normalized to ::H:H), deprecated but
+  // still routable.
+  const v4CompatMatch = lower.match(/^::([^:]+:[^:]+|[0-9.]+)$/);
+  if (v4CompatMatch && v4CompatMatch[1]) {
+    const decoded = decodeEmbeddedIPv4(v4CompatMatch[1]);
+    if (decoded && isPrivateIPv4(decoded)) return true;
+  }
   return false;
 }
 

--- a/src/lib/security/ssrf-guard.ts
+++ b/src/lib/security/ssrf-guard.ts
@@ -1,0 +1,104 @@
+/**
+ * SSRF guard for outbound HTTP requests.
+ *
+ * Blocks loopback, link-local, RFC1918 private ranges, and (in production)
+ * non-https URLs. Use before any fetch whose URL comes from configuration
+ * the application doesn't fully control (env vars, DB-backed partner
+ * registry, etc.) so a misconfigured row can't pivot into internal services.
+ *
+ * This is a hostname/IP-literal check. It does NOT resolve DNS — a hostname
+ * that resolves to a private IP at request time will pass; pair with a
+ * resolving check at the network layer if that threat model matters.
+ */
+
+const PRIVATE_LITERAL_BLOCKLIST = new Set<string>([
+  '0.0.0.0',
+  '127.0.0.1',
+  '::1',
+  '::',
+  'localhost',
+  'localhost.localdomain',
+  'metadata.google.internal',
+]);
+
+function isPrivateIPv4(host: string): boolean {
+  const parts = host.split('.');
+  if (parts.length !== 4) return false;
+  const octets = parts.map((p) => Number(p));
+  if (octets.some((o) => Number.isNaN(o) || o < 0 || o > 255)) return false;
+  const [a, b] = octets as [number, number, number, number];
+  if (a === 10) return true;
+  if (a === 127) return true;
+  if (a === 0) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  return false;
+}
+
+function isPrivateIPv6(host: string): boolean {
+  const lower = host.toLowerCase().replace(/^\[|\]$/g, '');
+  if (lower === '::' || lower === '::1') return true;
+  if (lower.startsWith('fc') || lower.startsWith('fd')) return true;
+  if (lower.startsWith('fe80:')) return true;
+  return false;
+}
+
+export interface SsrfGuardOptions {
+  requireHttps?: boolean;
+}
+
+export interface SsrfCheckResult {
+  ok: boolean;
+  reason?: string;
+}
+
+export function checkOutboundUrl(
+  rawUrl: string,
+  opts: SsrfGuardOptions = {}
+): SsrfCheckResult {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return { ok: false, reason: 'Invalid URL' };
+  }
+
+  const requireHttps = opts.requireHttps ?? process.env.NODE_ENV === 'production';
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    return { ok: false, reason: `Protocol not allowed: ${parsed.protocol}` };
+  }
+
+  if (requireHttps && parsed.protocol !== 'https:') {
+    return { ok: false, reason: 'HTTPS required in production' };
+  }
+
+  const host = parsed.hostname.toLowerCase();
+
+  if (PRIVATE_LITERAL_BLOCKLIST.has(host)) {
+    return { ok: false, reason: `Blocked host: ${host}` };
+  }
+
+  if (isPrivateIPv4(host)) {
+    return { ok: false, reason: `Private IPv4 address: ${host}` };
+  }
+
+  if (isPrivateIPv6(host)) {
+    return { ok: false, reason: `Private IPv6 address: ${host}` };
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Throws if the URL fails the SSRF check. Convenience wrapper for callers
+ * that want to fail fast.
+ */
+export function assertSafeOutboundUrl(rawUrl: string, opts?: SsrfGuardOptions): void {
+  const result = checkOutboundUrl(rawUrl, opts);
+  if (!result.ok) {
+    throw new Error(`Outbound URL rejected by SSRF guard: ${result.reason}`);
+  }
+}

--- a/src/lib/services/pricingService.ts
+++ b/src/lib/services/pricingService.ts
@@ -179,9 +179,20 @@ export async function calculateDeliveryPrice(params: PricingParams): Promise<Pri
  * Calculate actual distance between two addresses using Google Maps API
  * This replaces the mock implementation with real distance calculation
  */
+/**
+ * Redact full address strings to "City, ST" for Sentry payloads. Street
+ * numbers / lines are PII; the city/state granularity is sufficient for
+ * operational triage of geocoding failures.
+ */
+function redactAddressForLogging(address: string): string {
+  const parts = address.split(',').map((p) => p.trim()).filter(Boolean);
+  if (parts.length >= 2) return parts.slice(-2).join(', ');
+  return '<redacted>';
+}
+
 export async function calculateDistance(pickupAddress: string, dropoffAddress: string): Promise<number> {
   const GOOGLE_MAPS_API_KEY = process.env.GOOGLE_MAPS_API_KEY;
-  
+
   if (!GOOGLE_MAPS_API_KEY) {
     captureMessage(
       'Google Maps API key not configured. Using estimated distance.',
@@ -189,7 +200,10 @@ export async function calculateDistance(pickupAddress: string, dropoffAddress: s
       {
         action: 'missing_google_maps_key',
         feature: 'distance_calculation',
-        metadata: { pickupAddress, dropoffAddress }
+        metadata: {
+          pickupCityState: redactAddressForLogging(pickupAddress),
+          dropoffCityState: redactAddressForLogging(dropoffAddress),
+        }
       }
     );
     return estimateDistance(pickupAddress, dropoffAddress);
@@ -200,8 +214,12 @@ export async function calculateDistance(pickupAddress: string, dropoffAddress: s
     const destinations = encodeURIComponent(dropoffAddress);
     
     const url = `https://maps.googleapis.com/maps/api/distancematrix/json?origins=${origins}&destinations=${destinations}&units=imperial&key=${GOOGLE_MAPS_API_KEY}`;
-    
-    const response = await fetch(url);
+
+    // 5s timeout: previously this fetch was unbounded, so a hung Google
+    // Maps request would block the partner's order/draft handler until
+    // the platform's request timeout (≥30s on Vercel). Existing catch
+    // block already falls back to estimateDistance() on AbortError.
+    const response = await fetch(url, { signal: AbortSignal.timeout(5000) });
     const data = await response.json();
     
     if (data.status === 'OK' && data.rows[0]?.elements[0]?.status === 'OK') {
@@ -219,8 +237,8 @@ export async function calculateDistance(pickupAddress: string, dropoffAddress: s
           action: 'distance_calculated',
           feature: 'google_maps_api',
           metadata: {
-            pickupAddress,
-            dropoffAddress,
+            pickupCityState: redactAddressForLogging(pickupAddress),
+            dropoffCityState: redactAddressForLogging(dropoffAddress),
             miles: miles.toFixed(2),
             distanceText
           }
@@ -236,8 +254,8 @@ export async function calculateDistance(pickupAddress: string, dropoffAddress: s
           action: 'google_maps_api_error',
           feature: 'distance_calculation',
           metadata: {
-            pickupAddress,
-            dropoffAddress,
+            pickupCityState: redactAddressForLogging(pickupAddress),
+            dropoffCityState: redactAddressForLogging(dropoffAddress),
             apiStatus: data.status,
             errorMessage: data.error_message,
             elementStatus: data.rows[0]?.elements[0]?.status
@@ -251,7 +269,10 @@ export async function calculateDistance(pickupAddress: string, dropoffAddress: s
     captureException(error as Error, {
       action: 'google_maps_api_failure',
       feature: 'distance_calculation',
-      metadata: { pickupAddress, dropoffAddress }
+      metadata: {
+        pickupCityState: redactAddressForLogging(pickupAddress),
+        dropoffCityState: redactAddressForLogging(dropoffAddress),
+      }
     });
     return estimateDistance(pickupAddress, dropoffAddress);
   }

--- a/src/services/caterValleyService.ts
+++ b/src/services/caterValleyService.ts
@@ -1,5 +1,8 @@
 // src/services/caterValleyService.ts
 
+import { signPayload, SIGNATURE_HEADER } from '@/lib/security/hmac';
+import { checkOutboundUrl } from '@/lib/security/ssrf-guard';
+
 // Define allowed status values based on the documentation
 export const ALLOWED_STATUSES = [
     'CONFIRM',
@@ -42,10 +45,10 @@ export async function updateCaterValleyOrderStatus(
     status: OrderStatus
   ): Promise<CaterValleyUpdateResult> {
     const CATER_VALLEY_API_URL =
+      process.env.CATERVALLEY_WEBHOOK_URL ||
       'https://api.catervalley.com/api/operation/order/update-order-status';
-    // Hardcode the partner header as specified in the CaterValley documentation
     const PARTNER_HEADER = 'ready-set';
-  
+
     // Input validation
     if (!orderNumber || typeof orderNumber !== 'string' || orderNumber.trim() === '') {
         return {
@@ -61,24 +64,44 @@ export async function updateCaterValleyOrderStatus(
           error: `Invalid status provided for CaterValley update: ${status}. Must be one of ${ALLOWED_STATUSES.join(', ')}.`,
         };
     }
-  
+
+    const ssrfCheck = checkOutboundUrl(CATER_VALLEY_API_URL);
+    if (!ssrfCheck.ok) {
+      console.error('[CaterValley Service] Outbound URL rejected by SSRF guard:', ssrfCheck.reason);
+      return {
+        success: false,
+        orderFound: false,
+        error: `Refusing to call CaterValley webhook: ${ssrfCheck.reason}`,
+      };
+    }
+
     // Ensure status is always uppercase as expected by the API
     const normalizedStatus = status.toUpperCase() as OrderStatus;
-    
-    
+    const requestBody = JSON.stringify({
+      orderNumber,
+      status: normalizedStatus,
+    });
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      partner: PARTNER_HEADER,
+    };
+
+    // Sign the body with HMAC-SHA256 if a secret is configured. Additive
+    // rollout: CaterValley can ignore this header until they add
+    // verification on their side. Once they're verifying, the header
+    // becomes required and unsigned requests should fail their auth.
+    const outboundSecret = process.env.CATERVALLEY_OUTBOUND_WEBHOOK_SECRET;
+    if (outboundSecret) {
+      headers[SIGNATURE_HEADER] = signPayload(outboundSecret, requestBody);
+    }
+
     try {
       const response = await fetch(CATER_VALLEY_API_URL, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'partner': PARTNER_HEADER, // Crucial header for CaterValley
-        },
-        body: JSON.stringify({ 
-          orderNumber, 
-          status: normalizedStatus 
-        }),
-        // Consider adding a timeout if needed
-        // signal: AbortSignal.timeout(10000) // 10 seconds timeout
+        headers,
+        body: requestBody,
+        signal: AbortSignal.timeout(10000),
       });
   
       // Log raw response details for debugging

--- a/src/services/caterValleyService.ts
+++ b/src/services/caterValleyService.ts
@@ -93,7 +93,7 @@ export async function updateCaterValleyOrderStatus(
     // becomes required and unsigned requests should fail their auth.
     const outboundSecret = process.env.CATERVALLEY_OUTBOUND_WEBHOOK_SECRET;
     if (outboundSecret) {
-      headers[SIGNATURE_HEADER] = signPayload(outboundSecret, requestBody);
+      headers[SIGNATURE_HEADER] = await signPayload(outboundSecret, requestBody);
     }
 
     try {


### PR DESCRIPTION
## Summary

Phase 1 of the partner API production-readiness plan ([plan](../../../../.claude/plans/awesome-now-we-should-vivid-stallman.md)). Closes the OWASP-aligned audit findings on the existing CaterValley integration before we expose it to real partner traffic. CaterCow onboarding (Phase 2 + 3) follows in separate PRs once this lands.

The CaterValley path has been **tested but never run with real partner traffic**, so several findings here are real production bugs we'd hit even without onboarding a second partner — CaterCow just forces the timeline.

## What changed

### P1.1 — Auth & webhook security
- **Timing-safe API key compare** (`auth-utils.ts`): replaced `!==` with `crypto.timingSafeEqual` + length precheck.
- **Inbound HMAC verification** (`update-order-status/route.ts`): the route previously had a TODO admitting auth was missing. Now reads raw body once, verifies HMAC-SHA256 against `CATERVALLEY_INBOUND_WEBHOOK_SECRET`. Gated by `ENFORCE_INBOUND_WEBHOOK_HMAC` flag — log-only by default during rollout, 401 reject when flipped.
- **Outbound HMAC signing** (`caterValleyService.ts`): signs payload with `CATERVALLEY_OUTBOUND_WEBHOOK_SECRET` if set (additive — CaterValley ignores the header until they verify). Adds `x-readyset-signature`, env-driven webhook URL, 10s `AbortSignal.timeout`, and runs every URL through an SSRF guard.
- **SSRF guard** (`src/lib/security/ssrf-guard.ts`): blocks loopback, RFC1918 (10/8, 172.16/12, 192.168/16), link-local (169.254/16), CGNAT (100.64/10), AWS/GCP metadata IPs, plus http-in-production.
- **Debug + catch-all lockdown** (`debug/route.ts`, `[...slug]/route.ts`): both echoed full request headers (incl. `x-api-key`, `partner`) and body in their JSON responses. New `_lib/debug-guard.ts` returns plain 404 in production, redacts sensitive headers in dev.
- **Status route lockdown** (`status/route.ts`): dropped public `apiKeyConfigured` / `webhookUrlConfigured` booleans and the configured webhook URL — fingerprinting vectors. Added `deletedAt: null` filter on the order count.

### P1.2 — Data integrity
- **Atomic order create** (`orders/draft/route.ts`, `orders/update/route.ts`): system user upsert + address upserts + cateringRequest create now run inside `prisma.$transaction`. Previous flow could leave orphan addresses on partial failure. `_lib/{order-utils,address-utils}.ts` helpers accept an optional `PrismaExecutor` so they participate in the caller's transaction.
- **Soft-delete filter** on all order lookups (project convention per CLAUDE.md). Update + confirm 404 on tombstoned orders; draft allows orderCode reuse after a soft-delete.
- **1MB body size limit** (`src/lib/security/body-size-limit.ts`): rejects oversized requests with 413 ahead of auth, so we don't burn cycles authenticating a 100MB body.
- **Race-safe `orderCode` collision**: try/catch on Prisma `P2002` unique-violation around the create/update. Two concurrent partner requests with the same orderCode now resolve as 1×201 + 1×409, not 1×201 + 1×500.

### P1.3 — External call reliability
- **5s Google Maps fetch timeout** (`pricingService.ts`): the Distance Matrix fetch was unbounded — a hung Maps endpoint blocked partner handlers until the platform request timeout. Existing fallback path handles `AbortError` gracefully.

### P1.4 — Observability
- **PII redaction in Sentry payloads** (`pricingService.ts`, `pricing-helper.ts`): five Sentry call sites previously logged full street addresses. Replaced with `pickupCityState` / `dropoffCityState` (city + state only). New `redactAddressForLogging` helper in `pricingService.ts`.

## Tests

- **56 new tests** across new modules:
  - `auth-utils.test.ts` — 8 (constant-time comparison, length-mismatch, env-unset fallback)
  - `hmac.test.ts` — 9 (sign/verify, tamper, malformed hex, Buffer/string parity)
  - `ssrf-guard.test.ts` — 25 (every private range, protocol filtering, prod https enforcement, boundary octets)
  - `body-size-limit.test.ts` — 6 (boundary, overflow, missing/negative/non-numeric headers)
  - `caterValleyService.outbound.test.ts` — 6 (signed body matches `signPayload()`, localhost/metadata/http-in-prod rejected without fetch)
  - `update-order-status-hmac.test.ts` — 8 (no-secret/log-only/enforced modes, tamper detection)
- **Updated existing tests** to reflect new security posture: 9 cases in `debug.test.ts`/`catch-all.test.ts` (sensitive headers redacted, prod returns 404), 4 in `status.test.ts` (no env config leak), 3 hardening cases added to `orders-draft.test.ts` (413, soft-delete reuse, P2002 race).
- **`prisma.$transaction` test shim**: mock now invokes the callback with the same client so `tx.foo.bar()` calls hit the same `jest.fn` as `prisma.foo.bar()`.

**Final state: 195/195 cater-valley + security tests pass. `pnpm typecheck` + `pnpm lint` clean.**

## Rollout plan

Per the plan's locked decisions:

1. **Ship Phase 1 first, independently of Phase 2** — get security + reliability fixes into the live CaterValley path immediately. Multi-partner refactor lands in a follow-up PR.
2. **HMAC additive rollout** — outbound signing ships now (CaterValley ignores until they verify). Inbound enforcement is flag-gated:
   - Deploy with `ENFORCE_INBOUND_WEBHOOK_HMAC=false` and `CATERVALLEY_INBOUND_WEBHOOK_SECRET=<secret>` set. Mismatches log to Sentry but still process.
   - Coordinate with Halil/Ugras at CaterValley to align on the shared secret.
   - Once CaterValley is signing outbound, flip `ENFORCE_INBOUND_WEBHOOK_HMAC=true` to start rejecting unsigned requests.
3. **No DB migration** in this PR. The `ApiPartner` table lands in Phase 2.

## Still pending in Phase 1 (separate follow-ups)

These need infrastructure decisions and are deferred to keep this PR reviewable:

- **P1.2d** — Idempotency-key support (needs Redis client; pending decision on `@upstash/redis` vs existing infra)
- **P1.3b** — Distance memoization within request (small AsyncLocalStorage helper)
- **P1.4b/c** — Structured logger + per-route Sentry transactions (touches every order route)
- **P1.4d** — Per-partner rate limiting (needs Redis)

## Test plan

- [ ] CI passes (typecheck, lint, jest, build)
- [ ] Smoke test on staging with `ENFORCE_INBOUND_WEBHOOK_HMAC=false`:
  - [ ] Send draft with wrong api-key → 401
  - [ ] Send draft with valid key → 201, response includes `orderId`
  - [ ] Send same orderCode twice concurrently → exactly one 201, one 409
  - [ ] Send draft with body >1MB → 413
  - [ ] Block Google Maps connectivity → request completes <6s with fallback distance
  - [ ] Hit `/cater-valley/debug` in production build → 404 with no body echo
  - [ ] Hit `/cater-valley/[unknown-path]` → 404 with available endpoints list, no headers/body echo
  - [ ] Verify status endpoint no longer shows `apiKeyConfigured` / `webhookUrlConfigured`
  - [ ] Outbound webhook to a test endpoint includes valid `x-readyset-signature` header
  - [ ] Inbound `update-order-status` with bad signature → logged to Sentry but request still processes (log-only mode)
- [ ] Confirm CaterValley team has the inbound HMAC secret before flipping `ENFORCE_INBOUND_WEBHOOK_HMAC=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)