### PR TITLE
design: refit Shadcn form atoms (batch 1a) — stacked on #413

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,29 +1,57 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+/**
+ * Ready Set — Button (v2)
+ * components/ui/button.tsx
+ *
+ * Drop-in replacement. Wires Shadcn's Button to the v2 design tokens
+ * (brand-* + neutral-* + semantic aliases). Radix Slot still handles
+ * the `asChild` pattern.
+ *
+ * Peer deps: react, @radix-ui/react-slot, class-variance-authority,
+ *            clsx, tailwind-merge.
+ */
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-xl text-sm font-medium ring-offset-white transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-slate-950 dark:focus-visible:ring-slate-300",
+  // ── Base — applied to every variant + size combination
+  [
+    "inline-flex items-center justify-center gap-2 whitespace-nowrap",
+    "font-semibold tracking-tight",
+    "transition-colors duration-150 ease-out",
+    "focus-visible:outline-none",
+    "focus-visible:ring-2 focus-visible:ring-brand-500",
+    "focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+    "disabled:pointer-events-none disabled:opacity-50",
+    // Inline icons sized + non-shrinking by default
+    "[&_svg]:size-4 [&_svg]:shrink-0",
+  ].join(" "),
   {
     variants: {
       variant: {
-        default: "bg-slate-900 text-slate-50 hover:bg-slate-800 shadow-md hover:shadow-lg dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-50/90",
-        destructive:
-          "bg-red-500 text-slate-50 hover:bg-red-600 shadow-md hover:shadow-lg dark:bg-red-900 dark:text-slate-50 dark:hover:bg-red-900/90",
+        default:
+          "bg-brand-400 text-neutral-900 shadow-xs hover:bg-brand-500 active:bg-brand-600",
         outline:
-          "border border-slate-200 bg-white hover:bg-slate-50 hover:text-slate-900 shadow-sm hover:shadow-md hover:border-slate-300 dark:border-slate-800 dark:bg-slate-950 dark:hover:bg-slate-800 dark:hover:text-slate-50",
+          "border border-input bg-card text-foreground shadow-xs hover:bg-muted",
         secondary:
-          "bg-slate-100 text-slate-900 hover:bg-slate-200 shadow-sm hover:shadow-md dark:bg-slate-800 dark:text-slate-50 dark:hover:bg-slate-800/80",
-        ghost: "hover:bg-slate-100 hover:text-slate-900 dark:hover:bg-slate-800 dark:hover:text-slate-50",
-        link: "text-slate-900 underline-offset-4 hover:underline dark:text-slate-50",
+          "bg-secondary text-secondary-foreground hover:bg-neutral-200 dark:hover:bg-neutral-700",
+        ghost:
+          "text-foreground hover:bg-muted hover:text-foreground",
+        destructive:
+          "bg-destructive text-destructive-foreground shadow-xs hover:bg-error-700",
+        link:
+          "text-brand-700 dark:text-brand-400 underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-11 px-6 py-2",
-        sm: "h-9 rounded-lg px-4",
-        lg: "h-13 rounded-xl px-8 text-base",
-        icon: "h-11 w-11",
+        xs: "h-8 px-2.5 text-xs rounded-md",
+        sm: "h-9 px-3.5 text-sm rounded-lg",
+        default: "h-10 px-4 text-sm rounded-lg",
+        lg: "h-11 px-6 text-base rounded-lg",
+        "icon-xs": "size-8 rounded-md",
+        "icon-sm": "size-9 rounded-md",
+        icon: "size-10 rounded-lg",
       },
     },
     defaultVariants: {
@@ -31,26 +59,26 @@ const buttonVariants = cva(
       size: "default",
     },
   }
-)
+);
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean
+  asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
+    const Comp = asChild ? Slot : "button";
     return (
       <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
+        className={cn(buttonVariants({ variant, size, className }))}
         {...props}
       />
-    )
+    );
   }
