### PR TITLE
fix: silence Supabase auth lock 'steal' AbortError noise in Sentry

### DIFF
--- a/src/lib/monitoring/__tests__/sentry-filters.test.ts
+++ b/src/lib/monitoring/__tests__/sentry-filters.test.ts
@@ -1,0 +1,43 @@
+import type { ErrorEvent, EventHint } from '@sentry/nextjs';
+import { createBeforeSend } from '../sentry-filters';
+
+const beforeSend = createBeforeSend({ includeClientFilters: true });
+const noHint = {} as EventHint;
+
+function abortEvent(value: string, withAuthJsFrame = false): ErrorEvent {
+  return {
+    exception: {
+      values: [
+        {
+          type: 'AbortError',
+          value,
+          stacktrace: withAuthJsFrame
+            ? { frames: [{ filename: 'node_modules/@supabase/auth-js/dist/locks.js' }] }
+            : undefined,
+        },
+      ],
+    },
+  } as unknown as ErrorEvent;
+}
+
+describe('createBeforeSend — Supabase auth navigator-lock AbortErrors', () => {
+  it('drops the "steal" variant even with no stacktrace (READY-SET-NEXTJS-1M)', () => {
+    const event = abortEvent("Lock broken by another request with the 'steal' option.");
+    expect(beforeSend(event, noHint)).toBeNull();
+  });
+
+  it('drops the lock-timeout variant when it has auth-js frames (READY-SET-NEXTJS-1D)', () => {
+    const event = abortEvent('signal is aborted without reason', true);
+    expect(beforeSend(event, noHint)).toBeNull();
+  });
+
+  it('keeps the lock-timeout variant when it does NOT originate from auth-js', () => {
+    const event = abortEvent('signal is aborted without reason', false);
+    expect(beforeSend(event, noHint)).not.toBeNull();
+  });
+
+  it('keeps unrelated AbortErrors', () => {
+    const event = abortEvent('The user aborted a request.');
+    expect(beforeSend(event, noHint)).not.toBeNull();
+  });
+});

--- a/src/lib/monitoring/sentry-filters.ts
+++ b/src/lib/monitoring/sentry-filters.ts
@@ -89,19 +89,27 @@ function isNetworkError(event: ErrorEvent): boolean {
 }
 
 /**
- * Check if error is an AbortError from Supabase Auth's navigator lock timeout
- * This is a known issue in @supabase/auth-js where the lock acquisition abort
- * isn't caught internally, causing an unhandled rejection. Not actionable.
- * Fixes: READY-SET-NEXTJS-1D
+ * Check if error is an AbortError from Supabase Auth's navigator lock (Web Locks API).
+ * Two known variants, both caused by @supabase/auth-js not catching the lock abort
+ * internally, surfacing as an unhandled rejection. Neither is actionable (0 users impacted):
+ *   1. "signal is aborted without reason"  — lock acquisition timeout (has auth-js frames)
+ *   2. "Lock broken by another request with the 'steal' option." — a concurrent request
+ *      stole the lock; arrives as a global unhandledrejection with NO stacktrace.
+ * Fixes: READY-SET-NEXTJS-1D, READY-SET-NEXTJS-1M
  */
 function isSupabaseLockAbortError(event: ErrorEvent): boolean {
   const errorType = event.exception?.values?.[0]?.type || '';
   const errorValue = event.exception?.values?.[0]?.value || '';
 
   if (errorType !== 'AbortError') return false;
+
+  // Variant 2: "steal" — message is specific enough; it arrives with no stacktrace
+  // frames, so we must NOT require an auth-js frame here.
+  if (errorValue.includes('Lock broken by another request')) return true;
+
+  // Variant 1: lock acquisition timeout — verify it originates from auth-js locks.
   if (!errorValue.includes('signal is aborted without reason')) return false;
 
-  // Verify it originates from the Supabase auth-js locks module
   const frames = event.exception?.values?.[0]?.stacktrace?.frames || [];
   return frames.some(
     (frame: { filename?: string; module?: string }) =>


### PR DESCRIPTION
## Summary

Fixes **READY-SET-NEXTJS-1M** — `AbortError: Lock broken by another request with the 'steal' option.` — which accounted for **9,831 events (~96% of all client error volume, 0 users impacted)** in Sentry, burying real signal.

### Root cause
`isSupabaseLockAbortError()` in `src/lib/monitoring/sentry-filters.ts` only dropped the `"signal is aborted without reason"` lock-timeout variant **and** required an `@supabase/auth-js` stacktrace frame. The `"Lock broken by another request with the 'steal' option."` variant:
- has a **different message**, and
- arrives as a global `unhandledrejection` with **no stacktrace frames**,

so it failed both checks and was reported every time.

### Change
- Broaden the filter to drop the `"steal"` variant by message alone (it's specific enough, and has no frames to match against).
- Keep the existing frame-verification for the timeout variant unchanged.
- Add `src/lib/monitoring/__tests__/sentry-filters.test.ts` covering both lock variants + the keep-cases (non-auth-js abort, unrelated AbortError) to prevent another recurrence (this is the second variant of this bug — `1D` was the first).

### Validation
- `pnpm typecheck` ✅
- New test suite ✅ (4/4)
- `pnpm lint` ✅ (only pre-existing unrelated warnings)

### Out of scope
`Maximum update depth exceeded` (READY-SET-NEXTJS-1P / -E, 19 events) is a separate React/Radix composed-ref infinite loop that needs a repro or Seer (currently out of budget) to locate precisely — intentionally left for a follow-up rather than a speculative fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)