### PR TITLE
chore(internal-boards): sync tasks-board mirror to 2026-05-19 state

### DIFF
--- a/src/data/tasks-board.json
+++ b/src/data/tasks-board.json
@@ -401,6 +401,20 @@
       "owner": "emmanuel",
       "source": "may19",
       "description": "First version of the ordering system is functional on the testing site (local mode). Gary deferred today's demo to focus the Christino 2:00 meeting on financials; demo to land next week."
+    },
+    {
+      "id": "rea-367-realtime-channel-off-cleanup",
+      "status": "open",
+      "title": "REA-367 — Realtime <code>channel.off()</code> cleanup throws (channel closes ~1ms after subscribe)",
+      "owner": "emmanuel",
+      "source": "qa",
+      "sourceRef": "REA-367",
+      "relatedQa": "REA-DRT-05",
+      "tags": [
+        "bug",
+        "critical"
+      ],
+      "description": "<code>RealtimeChannelManager.off()</code> (<code>src/lib/realtime/channels.ts:168-173</code>) calls <code>this.channel.off('broadcast', { event }, listener)</code>, but the Supabase <code>RealtimeChannel</code> has no runtime <code>.off()</code> — that's a Phoenix Channels method present only via a <code>.d.ts</code> type augmentation. So cleanup throws <code>TypeError: this.channel.off is not a function</code>; the <code>catch</code> only swallows 'closed' / 'not found' / 'already removed' messages, so it logs a WARN and the channel tears down — the admin <code>driver-locations</code> channel reaches <code>subscribed</code> then closes ~1ms later. <strong>Fix:</strong> drop the per-event <code>off()</code> path and tear down via <code>client.removeChannel(channel)</code> / <code>channel.unsubscribe()</code> (supabase-js v2 has no per-callback removal). Confirmed live during REA-DRT-07 verification on 2026-05-20 (channel <code>subscribed</code> → cleanup TypeError → <code>closed</code>). Blocks DRT-06+. Promoted from QA fail <strong>REA-DRT-05</strong> (sub-step DT5-01, Critical)."
     }
   ]
 }

--- a/src/data/tasks-board.json
+++ b/src/data/tasks-board.json
@@ -404,7 +404,7 @@
     },
     {
       "id": "rea-367-realtime-channel-off-cleanup",
-      "status": "open",
+      "status": "progress",
       "title": "REA-367 — Realtime <code>channel.off()</code> cleanup throws (channel closes ~1ms after subscribe)",
       "owner": "emmanuel",
       "source": "qa",
@@ -414,7 +414,20 @@
         "bug",
         "critical"
       ],