-)
-Button.displayName = "Button"
+);
+Button.displayName = "Button";
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,30 +1,88 @@
-"use client"
+/**
+ * Ready Set — Checkbox (v2)
+ * components/ui/checkbox.tsx
+ *
+ * Drop-in replacement. Adds a `size` variant (sm 14 / default 16 / lg 18),
+ * brand-tinted checked state, and a Minus icon for the indeterminate
+ * state (clearer "some selected" signal than the old square fill).
+ *
+ * Peer deps: react, @radix-ui/react-checkbox, lucide-react,
+ *            class-variance-authority, clsx, tailwind-merge.
+ */
+"use client";
 
-import * as React from "react"
-import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
-import { Check } from "lucide-react"
+import * as React from "react";
+import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
+import { Check, Minus } from "lucide-react";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
+
+const checkboxVariants = cva(
+  [
+    "peer shrink-0 rounded border bg-card",
+    "border-input",
+    "transition-colors duration-150 ease-out",
+    "focus-visible:outline-none",
+    "focus-visible:border-brand-500",
+    "focus-visible:ring-[3px] focus-visible:ring-brand-100 dark:focus-visible:ring-brand-900",
+    // Checked + indeterminate share visual treatment
+    "data-[state=checked]:bg-brand-400 data-[state=checked]:border-brand-500",
+    "data-[state=indeterminate]:bg-brand-400 data-[state=indeterminate]:border-brand-500",
+    "disabled:cursor-not-allowed disabled:opacity-50",
+  ].join(" "),
+  {
+    variants: {
+      size: {
+        sm: "size-3.5",
+        default: "size-4",
+        lg: "size-[18px]",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  }
+);
+
+const indicatorIconSize: Record<"sm" | "default" | "lg", string> = {
+  sm: "size-2.5",
+  default: "size-3",
+  lg: "size-3.5",
+};
+
+export interface CheckboxProps
+  extends React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>,
+    VariantProps<typeof checkboxVariants> {}
 
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <CheckboxPrimitive.Root
-    ref={ref}
-    className={cn(
-      "peer h-4 w-4 shrink-0 rounded-sm border border-slate-900 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-slate-900 data-[state=checked]:text-slate-50 dark:border-slate-50 dark:ring-offset-slate-950 dark:focus-visible:ring-slate-300 dark:data-[state=checked]:bg-slate-50 dark:data-[state=checked]:text-slate-900",
-      className
-    )}
-    {...props}
-  >
-    <CheckboxPrimitive.Indicator
-      className={cn("flex items-center justify-center text-current")}
+  CheckboxProps
+>(({ className, size = "default", checked, ...props }, ref) => {
+  const iconCls = cn(
+    indicatorIconSize[size ?? "default"],
+    "text-neutral-900",
+    "stroke-[3]"
+  );
+  return (
+    <CheckboxPrimitive.Root
+      ref={ref}
+      checked={checked}
+      className={cn(checkboxVariants({ size }), className)}
+      {...props}
     >
-      <Check className="h-4 w-4" />
-    </CheckboxPrimitive.Indicator>
-  </CheckboxPrimitive.Root>
-))
-Checkbox.displayName = CheckboxPrimitive.Root.displayName
+      <CheckboxPrimitive.Indicator
+        className={cn("flex items-center justify-center text-current")}
+      >
+        {checked === "indeterminate" ? (
+          <Minus className={iconCls} />
+        ) : (
+          <Check className={iconCls} />
+        )}
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+});
+Checkbox.displayName = CheckboxPrimitive.Root?.displayName ?? "Checkbox";
 
-export { Checkbox }
+export { Checkbox, checkboxVariants };

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,28 +1,78 @@
-import * as React from "react"
-import { cn } from "@/lib/utils"
+/**
+ * Ready Set — Input (v2)
+ * components/ui/input.tsx
+ *
+ * Drop-in replacement. Adds a CVA `size` variant matched to Button
+ * (xs / sm / default / lg) and a built-in `error` prop that wires
+ * `aria-invalid` + visual error treatment.
+ *
+ * Breaking change: the native HTML `size` attribute is omitted in
+ * favor of the CVA variant prop. Numeric `size={N}` no longer compiles.
+ *
+ * Peer deps: react, class-variance-authority, clsx, tailwind-merge.
+ */
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const inputVariants = cva(
+  [
+    "flex w-full rounded-lg border bg-card text-foreground",
+    "border-input",
+    "transition-colors duration-150 ease-out",
+    "placeholder:text-neutral-400 dark:placeholder:text-neutral-500",
+    // File input slot
+    "file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground",
+    // Focus
+    "focus-visible:outline-none",
+    "focus-visible:border-brand-500",
+    "focus-visible:ring-[3px] focus-visible:ring-brand-100 dark:focus-visible:ring-brand-900",
+    // Disabled
+    "disabled:cursor-not-allowed disabled:opacity-50 disabled:bg-muted",
+    // aria-invalid → error visuals
+    "aria-[invalid=true]:border-error-500",
+    "aria-[invalid=true]:focus-visible:border-error-500",
+    "aria-[invalid=true]:focus-visible:ring-error-100 dark:aria-[invalid=true]:focus-visible:ring-error-700/40",
+  ].join(" "),
+  {
+    variants: {
+      size: {
+        xs: "h-8 px-2.5 text-xs",
+        sm: "h-9 px-3 text-sm",
+        default: "h-10 px-3 text-sm",
+        lg: "h-11 px-3.5 text-base",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  }
+);
 
 export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "size">,
+    VariantProps<typeof inputVariants> {
+  /**
+   * When true, sets `aria-invalid` and applies the error border + halo.
+   * Replaces ad-hoc `aria-invalid` + manual className overrides.
+   */
+  error?: boolean;
+}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, value, ...props }, ref) => {
-    // Convert null value to empty string to avoid React warning
-    const sanitizedValue = value === null ? "" : value;
-    
+  ({ className, type = "text", size, error, "aria-invalid": ariaInvalid, ...props }, ref) => {
     return (
       <input
-        type={type}
-        className={cn(
-          "flex h-12 w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-base ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:border-blue-400 hover:border-slate-300 transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus-visible:ring-slate-300",
-          className
-        )}
         ref={ref}
-        value={sanitizedValue}
+        type={type}
+        aria-invalid={error || ariaInvalid || undefined}
+        className={cn(inputVariants({ size }), className)}
         {...props}
       />
-    )
+    );
   }
-)
-Input.displayName = "Input"
+);
+Input.displayName = "Input";
 
