### PR TITLE
chore(qa): sync QA + tasks board mirrors for REA-DRT-07 promotion

### DIFF
--- a/src/data/qa-board.json
+++ b/src/data/qa-board.json
@@ -1,13 +1,13 @@
 {
   "source": "2026-Q2-test-cases.csv",
-  "generated": "2026-05-12",
+  "generated": "2026-05-15",
   "total": 29,
   "counts": {
     "PASS": 7,
     "PARTIAL-FAIL": 1,
-    "FAIL": 8,
+    "FAIL": 9,
     "BLOCKED": 0,
-    "IN-PROGRESS": 2,
+    "IN-PROGRESS": 1,
     "NOT-RUN": 11,
     "SKIPPED": 0,
     "UNKNOWN": 0
@@ -680,7 +680,7 @@
       "key": "REA-DRT-07",
       "summary": "Feature flag combinations",
       "description": "Verify behavior under all four flag combinations (driver + admin × on/off).",
-      "status": "In Process",
+      "status": "DONE",
       "priority": "Medium",
       "assignee": "Fernando Cardenas",
       "labels": [
@@ -693,8 +693,8 @@
         "lib/feature-flags"
       ],
       "folder": "Q2 2026/Driver Tracking",
-      "notes": "",
-      "verdict": "IN-PROGRESS",
+      "notes": "FAIL [BUG][CRITICAL] Supabase Realtime never initializes - browser client has no active session | Module: Tracking / Realtime | Priority: Urgent | Severity: Critical | Reproducible: 100% | Environment: Local dev + Production (per 2026-04-04 QA) | Affected: useRealtimeLocationTracking, useAdminRealtimeTracking, all Realtime-dependent flows | Symptom: zero WebSocket connections to <project>.supabase.co/realtime/v1/websocket despite NEXT_PUBLIC_FF_USE_REALTIME_LOCATION_UPDATES=true and NEXT_PUBLIC_FF_USE_REALTIME_ADMIN_DASHBOARD=true | Root cause hypothesis: supabase.auth.getSession() returns null in browser; localStorage has no sb-<ref>-auth-token key after login; SSR cookie (sb-khvteminrbghoeuqajzm-auth-token) is set server-side but not bridged to the browser supabase-js client | Code path: src/hooks/tracking/useRealtimeLocationTracking.ts:initializeRealtime + src/hooks/tracking/useAdminRealtimeTracking.ts (early return on !session, setConnectionMode('sse')) | Repro manual: pnpm dev, login as admin or driver, open /admin/tracking or /driver/tracking, DevTools Network filter 'ws' → only HMR socket, no Supabase WS | Repro E2E: e2e/drt07-feature-flag-combinations.spec.ts — 3/3 tests fail asserting wsActivity.supabaseWsOpened=true | Related: 2026-04-04 production QA report (vendors stuck in 'Connecting...') | Acceptance criteria: (1) browser localStorage contains sb-<ref>-auth-token with valid JWT after login (2) supabase.auth.getSession() returns active session in browser, not null (3) WS connection to /realtime/v1/websocket opens on /admin/tracking and on /driver/tracking after Enable Location (4) REA-DRT-07 spec passes without code modifications | First investigation target: src/utils/supabase/client.ts vs middleware.ts — verify createBrowserClient cookie config matches SSR client | Reported by: Fer",
+      "verdict": "FAIL",
       "steps": [
         {
           "step": "Both flags true",

--- a/src/data/tasks-board.json
+++ b/src/data/tasks-board.json
@@ -34,7 +34,8 @@
   "sourceLabels": {
     "may4": "May 4",
     "may11": "May 11",
-    "qa": "QA"
+    "qa": "QA",
+    "catercow": "CaterCow"
   },
   "tasks": [
     {
@@ -208,6 +209,19 @@
       "description": "No realtime broadcast emitted from <code>assignDriver/route.ts</code>. Infrastructure exists (<code>broadcastDeliveryAssigned</code> in <code>lib/realtime/channels.ts:475</code>) but has zero callers — admin dashboard requires reload. Secondary: Delivery upsert creates rows with <code>deliveryAddress=''</code> and swallows errors. Promoted from QA fail on test REA-OMG-08."
     },
     {
+      "id": "rea-drt-07-supabase-browser-session-bridge",
+      "status": "open",
+      "title": "REA-DRT-07 — Bridge SSR cookie to browser supabase-js session (Realtime never initializes)",
+      "owner": "emmanuel",
+      "source": "qa",
+      "relatedQa": "REA-DRT-07",
+      "tags": [
+        "bug",
+        "critical"
+      ],
+      "description": "<code>supabase.auth.getSession()</code> returns null in the browser; <code>localStorage</code> has no <code>sb-&lt;ref&gt;-auth-token</code> key after login. SSR cookie is set server-side but not bridged to the browser <code>supabase-js</code> client, so all Realtime-dependent flows (<code>useRealtimeLocationTracking</code>, <code>useAdminRealtimeTracking</code>) early-return and never open a WS connection. <strong>First investigation target:</strong> <code>src/utils/supabase/client.ts</code> vs <code>src/middleware.ts</code> — verify <code>createBrowserClient</code> cookie config matches the SSR client. Related: Sentry READY-SET-NEXTJS-1S (unhandled refresh rejection on <code>/driver/tracking</code> — patched on <code>fix/auth-refresh-unhandled-rejection</code> as graceful failure, but root cause is this bug). Reported by Fer in QA notes; no engineering ticket filed yet."
+    },
+    {
       "id": "test-telnyx-integration",
       "status": "new",
       "title": "Test Telnyx Integration",
@@ -270,6 +284,54 @@
       "owner": "emmanuel",
       "source": "may11",
       "description": "Calculator must handle driver, vendor, and internal calculations simultaneously to eliminate manual data entry errors."
+    },
+    {
+      "id": "catercow-webhook-preconfigure",
+      "status": "progress",
+      "title": "Pre-configure CaterCow staging webhook URL",
+      "owner": "emmanuel",
+      "source": "catercow",
+      "description": "Dispatcher landed (<code>src/lib/services/partnerWebhookService.ts</code>) and wired into the status route; <code>scripts/update-partner-webhook.ts</code> is ready. Still need to run it against the staging DB: <code>PARTNER_SLUG=catercow WEBHOOK_URL=https://api.staging.steerdelivery.com/webhooks/ready_set pnpm tsx scripts/update-partner-webhook.ts</code>. Their endpoint isn't live yet, so dispatcher will log <code>[partner-webhook] misconfigured</code> until <code>webhookSecret</code> is also set."
+    },
+    {
+      "id": "catercow-dispatcher-refactor",
+      "status": "done",
+      "title": "Generalize outbound webhook dispatcher (partner-registry-driven)",
+      "owner": "emmanuel",
+      "source": "catercow",
+      "description": "New <code>src/lib/services/partnerWebhookService.ts</code> reads <code>webhookUrl</code>/<code>webhookSecret</code> from the <code>api_partners</code> row at send time. Wired into <code>/api/catering-requests/[orderId]/status/route.ts</code> for partners not in <code>CARRIER_CONFIGS</code>. HMAC-SHA256 signed per <code>API_CONTRACT.md</code> (<code>x-readyset-signature</code>); 3-attempt retry, no-retry on 4xx; 6 new unit tests; existing 161 cater-valley tests still green."
+    },
+    {
+      "id": "catercow-hmac-secret",
+      "status": "new",
+      "title": "Generate + deliver CaterCow webhook HMAC secret",
+      "owner": "emmanuel",
+      "source": "catercow",
+      "description": "Generate a 256-bit secret (<code>crypto.randomBytes(32)</code>), set <code>webhookSecret</code> on the staging row, deliver to CaterCow via 1Password share link (7-day expiry). Trigger: their webhook endpoint becomes reachable."
+    },
+    {
+      "id": "catercow-steerdelivery-domain-check",
+      "status": "new",
+      "title": "Confirm CaterCow ↔ steerdelivery.com relationship with Gary",
+      "owner": "emmanuel",
+      "source": "catercow",
+      "description": "Nate's webhook URL is on <code>steerdelivery.com</code>, not <code>catercow.com</code>. Verify this is a known parent/shared-infra relationship before exchanging production HMAC secrets. Quick Slack to Gary should resolve."
+    },
+    {
+      "id": "catercow-get-orders-scope",
+      "status": "open",
+      "title": "Scope GET /orders/{id} for partner API v1.x",
+      "owner": "emmanuel",
+      "source": "catercow",
+      "description": "Pre-scoped in <code>docs/catercow/IMPLEMENTATION_PLAN.md</code> Phase 4.1 (~half day). Reads from <code>catering_requests</code> filtered by <code>brokerage = partner.displayName</code>, returns status + last 10 lifecycle events. Pull forward only if CaterCow flags as a go-live blocker."
+    },
+    {
+      "id": "catercow-openapi-export",
+      "status": "open",
+      "title": "OpenAPI 3.1 export from Zod schemas",
+      "owner": "emmanuel",
+      "source": "catercow",
+      "description": "Pre-scoped in <code>docs/catercow/IMPLEMENTATION_PLAN.md</code> Phase 4.2 (~half day). Generate from existing Zod schemas in <code>src/app/api/partners/orders/*/route.ts</code> using <code>zod-to-openapi</code>; output <code>docs/catercow/openapi.yaml</code> + a <code>pnpm openapi:partners</code> script. Defer until CaterCow flags it as needed."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Regenerates `src/data/qa-board.json` and `src/data/tasks-board.json` from upstream workspace sources after a fresh Q2 QA re-export.

**What changed in the QA export:** REA-DRT-07 (Feature flag combinations) flipped from `In Process` → `DONE` with a `[BUG][CRITICAL]` note from Fer. To avoid misclassification by `build-qa-board.mjs:verdictOf()` (which keys on the leading word of `Notes` and would otherwise have fallen through to `NOT-RUN`), the Notes field was prefixed with `FAIL` upstream in `docs/ready-set/qa/2026-Q2-test-cases.csv`. QA board now shows **9 Fail** (up from 8).

**Task added** to `meetings/shared/tasks-board.json` per the workspace QA-fail promotion convention:
- `id`: `rea-drt-07-supabase-browser-session-bridge`
- `status`: `open`
- `relatedQa`: `REA-DRT-07`
- `tags`: `["bug", "critical"]`
- `owner`: `emmanuel`

Tasks board now shows **32 tasks** (13 open).

## Why it matters

REA-DRT-07 is the **root cause** of Sentry READY-SET-NEXTJS-1S — `supabase.auth.getSession()` returns null in the browser because `localStorage` has no `sb-<ref>-auth-token` key after login. The SSR cookie is set server-side but not bridged to the browser supabase-js client, so all Realtime-dependent flows (`useRealtimeLocationTracking`, `useAdminRealtimeTracking`) early-return and never open a WS connection.

The graceful-failure patch for the Sentry symptom is on **PR #404** (`fix/auth-refresh-unhandled-rejection`). That PR catches the unhandled rejection and routes the user back to `/sign-in?error=session_expired`. **This** task tracks the underlying fix: bridge the SSR cookie into the browser supabase-js client so the session actually exists where it's needed. First investigation target per Fer: `src/utils/supabase/client.ts` vs `src/middleware.ts` (verify `createBrowserClient` cookie config matches the SSR client).

## Out of scope

- The actual auth fix for REA-DRT-07 — this PR just registers the task and corrects the QA verdict.
- PR #404 lands independently and can merge before or after this one; they don't conflict.

## Test plan

- [ ] Visual: open `/admin/qa-board` after deploy, confirm REA-DRT-07 row shows verdict **Fail**
- [ ] Visual: open `/admin/tasks-board` after deploy, confirm new "REA-DRT-07 — Bridge SSR cookie..." task in Open column with bug+critical tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)