### PR TITLE
fix: stop /api/tracking/live SSE from hitting Vercel runtime timeout

### DIFF
--- a/src/app/api/tracking/live/route.ts
+++ b/src/app/api/tracking/live/route.ts
@@ -3,6 +3,14 @@ import { withAuth } from '@/lib/auth-middleware';
 import { prisma } from '@/utils/prismaDB';
 import { captureException, captureMessage } from '@/lib/monitoring/sentry';
 
+// This route returns a long-lived SSE stream. Pin the Node.js runtime (Prisma
+// requires it) and raise the function ceiling. The stream self-terminates
+// (STREAM_MAX_MS, below) before this limit elapses, so Vercel never kills it
+// with a Runtime Timeout Error — the browser EventSource then auto-reconnects.
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
 /**
  * Typed result row for the active drivers query.
  *
@@ -141,6 +149,11 @@ export async function GET(request: NextRequest) {
     // Interval and cleanup function stored in outer scope so cancel() method can access them
     let intervalId: NodeJS.Timeout | null = null;
     let cleanupFn: (() => void) | null = null;
+    let maxDurationTimeout: NodeJS.Timeout | null = null;
+    // End the stream gracefully before Vercel's maxDuration (60s) elapses so
+    // the platform never logs a Runtime Timeout Error. 50s leaves headroom;
+    // the browser EventSource reconnects automatically on a clean close.
+    const STREAM_MAX_MS = 50_000;
 
     const stream = new ReadableStream({
       start(controller) {
@@ -473,6 +486,7 @@ export async function GET(request: NextRequest) {
         // Cleanup function
         const cleanup = () => {
           if (intervalId) clearInterval(intervalId);
+          if (maxDurationTimeout) clearTimeout(maxDurationTimeout);
           try {
             controller.close();
           } catch (error) {
@@ -483,15 +497,39 @@ export async function GET(request: NextRequest) {
         // Store cleanup function in outer scope for cancel() method
         cleanupFn = cleanup;
 
+        // Proactively end the stream before Vercel's function ceiling so the
+        // platform never kills it mid-flight (which logs a Runtime Timeout
+        // Error). Signal the client first so it can reconnect cleanly; the
+        // EventSource API reconnects on its own after a normal close anyway.
+        maxDurationTimeout = setTimeout(() => {
+          try {
+            if (controller.desiredSize !== null) {
+              const reconnectMessage = `event: reconnect\ndata: ${JSON.stringify({
+                type: 'reconnect',
+                reason: 'stream_cycle',
+                timestamp: new Date().toISOString(),
+              })}\n\n`;
+              controller.enqueue(new TextEncoder().encode(reconnectMessage));
+            }
+          } catch {
+            // Controller already closing — fall through to cleanup.
+          }
+          cleanup();
+        }, STREAM_MAX_MS);
+
         // Handle client disconnect
         request.signal.addEventListener('abort', cleanup);
       },
 
       cancel() {
-        // Clean up interval and event listener when stream is cancelled
+        // Clean up interval, timeout, and event listener when stream is cancelled
         if (intervalId) {
           clearInterval(intervalId);
           intervalId = null;
+        }
+        if (maxDurationTimeout) {
+          clearTimeout(maxDurationTimeout);
+          maxDurationTimeout = null;
         }
         if (cleanupFn) {
           request.signal.removeEventListener('abort', cleanupFn);

--- a/src/hooks/tracking/__tests__/useRealTimeTracking.test.ts
+++ b/src/hooks/tracking/__tests__/useRealTimeTracking.test.ts
@@ -13,11 +13,16 @@ class MockEventSource {
   onmessage: ((event: MessageEvent) => void) | null = null;
   onerror: ((event: Event) => void) | null = null;
 
+  private listeners: Record<string, ((event: Event) => void)[]> = {};
   private static instances: MockEventSource[] = [];
 
   constructor(url: string) {
     this.url = url;
     MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, handler: (event: Event) => void) {
+    (this.listeners[type] ||= []).push(handler);
   }
 
   close() {
@@ -36,6 +41,12 @@ class MockEventSource {
 
   simulateError() {
     this.onerror?.(new Event('error'));
+  }
+
+  // Fire the server's named `reconnect` event (the /api/tracking/live ~50s
+  // stream-rotation signal) at any registered addEventListener('reconnect') handler.
+  simulateReconnectEvent() {
+    this.listeners['reconnect']?.forEach((handler) => handler(new Event('reconnect')));
   }
 
   static getLastInstance(): MockEventSource | undefined {
@@ -228,6 +239,56 @@ describe('useRealTimeTracking', () => {
       });
 
       expect(result.current.isConnected).toBe(false);
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('stays silent on the server\'s planned ~50s stream rotation', async () => {
+      // The /api/tracking/live SSE route self-closes every ~50s (Vercel
+      // maxDuration guard) and emits a `reconnect` event first. The browser
+      // auto-reconnects, so this must NOT surface a user-facing error — otherwise
+      // the admin dashboard flashes "Connection error occurred" every 50 seconds.
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { result } = renderHook(() => useRealTimeTracking());
+      const eventSource = MockEventSource.getLastInstance();
+
+      await act(async () => {
+        eventSource?.simulateOpen();
+      });
+      expect(result.current.isConnected).toBe(true);
+
+      // Server signals rotation, then the stream closes and the browser begins
+      // auto-reconnecting (readyState CONNECTING, not CLOSED).
+      await act(async () => {
+        eventSource?.simulateReconnectEvent();
+        eventSource!.readyState = MockEventSource.CONNECTING;
+        eventSource?.simulateError();
+      });
+
+      expect(result.current.error).toBeNull();
+      expect(consoleErrorSpy).not.toHaveBeenCalledWith(
+        'SSE connection error:',
+        expect.anything(),
+      );
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('still surfaces an error on an unexpected transient drop', async () => {
+      // Without a preceding `reconnect` signal, a CONNECTING-state error is a
+      // genuine unexpected blip and should stay visible.
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const { result } = renderHook(() => useRealTimeTracking());
+      const eventSource = MockEventSource.getLastInstance();
+
+      await act(async () => {
+        eventSource?.simulateOpen();
+      });
+
+      await act(async () => {
+        eventSource!.readyState = MockEventSource.CONNECTING;
+        eventSource?.simulateError();
+      });
+
+      expect(result.current.error).toBe('Connection error occurred');
       consoleErrorSpy.mockRestore();
     });
 

--- a/src/hooks/tracking/useRealTimeTracking.ts
+++ b/src/hooks/tracking/useRealTimeTracking.ts
@@ -168,6 +168,11 @@ export function useRealTimeTracking(): UseRealTimeTrackingReturn {
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const reconnectAttemptsRef = useRef(0);
   const connectRef = useRef<(() => void) | null>(null);
+  // Set when the server sends its `reconnect` event just before intentionally
+  // rotating the stream (the /api/tracking/live ~50s maxDuration guard). Lets
+  // onerror tell a planned rotation apart from an unexpected drop, so we don't
+  // flash a connection error to the admin every 50 seconds.
+  const expectingReconnectRef = useRef(false);
 
   const maxReconnectAttempts = 5;
   const baseReconnectDelay = 1000; // 1 second
@@ -199,6 +204,7 @@ export function useRealTimeTracking(): UseRealTimeTrackingReturn {
 
     try {
       setError(null);
+      expectingReconnectRef.current = false;
       const eventSource = new EventSource('/api/tracking/live');
       eventSourceRef.current = eventSource;
 
@@ -206,6 +212,7 @@ export function useRealTimeTracking(): UseRealTimeTrackingReturn {
                 setIsConnected(true);
         setError(null);
         reconnectAttemptsRef.current = 0;
+        expectingReconnectRef.current = false;
       };
 
       eventSource.onmessage = (event) => {
@@ -238,17 +245,37 @@ export function useRealTimeTracking(): UseRealTimeTrackingReturn {
         }
       };
 
+      // The server rotates the stream every ~50s (Vercel maxDuration guard) and
+      // sends this `reconnect` event just before closing. Flag it as a planned
+      // rotation so the following onerror stays silent and the browser's native
+      // auto-reconnect takes over without alarming the user.
+      eventSource.addEventListener('reconnect', () => {
+        expectingReconnectRef.current = true;
+        reconnectAttemptsRef.current = 0;
+      });
+
       eventSource.onerror = (event) => {
-        // Only log actual errors, not normal close events
-        if (eventSource.readyState !== EventSource.CLOSED) {
-          console.error('SSE connection error:', event);
-          setError('Connection error occurred');
-        }
         setIsConnected(false);
 
         if (eventSource.readyState === EventSource.CLOSED) {
+          // The browser will not retry on its own (e.g. endpoint unreachable or
+          // a non-2xx reconnect). Drive our own backoff, which only surfaces a
+          // user-facing error once the retry budget is exhausted.
+          expectingReconnectRef.current = false;
           scheduleReconnect();
+          return;
         }
+
+        // readyState CONNECTING: the browser is already auto-reconnecting.
+        if (expectingReconnectRef.current) {
+          // Planned ~50s stream rotation — expected, recover silently.
+          expectingReconnectRef.current = false;
+          return;
+        }
+
+        // Unexpected transient drop — keep it visible but soft; onopen clears it.
+        console.error('SSE connection error:', event);
+        setError('Connection error occurred');
       };
 
     } catch (connectionError) {


### PR DESCRIPTION
## Summary

Fixes the dominant entry in the Vercel error logs: **`Vercel Runtime Timeout Error: Task timed out`** firing repeatedly on `GET /api/tracking/live`.

### Root cause
`src/app/api/tracking/live/route.ts` is a Server-Sent Events endpoint that opens a `ReadableStream` and pushes driver updates on a `setInterval(…, 5000)` **indefinitely** — it only ends when the client disconnects. On Vercel, a function has a hard max duration, so the still-open stream gets force-killed mid-flight and logs a runtime timeout on **every** admin tracking connection. It's an architecture mismatch, not a query bug.

### Change
- `export const runtime = 'nodejs'` (Prisma needs it), `dynamic = 'force-dynamic'`, `maxDuration = 60`.
- Self-terminate the stream at **50s** (`STREAM_MAX_MS`): emit a `reconnect` SSE event, clear the interval, close the controller gracefully. The browser `EventSource` auto-reconnects, so live tracking continues seamlessly and Vercel never force-kills the function (no more timeout errors logged).
- Clear the new timeout in both `cleanup()` and `cancel()` alongside the existing interval teardown.

### Verification
- `pnpm typecheck` ✅
- `pnpm lint` ✅ (route clean; only pre-existing unrelated warnings)
- Full `pnpm build` not run locally (bare-worktree OOM at 4–8 GB on this machine — environmental, same as recent PRs); CI build is the gate.

### Durable follow-up (not in this PR)
The real fix is to migrate admin tracking fully onto **Supabase Realtime** (the `NEXT_PUBLIC_FF_USE_REALTIME_ADMIN_DASHBOARD` path + `driver-locations` channel already exist) and **retire this SSE route**, which also removes the per-connection DB polling. Worth a `/spec`.

### Scope note — the second error class is NOT in this PR
The logs also show `Error: require() of ES Module` on `/free-resources/[slug]`. I investigated and **ruled out** the obvious suspect (`isomorphic-dompurify` — its whole subgraph, incl. `dompurify@3` and `jsdom@27`, resolves to CommonJS). The real culprit is most likely a **Sanity** ESM package (`next-sanity@11` / `@sanity/client@7`), but the dashboard truncates the module path and the error only fires on background ISR revalidation (pages return 200 with fallback content), so it's not triggerable on demand. Fixing it blind would risk shipping a no-op. Tracking it as a separate, targeted fix once the exact module path is captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)