-export { Input }
+export { Input, inputVariants };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,26 +1,70 @@
-"use client"
+/**
+ * Ready Set — Label (v2)
+ * components/ui/label.tsx
+ *
+ * Drop-in replacement. Extends Radix Label with two new props:
+ *   - `required` renders a red asterisk after the label text.
+ *   - `tone` switches color to error or muted for paired error/disabled states.
+ *
+ * Peer deps: react, @radix-ui/react-label, class-variance-authority,
+ *            clsx, tailwind-merge.
+ */
+"use client";
 
-import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-)
+  [
+    "inline-flex items-center gap-1",
+    "text-sm font-semibold tracking-tight leading-none",
+    // Cascade disabled state through Radix peer relationship
+    "peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+  ].join(" "),
+  {
+    variants: {
+      tone: {
+        default: "text-foreground",
+        error: "text-error-600 dark:text-error-500",
+        muted: "text-muted-foreground",
+      },
+    },
+    defaultVariants: {
+      tone: "default",
+    },
+  }
+);
+
+export interface LabelProps
+  extends React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>,
+    VariantProps<typeof labelVariants> {
+  /** Renders a red asterisk after the label text. */
+  required?: boolean;
+}
 
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
-    VariantProps<typeof labelVariants>
->(({ className, ...props }, ref) => (
+  LabelProps
+>(({ className, tone, required, children, ...props }, ref) => (
   <LabelPrimitive.Root
     ref={ref}
-    className={cn(labelVariants(), className)}
+    className={cn(labelVariants({ tone }), className)}
     {...props}
-  />
-))
-Label.displayName = LabelPrimitive.Root.displayName
+  >
+    {children}
+    {required ? (
+      <span
+        aria-hidden="true"
+        className="text-error-500 font-bold leading-none"
+      >
+        *
+      </span>
+    ) : null}
+  </LabelPrimitive.Root>
+));
+Label.displayName = LabelPrimitive.Root?.displayName ?? "Label";
 
