### PR TITLE
fix(auth): catch fire-and-forget token refresh rejections

### DIFF
--- a/src/__tests__/lib/auth/token-refresh-and-session.test.ts
+++ b/src/__tests__/lib/auth/token-refresh-and-session.test.ts
@@ -336,6 +336,45 @@ describe('Token Refresh Service', () => {
       expect(tokenRefreshService.refreshTokenWithRetry).toHaveBeenCalled();
     });
 
+    it('should not leak an unhandled rejection when auto-refresh fails', async () => {
+      // Regression: Sentry READY-SET-NEXTJS-1S — AuthError(REFRESH_FAILED) thrown
+      // from a setTimeout-fired refresh used to surface as an unhandled
+      // promise rejection. The safeRefreshTokenWithRetry wrapper must catch it.
+      const session: Session = {
+        access_token: 'token',
+        refresh_token: 'refresh',
+        expires_at: Math.floor((Date.now() - 1000) / 1000), // Already expired -> immediate path
+        user: { id: 'user-123' } as User,
+      };
+
+      const refreshError = new AuthError(
+        AuthErrorType.REFRESH_FAILED,
+        'Failed to refresh session',
+        'unknown',
+        false,
+      );
+      jest
+        .spyOn(tokenRefreshService, 'refreshTokenWithRetry')
+        .mockRejectedValue(refreshError);
+
+      const unhandledRejections: unknown[] = [];
+      const onUnhandled = (reason: unknown) => unhandledRejections.push(reason);
+      process.on('unhandledRejection', onUnhandled);
+
+      try {
+        tokenRefreshService.startAutoRefresh(session);
+        // Let the immediate refresh promise settle + dynamic import resolve.
+        await jest.advanceTimersByTimeAsync(100);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(tokenRefreshService.refreshTokenWithRetry).toHaveBeenCalled();
+        expect(unhandledRejections).toHaveLength(0);
+      } finally {
+        process.off('unhandledRejection', onUnhandled);
+      }
+    });
+
     it('should stop auto refresh when requested', async () => {
       const session: Session = {
         access_token: 'token',

--- a/src/lib/auth/error-handler.ts
+++ b/src/lib/auth/error-handler.ts
@@ -61,6 +61,31 @@ const RECOVERY_STRATEGIES: ErrorRecoveryStrategy[] = [
     priority: 8,
   },
 
+  // Refresh failure recovery: the refresh_token itself is no good (revoked,
+  // expired, or the post-sign-in race left storage stale). User must re-auth.
+  {
+    canRecover: (error) => error.type === AuthErrorType.REFRESH_FAILED,
+    recover: async (error) => {
+      if (typeof window === 'undefined') return;
+
+      try {
+        const { getSessionManager } = await import('./session-manager');
+        const sessionManager = getSessionManager();
+        await sessionManager.clearSession();
+      } catch (clearError) {
+        authLogger.warn('AuthErrorHandler: clearSession failed during REFRESH_FAILED recovery', clearError);
+      }
+
+      // Avoid a redirect loop if we're already on the sign-in page — covers
+      // the case where a stale refresh fires immediately after the user
+      // lands on sign-in.
+      if (!window.location.pathname.startsWith('/sign-in')) {
+        window.location.replace('/sign-in?error=session_expired');
+      }
+    },
+    priority: 5,
+  },
+
   // Fingerprint mismatch recovery (lowest priority - usually requires user intervention)
   {
     canRecover: (error) => error.type === AuthErrorType.FINGERPRINT_MISMATCH,

--- a/src/lib/auth/token-refresh-service.ts
+++ b/src/lib/auth/token-refresh-service.ts
@@ -109,11 +109,11 @@ export class TokenRefreshService {
       });
 
       this.refreshTimer = setTimeout(() => {
-        this.refreshTokenWithRetry();
+        this.safeRefreshTokenWithRetry('scheduled_expiry');
       }, timeUntilRefresh);
     } else {
       // Token is already close to expiry or expired, refresh immediately
-      this.refreshTokenWithRetry();
+      this.safeRefreshTokenWithRetry('immediate_expiry');
     }
 
     // Start background refresh if enabled
@@ -159,6 +159,36 @@ export class TokenRefreshService {
       clearInterval(this.backgroundRefreshTimer);
       this.backgroundRefreshTimer = null;
     }
+  }
+
+  // Fire-and-forget wrapper around refreshTokenWithRetry that catches any final
+  // rejection and routes it through the central auth error handler. Without this
+  // wrapper, callers that invoke refreshTokenWithRetry() from a setTimeout or
+  // event handler leak the rejection as an unhandled promise rejection.
+  private safeRefreshTokenWithRetry(reason: string): void {
+    this.refreshTokenWithRetry().catch(async (error) => {
+      authLogger.error('TokenRefreshService: Auto-refresh failed, surfacing to error handler', {
+        reason,
+        error: error instanceof Error ? error.message : error,
+      });
+
+      try {
+        const { getAuthErrorHandler } = await import('./error-handler');
+        const handler = getAuthErrorHandler();
+        const authError =
+          error instanceof AuthError
+            ? error
+            : new AuthError(
+                AuthErrorType.REFRESH_FAILED,
+                error instanceof Error ? error.message : 'Auto-refresh failed',
+                'auto_refresh_unhandled',
+                false,
+              );
+        await handler.handleError(authError, { source: 'auto_refresh', reason });
+      } catch (handlerError) {
+        authLogger.error('TokenRefreshService: Error handler itself failed', handlerError);
+      }
+    });
   }
 
   // Refresh token with retry logic


### PR DESCRIPTION
## Summary

Fixes Sentry **READY-SET-NEXTJS-1S** — an unhandled `AuthError: Failed to refresh session` thrown on `/driver/tracking` immediately after sign-in.

**Root cause:** `TokenRefreshService.startAutoRefresh` fires `refreshTokenWithRetry()` from a `setTimeout` and from the immediate-expiry branch without `.catch()`. When `EnhancedSessionManager.performTokenRefresh` throws `AuthError(REFRESH_FAILED)` (because Supabase returns no session/user during the post-sign-in race), the rejection bubbles up through `TokenRefreshQueue.processQueue` with no handler — Sentry catches it via `onunhandledrejection`.

**Secondary issue:** `error-handler.ts` had recovery strategies for `TOKEN_EXPIRED`, `SESSION_EXPIRED`, and `FINGERPRINT_MISMATCH` — but not `REFRESH_FAILED`. So even with the catch in place, there was no policy for "refresh truly failed → sign out and redirect."

## Changes

- `src/lib/auth/token-refresh-service.ts` — new private `safeRefreshTokenWithRetry(reason)` wraps `refreshTokenWithRetry()` with a `.catch()` that delegates to `getAuthErrorHandler()`. Both fire-and-forget callsites in `startAutoRefresh` (lines 112 & 116) now use it.
- `src/lib/auth/error-handler.ts` — added a `REFRESH_FAILED` recovery strategy (priority 5) that clears the session via `EnhancedSessionManager.clearSession()` and redirects to `/sign-in?error=session_expired`. Skips the redirect if `window.location.pathname` already starts with `/sign-in` to avoid a loop during the post-sign-in race that triggered the original Sentry event.
- `src/__tests__/lib/auth/token-refresh-and-session.test.ts` — added a regression test that listens for `process.on('unhandledRejection')` while `startAutoRefresh` fires an immediate refresh against a rejecting `refreshTokenWithRetry`. Will fail if the wrapper is ever removed.

## Verification

- `pnpm test -- src/__tests__/lib/auth` → 85 pass / 2 skipped (pre-existing). New regression test included.
- `pnpm typecheck` → clean.
- `pnpm lint` → clean.

## Out of scope

- The inner `TokenRefreshQueue.processQueue` already had a try/catch that rejects queued promises correctly — the unhandled rejection wasn't originating there. Left untouched to keep the blast radius small.
- The post-sign-in race itself (why `refreshSession()` returns no session/user immediately after sign-in) is not addressed here; this PR ensures the failure mode is *handled* (catch + redirect) rather than *prevented*. Worth a follow-up investigation if it recurs after deploy.

## Test plan

- [ ] Deploy to `development.readysetllc.com`
- [ ] Verify Sentry READY-SET-NEXTJS-1S stops receiving new events
- [ ] Manual: sign in as a driver, land on `/driver/tracking`, confirm no console rejection
- [ ] Manual: simulate stale refresh token (clear cookies mid-session) and confirm redirect to `/sign-in?error=session_expired` instead of stranded UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)