-      "description": "<code>RealtimeChannelManager.off()</code> (<code>src/lib/realtime/channels.ts:168-173</code>) calls <code>this.channel.off('broadcast', { event }, listener)</code>, but the Supabase <code>RealtimeChannel</code> has no runtime <code>.off()</code> — that's a Phoenix Channels method present only via a <code>.d.ts</code> type augmentation. So cleanup throws <code>TypeError: this.channel.off is not a function</code>; the <code>catch</code> only swallows 'closed' / 'not found' / 'already removed' messages, so it logs a WARN and the channel tears down — the admin <code>driver-locations</code> channel reaches <code>subscribed</code> then closes ~1ms later. <strong>Fix:</strong> drop the per-event <code>off()</code> path and tear down via <code>client.removeChannel(channel)</code> / <code>channel.unsubscribe()</code> (supabase-js v2 has no per-callback removal). Confirmed live during REA-DRT-07 verification on 2026-05-20 (channel <code>subscribed</code> → cleanup TypeError → <code>closed</code>). Blocks DRT-06+. Promoted from QA fail <strong>REA-DRT-05</strong> (sub-step DT5-01, Critical)."
+      "description": "<code>RealtimeChannelManager.off()</code> (<code>src/lib/realtime/channels.ts:168-173</code>) calls <code>this.channel.off('broadcast', { event }, listener)</code>, but the Supabase <code>RealtimeChannel</code> has no runtime <code>.off()</code> — that's a Phoenix Channels method present only via a <code>.d.ts</code> type augmentation. So cleanup throws <code>TypeError: this.channel.off is not a function</code>; the <code>catch</code> only swallows 'closed' / 'not found' / 'already removed' messages, so it logs a WARN and the channel tears down — the admin <code>driver-locations</code> channel reaches <code>subscribed</code> then closes ~1ms later. <strong>Fix:</strong> drop the per-event <code>off()</code> path and tear down via <code>client.removeChannel(channel)</code> / <code>channel.unsubscribe()</code> (supabase-js v2 has no per-callback removal). Confirmed live during REA-DRT-07 verification on 2026-05-20 (channel <code>subscribed</code> → cleanup TypeError → <code>closed</code>). Blocks DRT-06+. Promoted from QA fail <strong>REA-DRT-05</strong> (sub-step DT5-01, Critical). <strong>In progress:</strong> fixed in PR #410 (stable broadcast dispatcher; removed the phantom <code>channel.off()</code> + its <code>.d.ts</code> augmentation; 38 tests). The TypeError + cleanup WARN are verified gone. The remaining subscribe→close (StrictMode) is split to <code>rea-367b-realtime-strictmode-resubscribe</code>."
+    },
+    {
+      "id": "rea-367b-realtime-strictmode-resubscribe",
+      "status": "open",
+      "title": "Realtime channel closes after subscribe under React StrictMode (no re-subscribe)",
+      "owner": "emmanuel",
+      "source": "qa",
+      "sourceRef": "REA-367",
+      "relatedQa": "REA-DRT-05",
+      "tags": [
+        "bug"
+      ],
+      "description": "Split from REA-367. After the <code>channel.off</code> fix (PR #410), the admin <code>driver-locations</code> channel still reaches <code>subscribed</code> then closes ~1ms later in dev and does not re-subscribe. Root cause is a React <strong>StrictMode</strong> double-invoke race in <code>useAdminRealtimeTracking</code> (<code>src/hooks/tracking/useAdminRealtimeTracking.ts:512-534</code>): mount 1's deferred <code>.then</code> cleanup (lines 518-523) calls <code>removeChannel('driver-locations')</code> on the channel mount 2 established (the RealtimeClient dedups by channel name), tearing it down with no re-subscribe. StrictMode double-invoke is <strong>dev-only</strong>, so production single-mount is unaffected — but it blocks dev/QA (DRT-06+). <strong>Fix direction:</strong> ref-count or guard the shared channel so a stale mount's cleanup can't remove a channel a live mount owns (or key channels per-subscriber). Verify on <code>development.readysetllc.com</code> (prod build, no StrictMode double-invoke) after #410 merges. Found during #410 verification on 2026-05-20."
     }
   ]
 }