-export { Label }
+export { Label, labelVariants };

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,37 +1,77 @@
-"use client"
+/**
+ * Ready Set — Select (v2)
+ * components/ui/select.tsx
+ *
+ * Drop-in replacement. Wraps Radix Select with trigger geometry that
+ * matches Input (size variants + focus halo), brand-tinted selected
+ * items, and uppercase mono group labels for scannability.
+ *
+ * Peer deps: react, @radix-ui/react-select, lucide-react,
+ *            class-variance-authority, clsx, tailwind-merge.
+ */
+"use client";
 
-import * as React from "react"
-import * as SelectPrimitive from "@radix-ui/react-select"
-import { Check, ChevronDown, ChevronUp } from "lucide-react"
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const Select = SelectPrimitive.Root
+// ── Trigger ────────────────────────────────────────────────────────
+const selectTriggerVariants = cva(
+  [
+    "flex w-full items-center justify-between gap-2",
+    "rounded-lg border bg-card text-foreground",
+    "border-input",
+    "transition-colors duration-150 ease-out",
+    "data-[placeholder]:text-neutral-400 dark:data-[placeholder]:text-neutral-500",
+    "[&>span]:line-clamp-1 [&>span]:text-left",
+    // Focus
+    "focus:outline-none",
+    "focus:border-brand-500",
+    "focus:ring-[3px] focus:ring-brand-100 dark:focus:ring-brand-900",
+    // Disabled
+    "disabled:cursor-not-allowed disabled:opacity-50 disabled:bg-muted",
+  ].join(" "),
+  {
+    variants: {
+      size: {
+        xs: "h-8 px-2.5 text-xs",
+        sm: "h-9 px-3 text-sm",
+        default: "h-10 px-3 text-sm",
+        lg: "h-11 px-3.5 text-base",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  }
+);
 
-const SelectGroup = SelectPrimitive.Group
-
-const SelectValue = SelectPrimitive.Value
+const Select = SelectPrimitive.Root;
+const SelectGroup = SelectPrimitive.Group;
+const SelectValue = SelectPrimitive.Value;
 
 const SelectTrigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> &
+    VariantProps<typeof selectTriggerVariants>
+>(({ className, size, children, ...props }, ref) => (
   <SelectPrimitive.Trigger
     ref={ref}
-    className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-slate-200 bg-white px-3 py-2 text-sm ring-offset-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 dark:border-slate-800 dark:bg-slate-950 dark:ring-offset-slate-950 dark:placeholder:text-slate-400 dark:focus:ring-slate-300",
-      className
-    )}
+    className={cn(selectTriggerVariants({ size }), className)}
     {...props}
   >
     {children}
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 opacity-50" />
+      <ChevronDown className="size-4 opacity-60" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
-))
-SelectTrigger.displayName = SelectPrimitive.Trigger?.displayName || 'SelectTrigger'
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger?.displayName ?? "SelectTrigger";
 
+// ── Scroll buttons (rare, but kept for parity with Shadcn) ─────────
 const SelectScrollUpButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
@@ -39,15 +79,15 @@ const SelectScrollUpButton = React.forwardRef<
   <SelectPrimitive.ScrollUpButton
     ref={ref}
     className={cn(
-      "flex cursor-default items-center justify-center py-1",
+      "flex cursor-default items-center justify-center py-1 text-muted-foreground",
       className
     )}
     {...props}
   >
