### PR TITLE
security(partner-api): use Upstash for idempotency cache + cache fast-path 409s

### DIFF
--- a/src/app/api/cater-valley/orders/draft/route.ts
+++ b/src/app/api/cater-valley/orders/draft/route.ts
@@ -152,13 +152,10 @@ export async function POST(request: NextRequest) {
     });
 
     if (existingOrder && !existingOrder.deletedAt) {
-      return NextResponse.json(
-        {
-          status: 'ERROR',
-          message: `Order with code ${validatedData.orderCode} already exists`,
-        },
-        { status: 409 }
-      );
+      return storeAndReturnResponse(idempotency, 409, {
+        status: 'ERROR',
+        message: `Order with code ${validatedData.orderCode} already exists`,
+      });
     }
 
     // 5. Calculate pricing with distance, bridge toll detection, and validation

--- a/src/app/api/cater-valley/orders/update/route.ts
+++ b/src/app/api/cater-valley/orders/update/route.ts
@@ -196,13 +196,10 @@ export async function POST(request: NextRequest) {
       });
 
       if (duplicateOrder) {
-        return NextResponse.json(
-          {
-            status: 'ERROR',
-            message: `Order with code ${validatedData.orderCode} already exists`,
-          },
-          { status: 409 }
-        );
+        return storeAndReturnResponse(idempotency, 409, {
+          status: 'ERROR',
+          message: `Order with code ${validatedData.orderCode} already exists`,
+        });
       }
     }
 

--- a/src/lib/security/idempotency.ts
+++ b/src/lib/security/idempotency.ts
@@ -15,7 +15,7 @@
 
 import { NextResponse } from 'next/server';
 
-import { getRedisClient } from '@/lib/redis/client';
+import { getRedisClientAsync } from '@/lib/redis/client';
 
 const TTL_SECONDS_DEFAULT = 24 * 60 * 60;
 const HEADER_NAME = 'idempotency-key';
@@ -58,7 +58,7 @@ export async function replayCachedResponse(
 ): Promise<NextResponse | null> {
   if (!ctx.key) return null;
   try {
-    const client = getRedisClient();
+    const client = await getRedisClientAsync();
     const raw = await client.get(buildRedisKey(ctx.partnerSlug, ctx.key));
     if (!raw) return null;
     const cached = raw as CachedResponse;
@@ -90,7 +90,7 @@ export async function storeAndReturnResponse(
   if (ctx.key) {
     try {
       const cached: CachedResponse = { status, body };
-      const client = getRedisClient();
+      const client = await getRedisClientAsync();
       await client.set(buildRedisKey(ctx.partnerSlug, ctx.key), cached, {
         ex: ttlSeconds,
       });


### PR DESCRIPTION
## Summary

Two correctness fixes flagged in the pre-landing review of #391 (now merged into `development`).

### 1. Idempotency cache never used Upstash in production [CRITICAL]

`src/lib/security/idempotency.ts` called the **synchronous** `getRedisClient()`. Per `src/lib/redis/client.ts:113-128`, the sync accessor *always* returns the in-memory fallback and logs a warning when Upstash env vars are set:

> `[redis] sync getRedisClient() called with Upstash configured — caller should use getRedisClientAsync(). Falling back to in-memory.`

Net effect on Vercel: idempotency replays only worked within a single warm function instance. Two retries hitting different instances both created orders. The PR description for #391 ("Upstash Redis... shared across Vercel functions") wasn't actually delivered for the idempotency path.

`rate-limit.ts` was unaffected — `buildUpstashDecider()` instantiates its own `Redis` directly, so rate limits are correctly cross-instance.

**Fix:** swap to `await getRedisClientAsync()` in both `replayCachedResponse` and `storeAndReturnResponse`. Both functions are already `async`, so it's a one-line change at each call site.

### 2. Fast-path 409 not cached for idempotency [INFORMATIONAL]

The "order already exists" 409 from the fast-path duplicate check in `draft` and `update` routes returned `NextResponse.json` directly, bypassing the idempotency cache. The P2002 race-409 path already went through `storeAndReturnResponse`. Behaviorally identical to the partner (both return 409), but inconsistent cache state.

**Fix:** route the fast-path through `storeAndReturnResponse` for symmetry.

## What changed

- `src/lib/security/idempotency.ts` — import + 2 call sites switched to `getRedisClientAsync`
- `src/app/api/cater-valley/orders/draft/route.ts` — fast-path 409 routed through `storeAndReturnResponse`
- `src/app/api/cater-valley/orders/update/route.ts` — same as draft

3 files, +11 / -17.

## Tests

Existing test suite already covers the idempotency replay and the 409 cache paths via the in-memory fallback. After this change those tests still pass — the in-memory client is still the cached client when Upstash env vars are absent (which is the case in CI).

- `pnpm typecheck` ✅
- `pnpm test -- redis idempotency rate-limit orders-draft orders-update` → **62/62 pass**

## Test plan

- [ ] CI passes (typecheck, lint, jest, build)
- [ ] After deploy with `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN` set:
  - [ ] Send draft with `Idempotency-Key: foo` to one Vercel region
  - [ ] Force a different instance (open a second tab / wait for cold start) and send same key
  - [ ] Confirm second response returns `x-idempotent-replay: true` (proves cross-instance share)
  - [ ] Inspect Upstash dashboard for `idem:catervalley:foo` key

## Deferred from #391 review (not in this PR)

- Idempotency-key length cap (Stripe-style 255 char max)
- Rate limit running before replay check (penalizes well-behaved retrying partners)
- Body-fingerprint mismatch detection (current behavior: silent replay on body change)

Each is small enough for a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)