### PR TITLE
fix(auth): bridge SSR cookie to browser supabase-js session (REA-DRT-07)

### DIFF
--- a/src/__tests__/utils/supabase/cookie-options.test.ts
+++ b/src/__tests__/utils/supabase/cookie-options.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Regression guard for REA-DRT-07.
+ *
+ * Supabase auth cookies (`sb-<ref>-auth-token` chunks) are written through the
+ * cookie-option factories in `src/utils/supabase/{server,middleware}.ts`. The
+ * browser supabase-js client reads the session via `document.cookie`, which by
+ * spec cannot see HttpOnly cookies. If either factory ever sets
+ * `httpOnly: true` again, `getSession()` returns null in the browser, all
+ * Supabase Realtime flows silently fail to authenticate, and the token-refresh
+ * service throws REFRESH_FAILED (Sentry READY-SET-NEXTJS-1S).
+ *
+ * These tests fail loudly if anyone re-introduces `httpOnly: true`.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+
+// `@/utils/supabase/server` is globally auto-mocked in jest.setup.ts (for query
+// builders), which strips this pure helper. Pull the real implementations so we
+// assert against shipped behavior, not the mock. `getCookieOptions` is not
+// globally mocked, but we requireActual both for symmetry + future-proofing.
+const { getDefaultCookieOptions } = jest.requireActual<
+  typeof import('@/utils/supabase/server')
+>('@/utils/supabase/server');
+const { getCookieOptions } = jest.requireActual<
+  typeof import('@/utils/supabase/middleware')
+>('@/utils/supabase/middleware');
+
+describe('Supabase auth cookie options (REA-DRT-07 regression guard)', () => {
+  describe('server.ts getDefaultCookieOptions', () => {
+    it('must NOT mark cookies httpOnly — auth cookies have to be JS-readable', () => {
+      expect(getDefaultCookieOptions().httpOnly).toBeFalsy();
+    });
+
+    it('must not let caller options re-introduce httpOnly silently', () => {
+      // Even when @supabase/ssr passes through options, the default merge must
+      // not be the thing that stamps httpOnly. (supabase/ssr does not set it.)
+      const opts = getDefaultCookieOptions({ maxAge: 0 });
+      expect(opts.httpOnly).toBeFalsy();
+    });
+
+    it('preserves the other Safari/ITP-friendly hardening', () => {
+      const opts = getDefaultCookieOptions();
+      expect(opts.path).toBe('/');
+      expect(opts.sameSite).toBe('lax');
+      // secure follows NODE_ENV; just assert the key is computed, not dropped.
+      expect(opts).toHaveProperty('secure');
+    });
+
+    it('still lets callers override individual fields', () => {
+      const opts = getDefaultCookieOptions({ path: '/scoped', maxAge: 60 });
+      expect(opts.path).toBe('/scoped');
+      expect(opts.maxAge).toBe(60);
+    });
+  });
+
+  describe('middleware.ts getCookieOptions', () => {
+    it('must NOT mark cookies httpOnly — auth cookies have to be JS-readable', () => {
+      expect(getCookieOptions().httpOnly).toBeFalsy();
+    });
+
+    it('must not let caller options re-introduce httpOnly silently', () => {
+      const opts = getCookieOptions({ maxAge: 0 });
+      expect(opts.httpOnly).toBeFalsy();
+    });
+
+    it('preserves the other Safari/ITP-friendly hardening', () => {
+      const opts = getCookieOptions();
+      expect(opts.path).toBe('/');
+      expect(opts.sameSite).toBe('lax');
+      expect(opts).toHaveProperty('secure');
+    });
+  });
+});

--- a/src/utils/supabase/middleware.ts
+++ b/src/utils/supabase/middleware.ts
@@ -2,12 +2,22 @@
 import { createServerClient } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
 