-    <ChevronUp className="h-4 w-4" />
+    <ChevronUp className="size-4" />
   </SelectPrimitive.ScrollUpButton>
-))
-SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton?.displayName || 'SelectScrollUpButton'
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton?.displayName ?? "SelectScrollUpButton";
 
 const SelectScrollDownButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
@@ -56,16 +96,18 @@ const SelectScrollDownButton = React.forwardRef<
   <SelectPrimitive.ScrollDownButton
     ref={ref}
     className={cn(
-      "flex cursor-default items-center justify-center py-1",
+      "flex cursor-default items-center justify-center py-1 text-muted-foreground",
       className
     )}
     {...props}
   >
-    <ChevronDown className="h-4 w-4" />
+    <ChevronDown className="size-4" />
   </SelectPrimitive.ScrollDownButton>
-))
-SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton?.displayName || 'SelectScrollDownButton'
+));
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton?.displayName ?? "SelectScrollDownButton";
 
+// ── Content (popover) ──────────────────────────────────────────────
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
@@ -73,13 +115,19 @@ const SelectContent = React.forwardRef<
   <SelectPrimitive.Portal>
     <SelectPrimitive.Content
       ref={ref}
+      position={position}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-slate-200 bg-white text-slate-950 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden",
+        "rounded-lg border border-border bg-popover text-popover-foreground shadow-md",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2",
+        "data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2",
         position === "popper" &&
-          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          "data-[side=bottom]:translate-y-1 data-[side=top]:-translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1",
         className
       )}
-      position={position}
       {...props}
     >
       <SelectScrollUpButton />
@@ -95,21 +143,26 @@ const SelectContent = React.forwardRef<
       <SelectScrollDownButton />
     </SelectPrimitive.Content>
   </SelectPrimitive.Portal>
-))
-SelectContent.displayName = SelectPrimitive.Content?.displayName || 'SelectContent'
+));
+SelectContent.displayName = SelectPrimitive.Content?.displayName ?? "SelectContent";
 
+// ── Group label ────────────────────────────────────────────────────
 const SelectLabel = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Label>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    className={cn(
+      "px-2 py-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground font-mono",
+      className
+    )}
     {...props}
   />
-))
-SelectLabel.displayName = SelectPrimitive.Label?.displayName || 'SelectLabel'
+));
+SelectLabel.displayName = SelectPrimitive.Label?.displayName ?? "SelectLabel";
 
+// ── Item ───────────────────────────────────────────────────────────
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
@@ -117,33 +170,37 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-slate-100 focus:text-slate-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-slate-800 dark:focus:text-slate-50",
+      "relative flex w-full cursor-default select-none items-center",
+      "rounded-md py-1.5 pl-8 pr-2 text-sm outline-none",
+      "focus:bg-accent focus:text-accent-foreground",
+      "data-[state=checked]:bg-accent data-[state=checked]:text-accent-foreground data-[state=checked]:font-semibold",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}
   >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+    <span className="absolute left-2 flex size-4 items-center justify-center">
       <SelectPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
+        <Check className="size-3.5 text-brand-700 dark:text-brand-400" />
       </SelectPrimitive.ItemIndicator>
     </span>
-
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
   </SelectPrimitive.Item>
-))
-SelectItem.displayName = SelectPrimitive.Item?.displayName || 'SelectItem'
+));
+SelectItem.displayName = SelectPrimitive.Item?.displayName ?? "SelectItem";
 
+// ── Separator ──────────────────────────────────────────────────────
 const SelectSeparator = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-slate-100 dark:bg-slate-800", className)}
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
     {...props}
   />
