### PR TITLE
revert(home): restore pre-M1 landing (no global nav + "How can we help?") pending approval

### DIFF
--- a/src/components/Clients/ClientLayout.tsx
+++ b/src/components/Clients/ClientLayout.tsx
@@ -53,6 +53,7 @@ export default function ClientLayout({
       <ToasterContext />
       {!isBackendAdminRoute &&
         !isStudioRoute &&
+        !isHomePage &&
         !isProfilePage &&
         !isDriverRoute && <Header key={headerKey} />}
       <main className="flex-grow">{children}</main>

--- a/src/components/Hero/index.tsx
+++ b/src/components/Hero/index.tsx
@@ -25,7 +25,6 @@ type MotionDivProps = Omit<React.HTMLProps<HTMLDivElement>, keyof MotionProps> &
 // Custom motion components
 const MotionDiv: React.FC<MotionDivProps> = motion("div");
 const MotionHeader: React.FC<MotionDivProps> = motion("header");
-const MotionH1: React.FC<MotionDivProps> = motion("h1");
 const MotionHeading: React.FC<MotionDivProps> = motion("h2");
 
 const ButtonLink: React.FC<ButtonLinkProps> = ({
@@ -90,16 +89,16 @@ const Hero: React.FC = () => {
     <section className="relative p-4">
       {" "}
       {/* Removed min-h-screen */}
-      {/* Hidden SEO content (supplementary; document H1 is the visible one below) */}
+      {/* Hidden SEO content */}
       <div
         className="sr-only"
         role="complementary"
         aria-label="Company Overview"
       >
-        <h2>
+        <h1>
           Ready Set Group LLC - Bay Area&apos;s Premier Business Solutions
           Provider
-        </h2>
+        </h1>
         <p>
           Ready Set Group LLC, founded in 2019, has established itself as a
           cornerstone of Silicon Valley&apos;s business infrastructure. Our
@@ -170,12 +169,6 @@ const Hero: React.FC = () => {
           quality={100}
         />
       </div>
-      {/* Top-edge scrim: keeps the white global Header readable against the
-          yellow hero. Pointer-events disabled so it doesn't intercept clicks. */}
-      <div
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-x-0 top-0 z-10 h-32 bg-gradient-to-b from-black/45 via-black/15 to-transparent sm:h-40"
-      />
       {/* Changed h-screen to pt-16 (or higher as needed) and added padding-bottom */}
       <div className="flex flex-col items-center pb-16 pt-16 sm:pb-24 sm:pt-20 md:pt-24 lg:pt-20">
         <MotionHeader
@@ -202,36 +195,14 @@ const Hero: React.FC = () => {
             </div>
           </MotionDiv>
 
-          <MotionH1
-            initial={{ opacity: 0, y: 12 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.6, duration: 0.5 }}
-            className="mt-4 max-w-3xl text-balance text-center text-3xl font-extrabold text-white drop-shadow-lg sm:mt-6 sm:text-4xl md:text-5xl lg:text-6xl"
-          >
-            Same-day catering delivery for Bay Area enterprises.
-          </MotionH1>
-          <MotionDiv
+          <MotionHeading
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
-            transition={{ delay: 0.8, duration: 0.5 }}
-            className="mt-4 max-w-2xl text-balance text-center text-base text-white/90 drop-shadow sm:text-lg md:text-xl"
+            transition={{ delay: 0.7, duration: 0.5 }}
+            className="mb-8 mt-4 text-balance text-xl font-bold text-white drop-shadow-lg dark:text-white sm:mb-12 sm:mt-6 sm:text-2xl md:mb-16 md:text-3xl lg:text-4xl"
           >
-            Trusted by Apple, Google, and Facebook since 2019. Plus virtual
-            assistants who actually free up your week.
-          </MotionDiv>
-          <MotionDiv
-            initial={{ opacity: 0, y: 8 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 1.0, duration: 0.5 }}
-            className="mt-6 mb-8 sm:mt-8 sm:mb-12 md:mb-16"
-          >
-            <Link
-              href="/logistics"
-              className="inline-flex items-center justify-center rounded-lg bg-white px-6 py-3 text-base font-semibold text-gray-900 shadow-lg transition-colors hover:bg-gray-100 sm:px-8 sm:py-4 sm:text-lg"
-            >
-              Get a Quote
-            </Link>
-          </MotionDiv>
+            How can we help?
+          </MotionHeading>
         </MotionHeader>
 
         {/* Removed flex-1 and items-end, added mt-auto to push buttons to bottom, or simply removed flex-1 and used a top margin */}


### PR DESCRIPTION
## Why

The M1 design migration ([PR #385](https://github.com/ReadySet1/ready-set/pull/385), `aea5bcaa`, 2026-04-27) landed the global navbar on the home page and replaced the hero heading with a new visible H1 + tagline + "Get a Quote" CTA plus a dark top-edge scrim. That work was promoted to production via the subsequent `development → main` syncs **but was never approved by stakeholders**. This PR restores the pre-M1 landing in production while keeping the redesign one cherry-pick away.

## What changes (surgical, landing-only)

| File | Change |
|---|---|
| `src/components/Clients/ClientLayout.tsx` | Re-add `!isHomePage` to the Header gating → **global navbar no longer renders on `/`** (matches pre-M1 behavior). |
| `src/components/Hero/index.tsx` | Restore sr-only `<h1>` (M1 demoted it to `<h2>`); remove the new visible `<MotionH1>`, tagline, and "Get a Quote" CTA; restore the original `<MotionHeading>` *"How can we help?"*; remove the top-edge dark scrim div; drop the now-unused `MotionH1` declaration. |

**Diff:** +9 / −37, 2 files.

## What is NOT changing (intentional)

- **M3/M4 token system** (semantic color + spacing tokens migration) — kept in place. Hero retains M4 token classes (e.g. `md:h-card-h-md`).
- **M2 logistics conversion** (`/logistics` CTA hierarchy) — separate page, unaffected.
- **M5 analytics consent gating** (cookie banner) — kept in place.

## Mechanism

`git revert aea5bcaa` would conflict (M4 retouched `Hero/index.tsx`). Used a surgical forward-fix commit instead, which leaves the token system untouched.

## Redesign preserved

Branch [`design/homepage-redesign-hold`](https://github.com/ReadySet1/ready-set/tree/design/homepage-redesign-hold) (pushed from current `development` tip) pins the redesign state. Once stakeholders approve, re-apply via cherry-pick or revert-of-this-PR.

## Verification

- ✅ `pnpm typecheck` clean
- ✅ `pnpm lint` clean on changed files
- ✅ `pnpm test src/app/page.test.tsx` — 5/5 pass (metadata-only suite, no hero text assertions to update)
- ⏳ Manual verify on `development.readysetllc.com` after merge: home `/` has **no** global navbar, hero shows **"How can we help?"**, interior pages (`/about`, `/logistics`) **still render the navbar** (unchanged).

## Follow-up

- Add a task to `meetings/shared/tasks-board.json` tracking the pending-approval state of the redesign and pointing at the hold branch (separate small PR — keeps the generated mirror clean).
- Once approved by stakeholders, open a re-apply PR from `design/homepage-redesign-hold` (or revert this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)