### PR TITLE
feat: add v2 design token foundation (PR-A, additive, no visual changes)

### DIFF
--- a/components.json
+++ b/components.json
@@ -6,8 +6,8 @@
   "tailwind": {
     "config": "tailwind.config.js",
     "css": "styles/index.css",
-    "baseColor": "slate",
-    "cssVariables": false,
+    "baseColor": "neutral",
+    "cssVariables": true,
     "prefix": ""
   },
   "aliases": {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -23,6 +23,131 @@
   font-display: swap;
 }
 
+/* ────────────────────────────────────────────────────────────────
+ * V2 design tokens — CSS variable definitions
+ *
+ * Status: ADDITIVE in this PR. These variables back the new
+ * brand-*/neutral-*/semantic Tailwind tokens added in
+ * tailwind.config.ts. Legacy components don't consume them yet —
+ * they keep using legacy hex tokens (#FBD113, #F4F7FF, etc.).
+ *
+ * Base element rules (body bg/color, focus rings, ::selection,
+ * `* border-color`) are intentionally NOT included here — those
+ * land in the sweep PR (PR-B) alongside call-site migration.
+ *
+ * See: tailwind.tokens.ts and globals.css in the design bundle
+ *      docs/ready-set/reports/2026-05-22-design-baseline/
+ * ─────────────────────────────────────────────────────────────── */
+@layer base {
+  :root {
+    /* Brand ramp */
+    --brand-50:  48 100% 96%;
+    --brand-100: 50 96% 88%;
+    --brand-200: 50 96% 76%;
+    --brand-300: 50 96% 65%;
+    --brand-400: 50 97% 53%;   /* #FBD113 — anchor, matches legacy brand */
+    --brand-500: 47 92% 47%;
+    --brand-600: 42 95% 39%;
+    --brand-700: 36 90% 31%;
+    --brand-800: 32 80% 24%;
+    --brand-900: 28 80% 14%;
+
+    /* Neutrals (warm, low chroma) */
+    --neutral-50:  60 14% 97%;
+    --neutral-100: 50 12% 94%;
+    --neutral-200: 50 14% 89%;
+    --neutral-300: 48 10% 80%;
+    --neutral-400: 50 4%  62%;
+    --neutral-500: 51 3%  43%;
+    --neutral-600: 50 4%  31%;
+    --neutral-700: 48 4%  22%;
+    --neutral-800: 50 9%  13%;
+    --neutral-900: 60 10% 7%;
+
+    /* Semantic ramps */
+    --success-50:  138 76% 97%;
+    --success-100: 141 84% 93%;
+    --success-500: 142 71% 45%;
+    --success-600: 142 76% 36%;
+    --success-700: 142 72% 29%;
+
+    --warning-50:  48 100% 96%;
+    --warning-100: 48 96% 89%;
+    --warning-500: 38 92% 50%;
+    --warning-600: 32 95% 44%;
+    --warning-700: 26 90% 37%;
+
+    --error-50:    0 86% 97%;
+    --error-100:   0 93% 94%;
+    --error-500:   0 84% 60%;
+    --error-600:   0 72% 51%;
+    --error-700:   0 74% 42%;
+
+    --info-50:    214 100% 97%;
+    --info-100:   214 95% 93%;
+    --info-500:   217 91% 60%;
+    --info-600:   221 83% 53%;
+    --info-700:   224 76% 48%;
+
+    /* Shadcn semantic aliases (light) */
+    --background:        var(--neutral-50);
+    --foreground:        var(--neutral-900);
+    --card:              0 0% 100%;
+    --card-foreground:   var(--neutral-900);
+    --popover:           0 0% 100%;
+    --popover-foreground:var(--neutral-900);
+    --primary:           var(--brand-400);
+    --primary-hover:     var(--brand-500);
+    --primary-foreground:var(--neutral-900);
+    --secondary:         var(--neutral-100);
+    --secondary-foreground: var(--neutral-900);
+    --muted:             var(--neutral-100);
+    --muted-foreground:  var(--neutral-500);
+    --accent:            var(--brand-50);
+    --accent-foreground: var(--brand-800);
+    --destructive:           var(--error-600);
+    --destructive-foreground: 0 0% 100%;
+    --border:            var(--neutral-200);
+    --input:             var(--neutral-200);
+    --ring:              var(--brand-500);
+
+    /* Type */
+    --font-sans:    "Montserrat", ui-sans-serif, system-ui, -apple-system, sans-serif;
+    --font-display: "Kabel", "Montserrat", sans-serif;
+    --font-mono:    "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+    /* Radius (Shadcn maps `--radius` to its components) */
+    --radius: 0.5rem;
+  }
+
+  .dark {
+    --background:        var(--neutral-900);
+    --foreground:        var(--neutral-50);
+    --card:              var(--neutral-800);
+    --card-foreground:   var(--neutral-50);
+    --popover:           var(--neutral-800);
+    --popover-foreground:var(--neutral-50);
+    --primary:           var(--brand-400);
+    --primary-hover:     var(--brand-300);
+    --primary-foreground:var(--neutral-900);
+    --secondary:         var(--neutral-800);
+    --secondary-foreground: var(--neutral-50);
+    --muted:             var(--neutral-800);
+    --muted-foreground:  var(--neutral-400);
+    --accent:            var(--brand-900);
+    --accent-foreground: var(--brand-100);
+    --destructive:           var(--error-500);
+    --destructive-foreground: var(--neutral-50);
+    --border:            var(--neutral-700);
+    --input:             var(--neutral-700);
+    --ring:              var(--brand-400);
+  }
+
+  /* Opt-in display font (marketing/H1). Default headings stay Kabel
+     via the existing `h1, h2` rule below until PR-B. */
+  .font-display { font-family: var(--font-display); }
+}
+
 /* Custom utility classes */
 @layer utilities {
   .scrollbar-hide {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -27,7 +27,7 @@
  * V2 design tokens — CSS variable definitions
  *
  * Status: ADDITIVE in this PR. These variables back the new
- * brand-*/neutral-*/semantic Tailwind tokens added in
+ * brand / neutral / semantic Tailwind tokens added in
  * tailwind.config.ts. Legacy components don't consume them yet —
  * they keep using legacy hex tokens (#FBD113, #F4F7FF, etc.).
  *

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,18 +3,28 @@ import type { Config } from "tailwindcss";
 /**
  * Tailwind CSS Configuration
  *
- * Brand Colors: See src/styles/brand-colors.ts for centralized color system
- * - Primary brand colors: amber-300/400 (use for brand elements)
- * - Semantic colors: yellow-400/500/600 (use for warnings, highlights)
+ * V2 design token system is being landed in two phases:
+ *   PR-A (this PR): Add new tokens ADDITIVELY alongside legacy. Legacy
+ *                   tokens (primary/brand/cta/surface/text/auth-tint)
+ *                   keep working unchanged. New tokens (brand-50..900,
+ *                   neutral-*, semantic ramps, Shadcn aliases) become
+ *                   available for batch 1a downstream.
+ *   PR-B (later):   Sweep call sites to v2 tokens, then replace this
+ *                   entire `extend` block with `theme: tokens` from
+ *                   `./tailwind.tokens.ts`.
  *
- * Semantic tokens (M3): use these instead of arbitrary hex values.
+ * See: tailwind.tokens.ts (canonical v2 tokens, identical to bundle)
+ *      src/styles/index.css (CSS variable definitions in :root + .dark)
+ *      docs/ready-set/reports/2026-05-22-design-baseline/ (full context)
+ *
+ * Legacy color guidance (unchanged):
  * - bg-brand / bg-brand-muted / bg-brand-deep — yellow brand surfaces
  * - bg-cta / bg-cta-hover — interactive yellow surfaces
  * - text-text-primary / text-text-muted / text-text-inverse — text colors
  * - bg-surface / bg-surface-subtle / bg-surface-inverted — backgrounds
  * - bg-auth-tint — auth-page accent surface
  *
- * Spacing tokens (M3): named replacements for common arbitrary px values.
+ * Spacing tokens (unchanged):
  * - pt-page-y / -lg / -xl / -2xl — section vertical rhythm
  * - h-card-h / -md / -lg, min-h-card-h-sm — card height constraints
  * - w-card-min — card width baseline
@@ -29,6 +39,7 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
+        // ─── Legacy tokens (kept as-is for PR-A) ────────────────────
         primary: '#FBD113',
         'custom-yellow': "#ffc61a",
         'dark-navy': '#1a202c',
@@ -37,6 +48,17 @@ const config: Config = {
           DEFAULT: '#FBD113',
           muted: '#F8CC48',
           deep: '#854D0E',
+          // V2 ramp added alongside legacy keys above
+          50:  "hsl(var(--brand-50) / <alpha-value>)",
+          100: "hsl(var(--brand-100) / <alpha-value>)",
+          200: "hsl(var(--brand-200) / <alpha-value>)",
+          300: "hsl(var(--brand-300) / <alpha-value>)",
+          400: "hsl(var(--brand-400) / <alpha-value>)",
+          500: "hsl(var(--brand-500) / <alpha-value>)",
+          600: "hsl(var(--brand-600) / <alpha-value>)",
+          700: "hsl(var(--brand-700) / <alpha-value>)",
+          800: "hsl(var(--brand-800) / <alpha-value>)",
+          900: "hsl(var(--brand-900) / <alpha-value>)",
         },
         cta: {
           DEFAULT: '#FBD113',
@@ -53,6 +75,85 @@ const config: Config = {
           inverse: '#FFFFFF',
         },
         'auth-tint': '#F4F7FF',
+
+        // ─── V2 tokens (additive, CSS-variable-backed) ──────────────
+        neutral: {
+          50:  "hsl(var(--neutral-50) / <alpha-value>)",
+          100: "hsl(var(--neutral-100) / <alpha-value>)",
+          200: "hsl(var(--neutral-200) / <alpha-value>)",
+          300: "hsl(var(--neutral-300) / <alpha-value>)",
+          400: "hsl(var(--neutral-400) / <alpha-value>)",
+          500: "hsl(var(--neutral-500) / <alpha-value>)",
+          600: "hsl(var(--neutral-600) / <alpha-value>)",
+          700: "hsl(var(--neutral-700) / <alpha-value>)",
+          800: "hsl(var(--neutral-800) / <alpha-value>)",
+          900: "hsl(var(--neutral-900) / <alpha-value>)",
+        },
+        success: {
+          50:  "hsl(var(--success-50) / <alpha-value>)",
+          100: "hsl(var(--success-100) / <alpha-value>)",
+          500: "hsl(var(--success-500) / <alpha-value>)",
+          600: "hsl(var(--success-600) / <alpha-value>)",
+          700: "hsl(var(--success-700) / <alpha-value>)",
+          DEFAULT: "hsl(var(--success-600) / <alpha-value>)",
+        },
+        warning: {
+          50:  "hsl(var(--warning-50) / <alpha-value>)",
+          100: "hsl(var(--warning-100) / <alpha-value>)",
+          500: "hsl(var(--warning-500) / <alpha-value>)",
+          600: "hsl(var(--warning-600) / <alpha-value>)",
+          700: "hsl(var(--warning-700) / <alpha-value>)",
+          DEFAULT: "hsl(var(--warning-500) / <alpha-value>)",
+        },
+        error: {
+          50:  "hsl(var(--error-50) / <alpha-value>)",
+          100: "hsl(var(--error-100) / <alpha-value>)",
+          500: "hsl(var(--error-500) / <alpha-value>)",
+          600: "hsl(var(--error-600) / <alpha-value>)",
+          700: "hsl(var(--error-700) / <alpha-value>)",
+          DEFAULT: "hsl(var(--error-500) / <alpha-value>)",
+        },
+        info: {
+          50:  "hsl(var(--info-50) / <alpha-value>)",
+          100: "hsl(var(--info-100) / <alpha-value>)",
+          500: "hsl(var(--info-500) / <alpha-value>)",
+          600: "hsl(var(--info-600) / <alpha-value>)",
+          700: "hsl(var(--info-700) / <alpha-value>)",
+          DEFAULT: "hsl(var(--info-500) / <alpha-value>)",
+        },
+
+        // Shadcn-style semantic aliases (resolve via CSS variables).
+        // `--primary` resolves to `--brand-400` = #FBD113 = same color
+        // legacy `primary: '#FBD113'` produced. Visual parity preserved.
+        background:        "hsl(var(--background) / <alpha-value>)",
+        foreground:        "hsl(var(--foreground) / <alpha-value>)",
+        muted: {
+          DEFAULT:    "hsl(var(--muted) / <alpha-value>)",
+          foreground: "hsl(var(--muted-foreground) / <alpha-value>)",
+        },
+        card: {
+          DEFAULT:    "hsl(var(--card) / <alpha-value>)",
+          foreground: "hsl(var(--card-foreground) / <alpha-value>)",
+        },
+        popover: {
+          DEFAULT:    "hsl(var(--popover) / <alpha-value>)",
+          foreground: "hsl(var(--popover-foreground) / <alpha-value>)",
+        },
+        secondary: {
+          DEFAULT:    "hsl(var(--secondary) / <alpha-value>)",
+          foreground: "hsl(var(--secondary-foreground) / <alpha-value>)",
+        },
+        accent: {
+          DEFAULT:    "hsl(var(--accent) / <alpha-value>)",
+          foreground: "hsl(var(--accent-foreground) / <alpha-value>)",
+        },
+        destructive: {
+          DEFAULT:    "hsl(var(--destructive) / <alpha-value>)",
+          foreground: "hsl(var(--destructive-foreground) / <alpha-value>)",
+        },
+        border:  "hsl(var(--border) / <alpha-value>)",
+        input:   "hsl(var(--input) / <alpha-value>)",
+        ring:    "hsl(var(--ring) / <alpha-value>)",
       },
       spacing: {
         'page-y-sm': '100px',
@@ -65,6 +166,9 @@ const config: Config = {
         'card-h': '300px',
         'card-h-md': '400px',
         'card-h-lg': '500px',
+      },
+      fontFamily: {
+        display: ["var(--font-display)", "Kabel", "Montserrat", "sans-serif"],
       },
       keyframes: {
         "accordion-down": {
@@ -80,11 +184,27 @@ const config: Config = {
           "50%": { transform: "scale(1.15)" },
           "100%": { transform: "scale(1.1)" },
         },
+        // V2 additions (opt-in via new animation names below)
+        "fade-in":  { from: { opacity: "0" }, to: { opacity: "1" } },
+        "fade-out": { from: { opacity: "1" }, to: { opacity: "0" } },
+        "slide-up": {
+          from: { opacity: "0", transform: "translateY(8px)" },
+          to:   { opacity: "1", transform: "translateY(0)" },
+        },
+        shimmer: {
+          "0%":   { backgroundPosition: "-200% 0" },
+          "100%": { backgroundPosition: "200% 0" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
         "pop": "pop 0.3s ease-in-out",
+        // V2 additions
+        "fade-in":  "fade-in 200ms cubic-bezier(0, 0, 0.2, 1)",
+        "fade-out": "fade-out 120ms cubic-bezier(0.4, 0, 1, 1)",
+        "slide-up": "slide-up 300ms cubic-bezier(0.2, 0, 0, 1)",
+        shimmer:    "shimmer 1.6s linear infinite",
       },
     },
   },

--- a/tailwind.tokens.ts
+++ b/tailwind.tokens.ts
@@ -1,0 +1,249 @@
+/**
+ * Ready Set — Tailwind tokens (v2)
+ * Drop-in extend block. Wired to CSS variables defined in src/styles/index.css.
+ *
+ * Status: ADDITIVE in the foundation PR — these tokens coexist alongside the
+ * legacy `primary`/`brand`/`cta`/`surface`/`text`/`auth-tint` tokens defined
+ * in tailwind.config.ts. The sweep PR (PR-B) will replace tailwind.config.ts's
+ * extend block entirely with `theme: tokens`.
+ *
+ * Shadcn `components.json` must set `cssVariables: true`.
+ */
+import type { Config } from "tailwindcss";
+
+export const tokens: Config["theme"] = {
+  extend: {
+    // ─── Colors (CSS variable-backed for light/dark) ─────────────
+    colors: {
+      // Brand ramp
+      brand: {
+        50:  "hsl(var(--brand-50) / <alpha-value>)",
+        100: "hsl(var(--brand-100) / <alpha-value>)",
+        200: "hsl(var(--brand-200) / <alpha-value>)",
+        300: "hsl(var(--brand-300) / <alpha-value>)",
+        400: "hsl(var(--brand-400) / <alpha-value>)",
+        500: "hsl(var(--brand-500) / <alpha-value>)",
+        600: "hsl(var(--brand-600) / <alpha-value>)",
+        700: "hsl(var(--brand-700) / <alpha-value>)",
+        800: "hsl(var(--brand-800) / <alpha-value>)",
+        900: "hsl(var(--brand-900) / <alpha-value>)",
+        DEFAULT: "hsl(var(--brand-400) / <alpha-value>)",
+      },
+
+      // Neutrals — replace slate
+      neutral: {
+        50:  "hsl(var(--neutral-50) / <alpha-value>)",
+        100: "hsl(var(--neutral-100) / <alpha-value>)",
+        200: "hsl(var(--neutral-200) / <alpha-value>)",
+        300: "hsl(var(--neutral-300) / <alpha-value>)",
+        400: "hsl(var(--neutral-400) / <alpha-value>)",
+        500: "hsl(var(--neutral-500) / <alpha-value>)",
+        600: "hsl(var(--neutral-600) / <alpha-value>)",
+        700: "hsl(var(--neutral-700) / <alpha-value>)",
+        800: "hsl(var(--neutral-800) / <alpha-value>)",
+        900: "hsl(var(--neutral-900) / <alpha-value>)",
+      },
+
+      // Semantic (status)
+      success: {
+        50:  "hsl(var(--success-50) / <alpha-value>)",
+        100: "hsl(var(--success-100) / <alpha-value>)",
+        500: "hsl(var(--success-500) / <alpha-value>)",
+        600: "hsl(var(--success-600) / <alpha-value>)",
+        700: "hsl(var(--success-700) / <alpha-value>)",
+        DEFAULT: "hsl(var(--success-600) / <alpha-value>)",
+      },
+      warning: {
+        50:  "hsl(var(--warning-50) / <alpha-value>)",
+        100: "hsl(var(--warning-100) / <alpha-value>)",
+        500: "hsl(var(--warning-500) / <alpha-value>)",
+        600: "hsl(var(--warning-600) / <alpha-value>)",
+        700: "hsl(var(--warning-700) / <alpha-value>)",
+        DEFAULT: "hsl(var(--warning-500) / <alpha-value>)",
+      },
+      error: {
+        50:  "hsl(var(--error-50) / <alpha-value>)",
+        100: "hsl(var(--error-100) / <alpha-value>)",
+        500: "hsl(var(--error-500) / <alpha-value>)",
+        600: "hsl(var(--error-600) / <alpha-value>)",
+        700: "hsl(var(--error-700) / <alpha-value>)",
+        DEFAULT: "hsl(var(--error-500) / <alpha-value>)",
+      },
+      info: {
+        50:  "hsl(var(--info-50) / <alpha-value>)",
+        100: "hsl(var(--info-100) / <alpha-value>)",
+        500: "hsl(var(--info-500) / <alpha-value>)",
+        600: "hsl(var(--info-600) / <alpha-value>)",
+        700: "hsl(var(--info-700) / <alpha-value>)",
+        DEFAULT: "hsl(var(--info-500) / <alpha-value>)",
+      },
+
+      // Shadcn-style semantic aliases (resolve via globals.css)
+      background:        "hsl(var(--background) / <alpha-value>)",
+      foreground:        "hsl(var(--foreground) / <alpha-value>)",
+      muted: {
+        DEFAULT:    "hsl(var(--muted) / <alpha-value>)",
+        foreground: "hsl(var(--muted-foreground) / <alpha-value>)",
+      },
+      card: {
+        DEFAULT:    "hsl(var(--card) / <alpha-value>)",
+        foreground: "hsl(var(--card-foreground) / <alpha-value>)",
+      },
+      popover: {
+        DEFAULT:    "hsl(var(--popover) / <alpha-value>)",
+        foreground: "hsl(var(--popover-foreground) / <alpha-value>)",
+      },
+      primary: {
+        DEFAULT:    "hsl(var(--primary) / <alpha-value>)",
+        foreground: "hsl(var(--primary-foreground) / <alpha-value>)",
+        hover:      "hsl(var(--primary-hover) / <alpha-value>)",
+      },
+      secondary: {
+        DEFAULT:    "hsl(var(--secondary) / <alpha-value>)",
+        foreground: "hsl(var(--secondary-foreground) / <alpha-value>)",
+      },
+      accent: {
+        DEFAULT:    "hsl(var(--accent) / <alpha-value>)",
+        foreground: "hsl(var(--accent-foreground) / <alpha-value>)",
+      },
+      destructive: {
+        DEFAULT:    "hsl(var(--destructive) / <alpha-value>)",
+        foreground: "hsl(var(--destructive-foreground) / <alpha-value>)",
+      },
+      border:  "hsl(var(--border) / <alpha-value>)",
+      input:   "hsl(var(--input) / <alpha-value>)",
+      ring:    "hsl(var(--ring) / <alpha-value>)",
+    },
+
+    // ─── Type ─────────────────────────────────────────────────────
+    fontFamily: {
+      sans:    ["var(--font-sans)",    "Montserrat", "ui-sans-serif", "system-ui", "sans-serif"],
+      display: ["var(--font-display)", "Kabel",      "Montserrat",    "sans-serif"],
+      mono:    ["var(--font-mono)",    "JetBrains Mono", "ui-monospace", "monospace"],
+    },
+
+    fontSize: {
+      // [size, { lineHeight, letterSpacing }]
+      xs:   ["0.75rem",  { lineHeight: "1.5",  letterSpacing: "0em" }],
+      sm:   ["0.875rem", { lineHeight: "1.5",  letterSpacing: "0em" }],
+      base: ["1rem",     { lineHeight: "1.6",  letterSpacing: "0em" }],
+      lg:   ["1.125rem", { lineHeight: "1.55", letterSpacing: "-0.005em" }],
+      xl:   ["1.25rem",  { lineHeight: "1.4",  letterSpacing: "-0.01em" }],
+      "2xl":["1.5rem",   { lineHeight: "1.35", letterSpacing: "-0.01em" }],
+      "3xl":["1.875rem", { lineHeight: "1.25", letterSpacing: "-0.015em" }],
+      "4xl":["2.25rem",  { lineHeight: "1.2",  letterSpacing: "-0.02em" }],
+      "5xl":["3rem",     { lineHeight: "1.1",  letterSpacing: "-0.02em" }],
+      "6xl":["3.75rem",  { lineHeight: "1.05", letterSpacing: "-0.022em" }],
+      "7xl":["4.5rem",   { lineHeight: "1",    letterSpacing: "-0.025em" }],
+    },
+
+    fontWeight: {
+      light: "300", regular: "400", medium: "500",
+      semibold: "600", bold: "700", extrabold: "800", black: "900",
+    },
+
+    letterSpacing: {
+      tighter: "-0.02em",
+      tight:   "-0.01em",
+      normal:  "0em",
+      wide:    "0.025em",
+      wider:   "0.04em",
+      widest:  "0.1em",
+    },
+
+    // ─── Spacing ──────────────────────────────────────────────────
+    spacing: {
+      "page-y-sm":  "6.25rem",
+      "page-y":     "7.5rem",
+      "page-y-lg":  "8.75rem",
+      "page-y-xl":  "10rem",
+      "page-y-2xl": "11.25rem",
+      "card-min":   "18.75rem",
+      "card-h-sm":  "12.5rem",
+      "card-h":     "18.75rem",
+      "card-h-md":  "25rem",
+      "card-h-lg":  "31.25rem",
+    },
+
+    // ─── Radius ───────────────────────────────────────────────────
+    borderRadius: {
+      none: "0",
+      xs:   "0.125rem",
+      sm:   "0.25rem",
+      md:   "0.375rem",
+      lg:   "0.5rem",
+      xl:   "0.75rem",
+      "2xl":"1rem",
+      "3xl":"1.5rem",
+      full: "9999px",
+    },
+
+    // ─── Shadows / elevation ─────────────────────────────────────
+    boxShadow: {
+      xs:  "0 1px 2px 0 rgba(19, 19, 16, 0.05)",
+      sm:  "0 1px 3px 0 rgba(19, 19, 16, 0.08), 0 1px 2px -1px rgba(19, 19, 16, 0.04)",
+      md:  "0 4px 8px -2px rgba(19, 19, 16, 0.08), 0 2px 4px -2px rgba(19, 19, 16, 0.04)",
+      lg:  "0 12px 20px -4px rgba(19, 19, 16, 0.10), 0 4px 8px -4px rgba(19, 19, 16, 0.04)",
+      xl:  "0 24px 40px -8px rgba(19, 19, 16, 0.14), 0 8px 16px -8px rgba(19, 19, 16, 0.06)",
+      "2xl": "0 40px 80px -16px rgba(19, 19, 16, 0.20)",
+      inner: "inset 0 1px 2px 0 rgba(19, 19, 16, 0.06)",
+      "focus-ring": "0 0 0 2px hsl(var(--background)), 0 0 0 4px hsl(var(--ring))",
+      none: "none",
+    },
+
+    // ─── Motion ───────────────────────────────────────────────────
+    transitionDuration: {
+      fast:    "120ms",
+      DEFAULT: "200ms",
+      base:    "200ms",
+      medium:  "300ms",
+      slow:    "500ms",
+      slower:  "750ms",
+    },
+    transitionTimingFunction: {
+      standard:   "cubic-bezier(0.2, 0, 0, 1)",
+      accelerate: "cubic-bezier(0.4, 0, 1, 1)",
+      decelerate: "cubic-bezier(0, 0, 0.2, 1)",
+      spring:     "cubic-bezier(0.5, 1.5, 0.6, 1)",
+      DEFAULT:    "cubic-bezier(0.2, 0, 0, 1)",
+    },
+
+    // ─── Keyframes / animations ──────────────────────────────────
+    keyframes: {
+      "accordion-down": {
+        from: { height: "0" },
+        to: { height: "var(--radix-accordion-content-height)" },
+      },
+      "accordion-up": {
+        from: { height: "var(--radix-accordion-content-height)" },
+        to: { height: "0" },
+      },
+      pop: {
+        "0%":   { transform: "scale(1)" },
+        "50%":  { transform: "scale(1.15)" },
+        "100%": { transform: "scale(1.1)" },
+      },
+      "fade-in":  { from: { opacity: "0" }, to: { opacity: "1" } },
+      "fade-out": { from: { opacity: "1" }, to: { opacity: "0" } },
+      "slide-up": {
+        from: { opacity: "0", transform: "translateY(8px)" },
+        to:   { opacity: "1", transform: "translateY(0)" },
+      },
+      shimmer: {
+        "0%":   { backgroundPosition: "-200% 0" },
+        "100%": { backgroundPosition: "200% 0" },
+      },
+    },
+    animation: {
+      "accordion-down": "accordion-down 200ms cubic-bezier(0.2, 0, 0, 1)",
+      "accordion-up":   "accordion-up 200ms cubic-bezier(0.2, 0, 0, 1)",
+      pop:              "pop 300ms cubic-bezier(0.5, 1.5, 0.6, 1)",
+      "fade-in":        "fade-in 200ms cubic-bezier(0, 0, 0.2, 1)",
+      "fade-out":       "fade-out 120ms cubic-bezier(0.4, 0, 1, 1)",
+      "slide-up":       "slide-up 300ms cubic-bezier(0.2, 0, 0, 1)",
+      shimmer:          "shimmer 1.6s linear infinite",
+    },
+  },
+};
+
+export default tokens;


### PR DESCRIPTION
## Summary

**PR-A of a two-part design system rollout.** Lands the v2 token system **alongside** the existing legacy tokens — both coexist so this PR has zero intended visual changes. Unblocks downstream work (Shadcn primitive refit batch 1a + admin redesign) without taking the visual-cutover risk in a single PR.

## What's included

| File | Change |
|---|---|
| `tailwind.tokens.ts` (new) | Canonical v2 tokens (brand/neutral ramps, semantic ramps, Shadcn aliases, type scale, motion). **PR-B will replace `tailwind.config.ts`'s `extend` with `theme: tokens` from here.** |
| `tailwind.config.ts` | Legacy tokens kept verbatim. New tokens added: `brand-50..900` inside existing `brand` object, plus `neutral`, `success`, `warning`, `error`, `info`, and Shadcn aliases (`background`, `foreground`, `card`, `popover`, `secondary`, `accent`, `destructive`, `border`, `input`, `ring`). Adds `fontFamily.display` and four new keyframes/animations (`fade-in`, `fade-out`, `slide-up`, `shimmer`). |
| `src/styles/index.css` | `:root` + `.dark` CSS variable blocks defining all ramps and Shadcn aliases. Adds `.font-display` utility. Base element rules (`body` bg/color, `:focus-visible`, `::selection`, `* { border-color }`) **intentionally deferred to PR-B.** |
| `components.json` | `cssVariables: false → true`, `baseColor: slate → neutral`. Required to unlock CSS-var-backed Shadcn generation. |

## Why this works without visual changes

Every legacy class (`bg-primary`, `bg-brand`, `bg-surface`, etc.) still resolves to its existing hex. The new tokens are additive — no existing class is removed or remapped. The new `--primary` CSS variable resolves to `--brand-400` = `#FBD113`, which is exactly the legacy `primary: '#FBD113'` value, so even Shadcn components that now read from CSS vars produce identical output.

## What's deferred to PR-B

- The 22-token migration sweep (~60 files / 84 occurrences) per `migration-map.md`
- Removing legacy tokens (`primary`/`cta`/`surface`/`text`/`auth-tint`/`dark-navy`/`charcoal`/`custom-yellow`)
- Visual deltas flagged in the migration map — these need design sign-off before landing:
  - Auth pages: `#F4F7FF` cool blue tint → `#FFFBEA` warm yellow tint (map explicitly says *"confirm with design before landing"*)
  - Kabel becomes opt-in via `.font-display` only — currently `h1, h2 { font-family: "Kabel" }` is a blanket rule
  - Warm-tuned neutral ramp (subtle tonal shift across surface-subtle, dark-navy, charcoal, brand-muted, cta-hover)
- Body / `:focus-visible` / `::selection` global rules

## Test plan

- [x] `pnpm pre-push-check` (typecheck + lint + prisma validate) passes
- [x] `pnpm test` — passes modulo two pre-existing failures on `development` unrelated to this PR (`orders/order-files` driver auth, 500 vs 403)
- [ ] **Visual spot-check on Vercel preview** before merge — verify auth pages, admin shell, marketing home look identical to `development`
- [ ] Smoke-test dark mode toggle if any UI exposes it (new CSS vars now backing dark mode)

## Source

- Bundle: `/Users/ealanis/Downloads/bundle-re-design/` (sha256-verified, fonts byte-identical to repo)
- Design baseline + rollout prompts: `docs/ready-set/reports/2026-05-22-design-baseline/`

## Follow-up

- **Ticket:** branch name is `REA-XXX` placeholder — please attach the real ticket before merge.
- **PR-B will follow** once batch 1a Shadcn primitives are also ready, so the sweep and the refit can ship in a single visual-cutover deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)