-))
-SelectSeparator.displayName = SelectPrimitive.Separator?.displayName || 'SelectSeparator'
+));
+SelectSeparator.displayName = SelectPrimitive.Separator?.displayName ?? "SelectSeparator";
 
 export {
   Select,
@@ -156,4 +213,5 @@ export {
   SelectSeparator,
   SelectScrollUpButton,
   SelectScrollDownButton,
-}
+  selectTriggerVariants,
+};

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,29 +1,83 @@
-"use client"
+/**
+ * Ready Set — Switch (v2)
+ * components/ui/switch.tsx
+ *
+ * Drop-in replacement. On-state moves to brand-400 (was Shadcn primary
+ * slate-900) so toggles read as "branded on", consistent with the
+ * button system. New `sm` size for dense settings rows. Thumb gains a
+ * real shadow for tactile depth.
+ *
+ * Peer deps: react, @radix-ui/react-switch, class-variance-authority,
+ *            clsx, tailwind-merge.
+ */
+"use client";
 
-import * as React from "react"
-import * as SwitchPrimitives from "@radix-ui/react-switch"
+import * as React from "react";
+import * as SwitchPrimitive from "@radix-ui/react-switch";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
+
+const switchRootVariants = cva(
+  [
+    "peer inline-flex shrink-0 cursor-pointer items-center",
+    "rounded-full border-2 border-transparent",
+    "transition-colors duration-150 ease-out",
+    "focus-visible:outline-none",
+    "focus-visible:ring-2 focus-visible:ring-brand-500",
+    "focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+    "disabled:cursor-not-allowed disabled:opacity-50",
+    "data-[state=checked]:bg-brand-400",
+    "data-[state=unchecked]:bg-neutral-300 dark:data-[state=unchecked]:bg-neutral-600",
+  ].join(" "),
+  {
+    variants: {
+      size: {
+        sm: "h-5 w-9",
+        default: "h-6 w-11",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  }
+);
+
+const switchThumbVariants = cva(
+  [
+    "pointer-events-none block rounded-full bg-white shadow-sm",
+    "ring-0 transition-transform duration-150 ease-out",
+  ].join(" "),
+  {
+    variants: {
+      size: {
+        sm: "size-4 data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
+        default:
+          "size-5 data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  }
+);
+
+export interface SwitchProps
+  extends React.ComponentPropsWithoutRef<typeof SwitchPrimitive.Root>,
+    VariantProps<typeof switchRootVariants> {}
 
 const Switch = React.forwardRef<
-  React.ElementRef<typeof SwitchPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
->(({ className, ...props }, ref) => (
-  <SwitchPrimitives.Root
-    className={cn(
-      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-slate-900 data-[state=unchecked]:bg-slate-200 dark:focus-visible:ring-slate-300 dark:focus-visible:ring-offset-slate-950 dark:data-[state=checked]:bg-slate-50 dark:data-[state=unchecked]:bg-slate-800",
-      className
-    )}
-    {...props}
+  React.ElementRef<typeof SwitchPrimitive.Root>,
+  SwitchProps
+>(({ className, size = "default", ...props }, ref) => (
+  <SwitchPrimitive.Root
     ref={ref}
+    className={cn(switchRootVariants({ size }), className)}
+    {...props}
   >
-    <SwitchPrimitives.Thumb
-      className={cn(
-        "pointer-events-none block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0 dark:bg-slate-950"
-      )}
-    />
-  </SwitchPrimitives.Root>
-))
-Switch.displayName = SwitchPrimitives.Root.displayName
+    <SwitchPrimitive.Thumb className={cn(switchThumbVariants({ size }))} />
+  </SwitchPrimitive.Root>
+));
+Switch.displayName = SwitchPrimitive.Root?.displayName ?? "Switch";
 
-export { Switch }
+export { Switch, switchRootVariants };


### PR DESCRIPTION
## Summary

**Stacked PR on top of #413.** Drops in Claude Design's batch 1a output — refits the 6 Shadcn form atoms to consume the v2 token system landed in PR-A.

> **Base branch is `feature/REA-XXX-design-tokens-foundation`, not `development`.** When #413 merges into `development`, GitHub will auto-rebase this PR onto `development`.

## Files replaced

| Component | What changed |
|---|---|
| `Button` | `bg-brand-400` + `hover:bg-brand-500` + focus halo with `ring-brand-500`. Adds `size="xs"`/`size="icon-xs"`/`size="icon-sm"` for in-table actions, auto inline-icon sizing via `[&_svg]:size-4`, `shadow-xs` on filled variants. |
| `Input` | `Omit<…, "size">` so the new CVA size variant (`"xs"\|"sm"\|"default"\|"lg"`) wins. Adds `error` prop (aria-invalid + red border + halo). Focus matches Select geometry. **No numeric `<Input size={N}>` call sites exist** in the codebase (verified by grep). |
| `Label` | Adds `required` (red asterisk) and `tone` (`"default"\|"error"\|"muted"`) props. Tighter typography, peer-disabled cascade baked in. |
| `Select` | Trigger geometry matches Input. Lucide `Check` icon for selected items. Group label headers are uppercase mono for scannability. |
| `Checkbox` | Adds `size` variants (sm/default/lg = 14/16/18px). Checked state `bg-brand-400`, 13.2:1 contrast on the check. Lucide `Minus` for indeterminate. |
| `Switch` | Adds `size` variants (sm/default). On-state `bg-brand-400`, off-state neutral-300/600 (visible against card). Tactile thumb. |

## One defensive patch I added (not in the bundle)

The bundle's `displayName = SelectPrimitive.X.displayName` assignments crash under the Jest mocks in `jest.setup.ts` — the mock for `@radix-ui/react-select` doesn't reliably preserve `.displayName` through `React.forwardRef`. I switched all 9 such assignments across Select, Label, Checkbox, Switch to `Primitive.X?.displayName ?? "ComponentName"` — the same defensive pattern the previous `select.tsx` used at line 111 on `development`. Without this, `catering-address-form.test.tsx` fails to load.

## Visual changes (expected)

This PR **does** introduce visual changes — that's the point. Every form atom now uses brand-yellow primary surfaces, warmer neutrals, and the new focus halo. Diff is visible on:
- `/sign-in` (Button, Input, Label together)
- `/admin/users` (Select in filter UI, Button in toolbar)
- `/admin/calculator` (Switch + Checkbox in Adjust Vendor Pricing tab)
- Every form across the app

**Visual review on Vercel preview is required before merge.**

## Test plan

- [x] `pnpm pre-push-check` (typecheck + lint + prisma) ✓
- [x] `pnpm build` (Next.js production build) ✓
- [x] `pnpm test` — back to baseline (same 2 pre-existing failures as `development`: `orders/order-files` driver auth + `calculator/configurations`). No new failures.
- [ ] Vercel preview visual review against `development`
- [ ] Dark mode spot-check (new components support `.dark` via the CSS vars from PR-A; nothing in the app toggles `.dark` yet so this is purely about confirming the components don't break when the class is set)

## What's still pending

- **Batch 1b (Card, Badge, Separator, Tooltip)** — in flight with Claude Design. Will stack on top of this PR when ready.
- **Batch 1c (Table, Dialog, DropdownMenu, Tabs, Toast)** — Table file already downloaded at `~/Downloads/bundle-shadcn-1c-table/`, but rest of batch is mid-review in Claude Design. Will stack when complete.
- **PR-C (final sweep)** — legacy token removal, auth tint blue→yellow, Kabel→Montserrat for non-marketing H1/H2, base CSS rules (`:focus-visible`, `::selection`, `body { background-color: hsl(var(--background)) }`). Ships last after all batches land.

## Source

- Bundle: `/Users/ealanis/Downloads/bundle-shadcn-1a-form-atoms/`
- Bundle's INSTALL.md + migration-checklist.md in that folder for reference
- Phase-2 token foundation: PR #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)