--- a/src/data/tasks-board.json
+++ b/src/data/tasks-board.json
@@ -1,12 +1,13 @@
 {
   "title": "Ready Set — Tasks Board",
-  "subtitle": "Action items from the Dev Team Meetings on May 4, 2026 and May 11, 2026 — status as of May 11.",
-  "generated": "2026-05-11",
+  "subtitle": "Action items from the Dev Team Meetings on May 4, May 11, and May 19, 2026 — status as of May 19.",
+  "generated": "2026-05-19",
   "sources": [
     "meetings/shared/2026-05-04-dev-team-meeting.md",
     "meetings/shared/2026-05-11-dev-team-meeting.md",
     "meetings/shared/2026-05-11-may4-action-item-review.md",
-    "meetings/shared/2026-05-11-weekly-recap.md"
+    "meetings/shared/2026-05-11-weekly-recap.md",
+    "meetings/shared/2026-05-19-dev-team-meeting.md"
   ],
   "columns": [
     {
@@ -23,7 +24,7 @@
     },
     {
       "key": "new",
-      "title": "★ New — May 11"
+      "title": "★ New — May 19"
     }
   ],
   "owners": {
@@ -34,6 +35,7 @@
   "sourceLabels": {
     "may4": "May 4",
     "may11": "May 11",
+    "may19": "May 19",
     "qa": "QA",
     "catercow": "CaterCow"
   },
@@ -219,7 +221,7 @@
         "bug",
         "critical"
       ],
-      "description": "<code>supabase.auth.getSession()</code> returns null in the browser; <code>localStorage</code> has no <code>sb-&lt;ref&gt;-auth-token</code> key after login. SSR cookie is set server-side but not bridged to the browser <code>supabase-js</code> client, so all Realtime-dependent flows (<code>useRealtimeLocationTracking</code>, <code>useAdminRealtimeTracking</code>) early-return and never open a WS connection. <strong>First investigation target:</strong> <code>src/utils/supabase/client.ts</code> vs <code>src/middleware.ts</code> — verify <code>createBrowserClient</code> cookie config matches the SSR client. Related: Sentry READY-SET-NEXTJS-1S (unhandled refresh rejection on <code>/driver/tracking</code> — patched on <code>fix/auth-refresh-unhandled-rejection</code> as graceful failure, but root cause is this bug). Reported by Fer in QA notes; no engineering ticket filed yet."
+      "description": "<strong>Root cause (investigated 2026-05-19):</strong> server-side cookie defaults force <code>httpOnly: true</code> on every cookie they write — including the <code>sb-&lt;ref&gt;-auth-token</code> chunks. <code>src/utils/supabase/server.ts:10-16</code> and <code>src/utils/supabase/middleware.ts:6-12</code> both define <code>{ httpOnly: true, ...options }</code> defaults, and <code>@supabase/ssr</code> doesn't override <code>httpOnly</code>, so the auth cookies land HttpOnly. The browser supabase-js client (<code>src/utils/supabase/client.ts:19-28</code>) reads cookies via <code>document.cookie</code>, which by spec cannot see HttpOnly cookies — so <code>getSession()</code> returns null, Realtime channels never authenticate, and <code>TokenRefreshService</code> throws <code>REFRESH_FAILED</code> (the symptom #404 patched as graceful failure). Regression introduced in commit <code>f49f6ec5</code> (2026-01-07 mobile-Safari ITP fix); the <code>sameSite: 'lax'</code> + request+response sync changes in that commit were correct, only <code>httpOnly: true</code> was wrong. <strong>Fix:</strong> drop <code>httpOnly: true</code> from <code>getDefaultCookieOptions</code> (server.ts) and <code>getCookieOptions</code> (middleware.ts); auth cookies must be JS-readable for the <code>@supabase/ssr</code> SSR↔browser bridge. ~2-line change in 2 files. Add a browser <code>getSession()</code> smoke test in <code>src/lib/auth/__tests__/token-refresh-and-session.test.ts</code> that fails if auth cookies are written HttpOnly. <strong>Tradeoff:</strong> XSS-exfiltrable auth tokens in principle; mitigated by existing CSP + dompurify + Supabase's short-lived JWT + refresh-token rotation. <strong>Keep #404 patch in place</strong> — graceful sign-in redirect on legitimate session expiry is still correct behavior. <strong>Out of scope:</strong> Realtime reconnect handler (see <code>docs/architecture/REMEDIATION_PLAN.md</code>). See <code>docs/JOURNAL.md</code> 2026-05-19 for full trace."
     },
     {
       "id": "test-telnyx-integration",
@@ -255,11 +257,11 @@
     },
     {
       "id": "update-hours-sheet",
-      "status": "new",
+      "status": "done",
       "title": "Update Hours Sheet (previous weeks)",
       "owner": "emmanuel",
       "source": "may11",
-      "description": "Record the work duration from the previous weeks into the tracking document."
+      "description": "Sheet updated with the latest tracked hours; Emmanuel confirmed in the May 19 meeting. Gary will review tonight (see <code>gary-review-hours-file</code>)."
     },
     {
       "id": "contact-james-trial",
@@ -332,6 +334,73 @@
       "owner": "emmanuel",
       "source": "catercow",
       "description": "Pre-scoped in <code>docs/catercow/IMPLEMENTATION_PLAN.md</code> Phase 4.2 (~half day). Generate from existing Zod schemas in <code>src/app/api/partners/orders/*/route.ts</code> using <code>zod-to-openapi</code>; output <code>docs/catercow/openapi.yaml</code> + a <code>pnpm openapi:partners</code> script. Defer until CaterCow flags it as needed."
+    },
+    {
+      "id": "fernando-email-seo-updates",
+      "status": "new",
+      "title": "Email SEO updates → sync with Caleb",
+      "owner": "fernando",
+      "source": "may19",
+      "description": "Complete the email SEO modifications Gary requested two weeks ago, then sync with Caleb for final verification."
+    },
+    {
+      "id": "fernando-redesign-address-manager",
+      "status": "new",
+      "title": "Redesign address manager — 3 proposals",
+      "owner": "fernando",
+      "source": "may19",
+      "description": "Current UI is confusing for selecting or adding addresses during new catering / on-demand orders. Develop 3 design proposals and review with Iman to pick the one that fits current architecture."
+    },
+    {
+      "id": "push-jitter-dev-code",
+      "status": "new",
+      "title": "Push Jitter integration code to <code>development</code>",
+      "owner": "emmanuel",
+      "source": "may19",
+      "description": "Push current local testing code for the Jitter integration to <code>development</code> so it can be verified in the staging environment. Endpoints (draft / update / confirm) already shared with Nate; waiting on partner-side feedback."
+    },
+    {
+      "id": "driver-integration-realworld-test",
+      "status": "new",
+      "title": "Real-world driver integration test (Thursday 2026-05-21)",
+      "owner": "emmanuel",
+      "source": "may19",
+      "tags": [
+        "critical"
+      ],
+      "description": "Real-world test with Gary + Mark on Thursday 2026-05-21. Monitor logs, identify + resolve errors. Co-owners: Fernando (testing), Gary (field). First step of the 3-week phased rollout (2–3 drivers at a time) leading to the July Cool Fire sunset."
+    },
+    {
+      "id": "gary-review-hours-file",
+      "status": "new",
+      "title": "Review Google hours file tonight",
+      "owner": "gary",
+      "source": "may19",
+      "description": "Review the updated hours sheet tonight; contact Emmanuel with any questions before the next scheduled meeting."
+    },
+    {
+      "id": "vendor-multi-pickup-support",
+      "status": "new",
+      "title": "Vendor multi-pickup-location support",
+      "owner": "emmanuel",
+      "source": "may19",
+      "description": "Implement multiple pickup locations per vendor. Test with Fresh (3 locations). Fresh is lenient on expectations since the company uses the product themselves."
+    },
+    {
+      "id": "fernando-ux-report-fixes",
+      "status": "progress",
+      "title": "Address Fernando's UX report",
+      "owner": "emmanuel",
+      "source": "may19",
+      "description": "Triage + ship fixes from the UX report Fernando provided. In progress per Emmanuel's May 19 update."
+    },
+    {
+      "id": "christino-demo-prep",
+      "status": "open",
+      "title": "Prepare Christino demo endpoint (deferred to next week)",
+      "owner": "emmanuel",
+      "source": "may19",
+      "description": "First version of the ordering system is functional on the testing site (local mode). Gary deferred today's demo to focus the Christino 2:00 meeting on financials; demo to land next week."
     }
   ]
 }