-// Cookie options optimized for mobile Safari compatibility (ITP)
-const getCookieOptions = (options?: Record<string, unknown>) => ({
+// Cookie options optimized for mobile Safari compatibility (ITP).
+//
+// ⚠️ DO NOT add `httpOnly: true` here. These options are applied to every
+// cookie @supabase/ssr writes during the middleware session refresh, including
+// the `sb-<ref>-auth-token` chunks. The browser supabase-js client
+// (src/utils/supabase/client.ts) reads the session via `document.cookie`, which
+// by spec cannot see HttpOnly cookies — so an HttpOnly auth cookie makes
+// `getSession()` return null in the browser, breaks all Supabase Realtime
+// flows, and surfaces as REFRESH_FAILED (Sentry READY-SET-NEXTJS-1S).
+// Regression history: REA-DRT-07 (httpOnly was wrongly added in f49f6ec5).
+// The XSS tradeoff is accepted and mitigated by CSP + short-lived JWTs +
+// refresh-token rotation.
+export const getCookieOptions = (options?: Record<string, unknown>) => ({
   path: '/',
   sameSite: 'lax' as const, // 'lax' is more compatible with mobile Safari than 'strict'
   secure: process.env.NODE_ENV === 'production',
-  httpOnly: true,
   ...options,
 })
 

--- a/src/utils/supabase/server.ts
+++ b/src/utils/supabase/server.ts
@@ -6,12 +6,21 @@ import { parseCookies, setCookie } from 'nookies'
 import { cookies } from 'next/headers'
 import { type Database } from '@/types/supabase'
 
-// Cookie options optimized for mobile Safari compatibility (ITP)
-const getDefaultCookieOptions = (options?: CookieOptions): CookieOptions => ({
+// Cookie options optimized for mobile Safari compatibility (ITP).
+//
+// ⚠️ DO NOT add `httpOnly: true` here. These options are applied to every
+// cookie @supabase/ssr writes, including the `sb-<ref>-auth-token` chunks.
+// The browser supabase-js client (src/utils/supabase/client.ts) reads the
+// session via `document.cookie`, which by spec cannot see HttpOnly cookies —
+// so an HttpOnly auth cookie makes `getSession()` return null in the browser,
+// breaks all Supabase Realtime flows, and surfaces as REFRESH_FAILED
+// (Sentry READY-SET-NEXTJS-1S). Regression history: REA-DRT-07 (httpOnly was
+// wrongly added in f49f6ec5). The XSS tradeoff is accepted and mitigated by
+// CSP + short-lived JWTs + refresh-token rotation.
+export const getDefaultCookieOptions = (options?: CookieOptions): CookieOptions => ({
   path: '/',
   sameSite: 'lax', // 'lax' is more compatible with mobile Safari than 'strict'
   secure: process.env.NODE_ENV === 'production',
-  httpOnly: true,
   ...options,
 })
 


### PR DESCRIPTION
## Problem

`supabase.auth.getSession()` returns `null` in the browser; all Supabase Realtime flows (`useRealtimeLocationTracking`, `useAdminRealtimeTracking`) early-return and never open a WebSocket, and `TokenRefreshService` throws `REFRESH_FAILED` (Sentry **READY-SET-NEXTJS-1S**, patched as graceful failure in #404).

## Root cause

The cookie-option factories in `src/utils/supabase/server.ts` and `src/utils/supabase/middleware.ts` stamped `httpOnly: true` on **every** cookie `@supabase/ssr` writes — including the `sb-<ref>-auth-token` chunks. The browser supabase-js client (`src/utils/supabase/client.ts`) reads the session via `document.cookie`, which **by spec cannot see HttpOnly cookies**. So after any server-side login or middleware refresh, the auth cookie became invisible to the browser client → no session → no Realtime → refresh failure.

Regression introduced in `f49f6ec5` (2026-01-07 mobile-Safari ITP fix). The `sameSite: 'lax'` + request/response cookie-sync changes from that commit were correct; only `httpOnly: true` was wrong.

## Fix

Remove `httpOnly: true` from `getDefaultCookieOptions` (server.ts) and `getCookieOptions` (middleware.ts) — auth cookies must be JS-readable for the `@supabase/ssr` SSR↔browser bridge. Both factories are now exported and carry a loud comment so the flag doesn't come back.

## Tradeoff

Auth tokens become XSS-exfiltrable in principle. Mitigated by existing CSP + dompurify sanitization + Supabase short-lived JWTs + refresh-token rotation. This is the standard `@supabase/ssr` posture (the library expects JS-readable auth cookies). The intentionally-HttpOnly app cookie `user-session-data` in `login.ts` is a **separate** cookie and is left untouched.

## Tests

- New `src/__tests__/utils/supabase/cookie-options.test.ts` (7 cases) asserts neither factory sets `httpOnly` — **verified it fails if `httpOnly` is reintroduced**.
- Full auth/login/session suites green: 283 passed / 3 skipped across 11 suites.
- `pnpm typecheck` clean.

## Notes

- **Keep #404's patch in place** — graceful sign-in redirect on legitimate session expiry is still correct.
- Out of scope: Realtime reconnect/dedupe handler (tracked separately in `docs/architecture/REMEDIATION_PLAN.md` #3).
- Worth a manual verify on `development.readysetllc.com` after deploy: sign in, confirm `getSession()` is non-null in the browser and `/admin/tracking` opens a WS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)