### PR TITLE
feat(apply): require equipment photo for driver role

### DIFF
--- a/src/app/api/job-applications/route.ts
+++ b/src/app/api/job-applications/route.ts
@@ -11,9 +11,25 @@ export async function POST(request: Request) {
 
   try {
     const data = await request.json();
-    
-    // Debug log received data
-    
+
+    // --- Server-side validation for required driver documents ---
+    if (data.role === "Driver for Catering Deliveries") {
+      const missingDocs: string[] = [];
+      if (!data.driversLicenseFilePath) missingDocs.push("driver's license");
+      if (!data.insuranceFilePath) missingDocs.push("insurance");
+      if (!data.vehicleRegFilePath) missingDocs.push("vehicle registration");
+      if (!data.driverPhotoFilePath) missingDocs.push("driver photo");
+      if (!data.carPhotoFilePath) missingDocs.push("car photo");
+      if (!data.equipmentPhotoFilePath) missingDocs.push("equipment photo");
+
+      if (missingDocs.length > 0) {
+        return NextResponse.json(
+          { error: `Missing required documents: ${missingDocs.join(", ")}` },
+          { status: 400 }
+        );
+      }
+    }
+
     // --- Step 1: Identify and Fetch FileUpload Records ---
     const fileIdsToProcess = [
       data.resumeFileId,

--- a/src/components/Apply/ApplyForm.tsx
+++ b/src/components/Apply/ApplyForm.tsx
@@ -688,6 +688,9 @@ const JobApplicationForm = () => {
       if (carPhotoUpload.uploadedFiles.length === 0) {
         errors.push("Please upload your car photo");
       }
+      if (equipmentPhotoUpload.uploadedFiles.length === 0) {
+        errors.push("Please upload your equipment photo");
+      }
     }
 
     return errors;
@@ -1346,10 +1349,14 @@ const JobApplicationForm = () => {
                     <div>
                       <label className="mb-2 block text-sm font-medium text-gray-700">
                         Equipment Photo
+                        <span className="ml-2 font-normal text-gray-500">
+                          (including bags and cart)
+                        </span>
+                        <span className="ml-1 text-red-500">*</span>
                       </label>
                       <FileUpload
                         name="equipmentPhoto"
-                        label="Upload Photo (Optional)"
+                        label="Upload Photo"
                         startUpload={equipmentPhotoUpload.onUpload as any}
                         file={
                           (equipmentPhotoUpload
@@ -1541,6 +1548,12 @@ const JobApplicationForm = () => {
                         <p>
                           Car Photo:{" "}
                           {carPhotoUpload.uploadedFiles.length > 0
+                            ? "Uploaded"
+                            : "Not uploaded"}
+                        </p>
+                        <p>
+                          Equipment Photo:{" "}
+                          {equipmentPhotoUpload.uploadedFiles.length > 0
                             ? "Uploaded"
                             : "Not uploaded"}
                         </p>


### PR DESCRIPTION
## Summary

- **Equipment Photo is now required** for the "Driver for Catering Deliveries" role, matching the other five required driver documents (license, insurance, vehicle registration, driver photo, car photo)
- Added server-side validation to reject driver applications missing any of the six required documents (returns 400 with descriptive error listing all missing docs)
- Previously, Equipment Photo was optional on both client and server — this PR closes that gap

## Changes

### Frontend — `src/components/Apply/ApplyForm.tsx`

| Area | What changed |
|---|---|
| **Label markup** (Step 3) | Added helper text `(including bags and cart)` in gray and a red `*` asterisk to the Equipment Photo label |
| **FileUpload in-box label** | Changed from `"Upload Photo (Optional)"` to `"Upload Photo"` |
| **Client validation** (`validateFiles()`) | Added `equipmentPhotoUpload.uploadedFiles.length === 0` check inside the driver role block, producing error `"Please upload your equipment photo"` |
| **Step 4 review summary** | Added Equipment Photo row to the driver "Required Documents" grid showing "Uploaded" / "Not uploaded" |

### Backend — `src/app/api/job-applications/route.ts`

| Area | What changed |
|---|---|
| **Server-side validation** | Added early validation block after parsing request JSON: when `role === "Driver for Catering Deliveries"`, checks all six required document file paths (`driversLicenseFilePath`, `insuranceFilePath`, `vehicleRegFilePath`, `driverPhotoFilePath`, `carPhotoFilePath`, `equipmentPhotoFilePath`). Returns `400` with `{ error: "Missing required documents: ..." }` listing all missing docs. |

> **Note:** The backend validation covers all six driver documents, not just equipment photo. This is intentional — previously there was no server-side enforcement for any of them. This prevents bypassing the client checks.

## What is NOT changed

- File accept types (`.jpg`, `.jpeg`, `.png`), `maxFileCount`
- `FormData` / `SubmissionData` TypeScript interfaces (equipment photo fields were already wired)
- The `useJobApplicationUpload` hook configuration
- Any non-driver role behavior (resume requirement for VA/Other is untouched)
- Database schema — no migrations needed

## Testing performed

### Manual testing checklist

- [ ] **Driver role → Step 3**: red asterisk and "(including bags and cart)" helper text render on Equipment Photo label
- [ ] **Driver role → Step 3**: in-box label reads "Upload Photo" (not "Upload Photo (Optional)")
- [ ] **Driver role → Step 3 → Next** with no equipment photo uploaded: blocked with "Please upload your equipment photo" toast
- [ ] **Driver role → Step 3 → Next** with equipment photo uploaded: advances to Step 4
- [ ] **Step 4 review**: "Equipment Photo: Uploaded" appears in the Required Documents grid
- [ ] **Non-driver roles**: no change in behavior (resume still required, no equipment photo shown)
- [ ] **Backend**: POST `/api/job-applications` with `role: "Driver for Catering Deliveries"` and `equipmentPhotoFilePath: null` → returns `400` with descriptive error
- [ ] **Backend**: POST with all six documents present → proceeds normally (201)

### Automated

- `pnpm typecheck` — passes (no new errors; pre-existing errors in unrelated files)
- `pnpm lint` — passes (pre-commit hook confirmed)

## Database migrations

None. No schema changes — `equipmentPhotoFilePath` already exists on the `JobApplication` model.

## Breaking changes

None. This is additive enforcement. Existing applications already in the database are unaffected. Only new submissions from drivers are now gated.

## Reviewer checklist

- [ ] **Validation parity**: confirm `validateFiles()` in `ApplyForm.tsx` (client) and the new block in `route.ts` (server) check the same six fields
- [ ] **Error UX**: verify the toast message wording matches the existing pattern for other missing documents
- [ ] **Label styling**: confirm `(including bags and cart)` uses `font-normal text-gray-500` within the `text-sm` label (not a separate smaller element)
- [ ] **Step 4 grid**: verify Equipment Photo row renders in the same `grid-cols-2` layout as the other document rows
- [ ] **No regressions for non-driver roles**: resume-only flow unaffected


🤖 Generated with [Claude Code](https://claude.com/claude-code)