### PR DESCRIPTION
## What

Regenerates the in-app tasks-board mirror (`src/data/tasks-board.json`, imported by `/admin/tasks-board`) from the workspace source via `meetings/shared/build-tasks-board.mjs`.

Two changes, both generated (not hand-edited):

### 1. Land the dangling May-19 board state
The mirror was sitting uncommitted in the working tree — the only git-tracked record of the May 19 board. Brings it up to the **2026-05-19** dev-team meeting:
- Subtitle / columns / sources May 11 → **May 19**; new `may19` source label
- **REA-DRT-07** description replaced with the full root-cause writeup (the `httpOnly: true` regression)
- `update-hours-sheet` flipped **new → done**
- 7 new May 19 tasks (Jitter push, Thursday driver test `[critical]`, vendor multi-pickup, Fernando email-SEO + address-manager, Gary hours review, Christino demo prep, Fernando UX report)

### 2. Promote REA-367 (Realtime `channel.off` cleanup bug) — added 2026-05-20
QA-fail→task promotion of **REA-DRT-05** (sub-step DT5-01, Critical), bug **REA-367**. Root cause confirmed live during the REA-DRT-07 verification (#409): `RealtimeChannelManager.off()` (`src/lib/realtime/channels.ts:168-173`) calls `this.channel.off(...)`, but supabase-js v2 `RealtimeChannel` has no runtime `.off()` (Phoenix method, only present via a `.d.ts` augmentation). Cleanup throws `TypeError: this.channel.off is not a function`; the admin `driver-locations` channel reaches `subscribed` then closes ~1ms later. Task carries `source=qa`, `sourceRef=REA-367`, `relatedQa=REA-DRT-05`, `tags=[bug,critical]`.

## Notes

- Board totals: **41 tasks** (6 done, 5 progress, 15 open, 15 new).
- Verified byte-identical to a fresh `build-tasks-board.mjs` run against the current source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)