### PR TITLE
fix(driver-tracking): guard against missing deliveryLocation coordinates

### DIFF
--- a/src/components/Driver/DriverTrackingPortal.tsx
+++ b/src/components/Driver/DriverTrackingPortal.tsx
@@ -498,10 +498,18 @@ export default function DriverTrackingPortal({ className }: DriverTrackingPortal
                 </div>
 
                 <div className="text-sm text-muted-foreground space-y-1">
-                  <p className="flex items-center gap-1">
-                    <MapPinIcon className="w-3 h-3" />
-                    {delivery.deliveryLocation.coordinates[1].toFixed(4)}, {delivery.deliveryLocation.coordinates[0].toFixed(4)}
-                  </p>
+                  {(() => {
+                    const coords = delivery.deliveryLocation?.coordinates;
+                    const lng = coords?.[0];
+                    const lat = coords?.[1];
+                    if (typeof lat !== 'number' || typeof lng !== 'number') return null;
+                    return (
+                      <p className="flex items-center gap-1">
+                        <MapPinIcon className="w-3 h-3" />
+                        {lat.toFixed(4)}, {lng.toFixed(4)}
+                      </p>
+                    );
+                  })()}
                   {delivery.estimatedArrival && (
                     <p className="flex items-center gap-1">
                       <ClockIcon className="w-3 h-3" />


### PR DESCRIPTION
## Summary

Fixes Sentry **READY-SET-NEXTJS-1R**: `TypeError: Cannot read properties of undefined (reading '1')` on `/driver/tracking`.

`DriverTrackingPortal.tsx:503` was calling `.toFixed(4)` on `delivery.deliveryLocation.coordinates[1]` without checking whether `coordinates` actually existed. The TS type marks it as required `[number, number]`, but at runtime the API can return active deliveries where `delivery_location_geojson` is null/missing — making `deliveryLocation` (or its `coordinates`) undefined and crashing the App Router error boundary for that user.

## Fix

`src/components/Driver/DriverTrackingPortal.tsx:500-512` — guard the coordinate read with optional chaining and a `typeof === 'number'` check on both lng and lat. When either is missing, the row is omitted instead of crashing the page.

This mirrors the existing guard in `DriverLiveMap.tsx:259` (`.filter((delivery) => delivery.deliveryLocation?.coordinates)`).

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new warnings)
- [ ] Verify `/driver/tracking` loads for a driver with an active delivery missing geojson coordinates (no crash, row simply hidden)
- [ ] Verify deliveries that DO have coordinates still render the lat/lng line correctly

## Sentry

- Issue: READY-SET-NEXTJS-1R
- URL: https://ready-set-19m7m335k-ready-sets-projects.vercel.app/driver/tracking
- Affected user role: driver

🤖 Generated with [Claude Code](https://claude.com/claude-code)