### PR TITLE
fix: silence Sentry tracking noise (NEXTJS-1F) + fix 3 stale test suites

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,6 +139,15 @@ SENTRY_PROJECT="your-project-name"
 # Default: 0.1 in production, 1.0 in development
 SENTRY_TRACES_SAMPLE_RATE=0.1
 
+# Sentry Environment tag (Optional but recommended for non-prod deployments)
+# Explicitly labels which environment events come from. NODE_ENV is NOT used
+# because Next.js forces it to "production" in every deployed build, which made
+# the dev deployment (development.readysetllc.com) report as "production".
+# Resolution order: NEXT_PUBLIC_SENTRY_ENVIRONMENT > NEXT_PUBLIC_VERCEL_ENV >
+# VERCEL_ENV > NODE_ENV. Set this to "development" in the ready-set-dev Vercel
+# project; production can rely on the Vercel/NODE_ENV fallback.
+NEXT_PUBLIC_SENTRY_ENVIRONMENT="development"
+
 # Instructions:
 # =============
 # 1. Create a Sentry account at https://sentry.io

--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,4 @@ src/components/Pricing/FlowerPricingLandingPageSimple.tsx
 # Bruno API test local overrides — put real keys here, never in *.bru committed files
 docs/bruno-api-tests/**/*.local.bru
 docs/bruno-api-tests/**/secrets.bru
+.vercel

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -4,7 +4,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';
-import { createBeforeSend, CLIENT_IGNORE_ERRORS } from '@/lib/monitoring/sentry-filters';
+import { createBeforeSend, getSentryEnvironment, CLIENT_IGNORE_ERRORS } from '@/lib/monitoring/sentry-filters';
 
 // Validate DSN is configured
 const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
@@ -25,8 +25,9 @@ if (!dsn) {
   Sentry.init({
     dsn,
 
-    // Environment name
-    environment: process.env.NODE_ENV,
+    // Environment name (NODE_ENV is always "production" in deployed builds;
+    // use the shared resolver so dev deploys don't report as production)
+    environment: getSentryEnvironment(),
 
     // Release tracking for better error grouping and deploy tracking
     // Uses Vercel's git commit SHA environment variables for automatic release tracking

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/nextjs';
 import type { NextRequest } from 'next/server';
 
 import { initializeMonitoring, initializeEdgeMonitoring } from './src/lib/monitoring';
-import { createBeforeSend, SERVER_IGNORE_ERRORS } from '@/lib/monitoring/sentry-filters';
+import { createBeforeSend, getSentryEnvironment, SERVER_IGNORE_ERRORS } from '@/lib/monitoring/sentry-filters';
 
 function initSentryForCurrentRuntime(): void {
   const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
@@ -22,7 +22,7 @@ function initSentryForCurrentRuntime(): void {
 
   const baseConfig = {
     dsn,
-    environment: process.env.NODE_ENV,
+    environment: getSentryEnvironment(),
     release: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA || process.env.VERCEL_GIT_COMMIT_SHA,
     tracesSampleRate: getSampleRate(),
     debug: false,

--- a/src/__tests__/api/calculator/configurations.test.ts
+++ b/src/__tests__/api/calculator/configurations.test.ts
@@ -38,6 +38,14 @@ describe('/api/calculator/configurations API', () => {
     auth: {
       getUser: jest.fn(),
     },
+    // authorizeCalculatorAdmin() resolves the caller's role via
+    // supabase.from('profiles').select('type').eq('id', …).maybeSingle().
+    // Default to an admin profile so authorized POST/DELETE paths pass.
+    from: jest.fn(() => ({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      maybeSingle: jest.fn().mockResolvedValue({ data: { type: 'super_admin' } }),
+    })),
   };
 
   beforeEach(() => {

--- a/src/__tests__/api/orders/order-files.test.ts
+++ b/src/__tests__/api/orders/order-files.test.ts
@@ -24,6 +24,9 @@ jest.mock('@/utils/prismaDB', () => ({
     onDemand: {
       findFirst: jest.fn(),
     },
+    dispatch: {
+      findFirst: jest.fn(),
+    },
     fileUpload: {
       findMany: jest.fn(),
     },
@@ -304,6 +307,9 @@ describe('GET /api/orders/[order_number]/files - Fetch Order Files', () => {
       mockSupabaseClient.auth.getUser.mockResolvedValue({
         data: { user: { id: 'user-123' } },
       });
+      // No dispatch assignment by default — the user is not the assigned driver,
+      // so access must fall through to 403 rather than the driver-access path.
+      (prisma.dispatch.findFirst as jest.Mock).mockResolvedValue(null);
     });
 
     it('should return 403 when CLIENT tries to access another user order files', async () => {

--- a/src/__tests__/lib/realtime/client.test.ts
+++ b/src/__tests__/lib/realtime/client.test.ts
@@ -82,20 +82,15 @@ process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-key';
 import {
   RealtimeClient,
   CHANNEL_ERROR_MAX_RETRIES,
-  CHANNEL_ERROR_BACKOFF_BASE_MS,
 } from '@/lib/realtime/client';
 import { REALTIME_CHANNELS, type RealtimeChannelName } from '@/lib/realtime/types';
 import type { RealtimeChannel, SupabaseClient } from '@supabase/supabase-js';
 import { createClient } from '@/utils/supabase/client';
 import { realtimeLogger } from '@/lib/logging/realtime-logger';
 
-// Helper to flush all pending microtasks (allow async auth/profile checks to complete)
+// Helper to flush all pending microtasks (allow async auth/profile checks to
+// complete, including the once-only token refresh on the first CHANNEL_ERROR retry)
 const flushPromises = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
-// Helper to wait out a CHANNEL_ERROR retry's backoff (plus a small buffer)
-const waitForBackoff = (attempt: number) =>
-  new Promise<void>((resolve) =>
-    setTimeout(resolve, CHANNEL_ERROR_BACKOFF_BASE_MS * attempt + 50),
-  );
 
 describe('RealtimeClient', () => {
   let mockSupabaseClient: any;
@@ -301,7 +296,7 @@ describe('RealtimeClient', () => {
 
       // First CHANNEL_ERROR -> retry #1 (refreshSession + backoff, no reject)
       await triggerSubscriptionAfterAuth(REALTIME_CHANNELS.DRIVER_LOCATIONS, 'CHANNEL_ERROR', error);
-      await waitForBackoff(1);
+      await flushPromises();
 
       // Auto-reconnect succeeds on the next callback invocation
       const callback = subscribeCallbacks.get(REALTIME_CHANNELS.DRIVER_LOCATIONS);
@@ -330,13 +325,13 @@ describe('RealtimeClient', () => {
 
       // Retry #1 (driven through the auth flush)
       await triggerSubscriptionAfterAuth(REALTIME_CHANNELS.DRIVER_LOCATIONS, 'CHANNEL_ERROR', error);
-      await waitForBackoff(1);
+      await flushPromises();
 
       const callback = subscribeCallbacks.get(REALTIME_CHANNELS.DRIVER_LOCATIONS)!;
       // Remaining retries (#2 .. #MAX) each back off and wait, never rejecting
       for (let attempt = 2; attempt <= CHANNEL_ERROR_MAX_RETRIES; attempt++) {
         callback('CHANNEL_ERROR', error);
-        await waitForBackoff(attempt);
+        await flushPromises();
       }
 
       // One more CHANNEL_ERROR past the retry budget -> finally rejects
@@ -368,12 +363,12 @@ describe('RealtimeClient', () => {
       const rejection = expect(subscribePromise).rejects.toThrow('Subscription failed');
 
       await triggerSubscriptionAfterAuth(REALTIME_CHANNELS.DRIVER_LOCATIONS, 'CHANNEL_ERROR', error);
-      await waitForBackoff(1);
+      await flushPromises();
 
       const callback = subscribeCallbacks.get(REALTIME_CHANNELS.DRIVER_LOCATIONS)!;
       for (let attempt = 2; attempt <= CHANNEL_ERROR_MAX_RETRIES; attempt++) {
         callback('CHANNEL_ERROR', error);
-        await waitForBackoff(attempt);
+        await flushPromises();
       }
       callback('CHANNEL_ERROR', error);
       await rejection;
@@ -694,11 +689,11 @@ describe('RealtimeClient', () => {
 
       // Retry #1 (driven through the auth flush), then exhaust the rest
       await triggerSubscriptionAfterAuth(REALTIME_CHANNELS.DRIVER_LOCATIONS, 'CHANNEL_ERROR', error);
-      await waitForBackoff(1);
+      await flushPromises();
       const callback = subscribeCallbacks.get(REALTIME_CHANNELS.DRIVER_LOCATIONS)!;
       for (let attempt = 2; attempt <= CHANNEL_ERROR_MAX_RETRIES; attempt++) {
         callback('CHANNEL_ERROR', error);
-        await waitForBackoff(attempt);
+        await flushPromises();
       }
       // One past the budget -> rejects and records error state
       callback('CHANNEL_ERROR', error);

--- a/src/__tests__/lib/realtime/client.test.ts
+++ b/src/__tests__/lib/realtime/client.test.ts
@@ -79,13 +79,23 @@ process.env.NODE_ENV = 'test';
 process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
 process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-key';
 
-import { RealtimeClient } from '@/lib/realtime/client';
+import {
+  RealtimeClient,
+  CHANNEL_ERROR_MAX_RETRIES,
+  CHANNEL_ERROR_BACKOFF_BASE_MS,
+} from '@/lib/realtime/client';
 import { REALTIME_CHANNELS, type RealtimeChannelName } from '@/lib/realtime/types';
 import type { RealtimeChannel, SupabaseClient } from '@supabase/supabase-js';
 import { createClient } from '@/utils/supabase/client';
+import { realtimeLogger } from '@/lib/logging/realtime-logger';
 
 // Helper to flush all pending microtasks (allow async auth/profile checks to complete)
 const flushPromises = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+// Helper to wait out a CHANNEL_ERROR retry's backoff (plus a small buffer)
+const waitForBackoff = (attempt: number) =>
+  new Promise<void>((resolve) =>
+    setTimeout(resolve, CHANNEL_ERROR_BACKOFF_BASE_MS * attempt + 50),
+  );
 
 describe('RealtimeClient', () => {
   let mockSupabaseClient: any;
@@ -275,7 +285,37 @@ describe('RealtimeClient', () => {
       expect(client.isConnected(REALTIME_CHANNELS.DRIVER_LOCATIONS)).toBe(true);
     });
 
-    it('should handle subscription errors', async () => {
+    it('should retry transient CHANNEL_ERROR and resolve when it recovers', async () => {
+      // A single CHANNEL_ERROR is usually a Realtime tenant cold-start blip;
+      // the channel recovers on the next status callback and must NOT reject.
+      const client = RealtimeClient.getInstance();
+      const onConnect = jest.fn();
+      const onError = jest.fn();
+      const error = new Error('transient cold-start');
+
+      const subscribePromise = client.subscribe(
+        REALTIME_CHANNELS.DRIVER_LOCATIONS,
+        undefined,
+        { onConnect, onError }
+      );
+
+      // First CHANNEL_ERROR -> retry #1 (refreshSession + backoff, no reject)
+      await triggerSubscriptionAfterAuth(REALTIME_CHANNELS.DRIVER_LOCATIONS, 'CHANNEL_ERROR', error);
+      await waitForBackoff(1);
+
+      // Auto-reconnect succeeds on the next callback invocation
+      const callback = subscribeCallbacks.get(REALTIME_CHANNELS.DRIVER_LOCATIONS);
+      if (callback) callback('SUBSCRIBED');
+
+      await expect(subscribePromise).resolves.toBeDefined();
+      expect(onConnect).toHaveBeenCalled();
+      expect(onError).not.toHaveBeenCalled();
+      expect(client.isConnected(REALTIME_CHANNELS.DRIVER_LOCATIONS)).toBe(true);
+      // Token refreshed exactly once, on the first retry
+      expect(mockSupabaseClient.auth.refreshSession).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reject only after exhausting CHANNEL_ERROR retries', async () => {
       const client = RealtimeClient.getInstance();
       const onError = jest.fn();
       const error = new Error('Subscription failed');
@@ -285,18 +325,71 @@ describe('RealtimeClient', () => {
         undefined,
         { onError }
       );
+      // Attach the rejection expectation up-front to avoid an unhandled rejection
+      const rejection = expect(subscribePromise).rejects.toThrow('Subscription failed');
 
-      // First CHANNEL_ERROR triggers a retry (refreshSession + return)
+      // Retry #1 (driven through the auth flush)
       await triggerSubscriptionAfterAuth(REALTIME_CHANNELS.DRIVER_LOCATIONS, 'CHANNEL_ERROR', error);
-      // Wait for the async refreshSession inside the callback to complete
-      await flushPromises();
-      // Second CHANNEL_ERROR actually rejects
-      const callback = subscribeCallbacks.get(REALTIME_CHANNELS.DRIVER_LOCATIONS);
-      if (callback) callback('CHANNEL_ERROR', error);
+      await waitForBackoff(1);
 
-      await expect(subscribePromise).rejects.toThrow('Subscription failed');
+      const callback = subscribeCallbacks.get(REALTIME_CHANNELS.DRIVER_LOCATIONS)!;
+      // Remaining retries (#2 .. #MAX) each back off and wait, never rejecting
+      for (let attempt = 2; attempt <= CHANNEL_ERROR_MAX_RETRIES; attempt++) {
+        callback('CHANNEL_ERROR', error);
+        await waitForBackoff(attempt);
+      }
+
+      // One more CHANNEL_ERROR past the retry budget -> finally rejects
+      callback('CHANNEL_ERROR', error);
+
+      await rejection;
       expect(onError).toHaveBeenCalled();
       expect(client.isConnected(REALTIME_CHANNELS.DRIVER_LOCATIONS)).toBe(false);
+      // Token refreshed only once across all retries
+      expect(mockSupabaseClient.auth.refreshSession).toHaveBeenCalledTimes(1);
+    });
+
+    it('should log exhausted CHANNEL_ERROR as warn (not error) to keep Sentry quiet', async () => {
+      // Regression for Sentry READY-SET-NEXTJS-1F: the post-retry failure must
+      // be a warning (no Sentry capture), mirroring TIMED_OUT, since the UI
+      // still falls back via onError. The old 'Channel subscription error'
+      // error-level log must be gone.
+      const warnSpy = jest.spyOn(realtimeLogger, 'warn');
+      const errorSpy = jest.spyOn(realtimeLogger, 'error');
+
+      const client = RealtimeClient.getInstance();
+      const error = new Error('Subscription failed');
+
+      const subscribePromise = client.subscribe(
+        REALTIME_CHANNELS.DRIVER_LOCATIONS,
+        undefined,
+        { onError: jest.fn() }
+      );
+      const rejection = expect(subscribePromise).rejects.toThrow('Subscription failed');
+
+      await triggerSubscriptionAfterAuth(REALTIME_CHANNELS.DRIVER_LOCATIONS, 'CHANNEL_ERROR', error);
+      await waitForBackoff(1);
+
+      const callback = subscribeCallbacks.get(REALTIME_CHANNELS.DRIVER_LOCATIONS)!;
+      for (let attempt = 2; attempt <= CHANNEL_ERROR_MAX_RETRIES; attempt++) {
+        callback('CHANNEL_ERROR', error);
+        await waitForBackoff(attempt);
+      }
+      callback('CHANNEL_ERROR', error);
+      await rejection;
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Channel subscription failed after retries - may fallback to SSE',
+        expect.objectContaining({ channelName: REALTIME_CHANNELS.DRIVER_LOCATIONS }),
+      );
+      // The noisy error-level log that fed Sentry NEXTJS-1F is gone
+      expect(errorSpy).not.toHaveBeenCalledWith(
+        'Channel subscription error',
+        expect.anything(),
+      );
+
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
     });
 
     it('should handle subscription timeout', async () => {
@@ -597,14 +690,20 @@ describe('RealtimeClient', () => {
       const error = new Error('Connection failed');
 
       const subscribePromise = client.subscribe(REALTIME_CHANNELS.DRIVER_LOCATIONS);
-      // First CHANNEL_ERROR triggers retry
-      await triggerSubscriptionAfterAuth(REALTIME_CHANNELS.DRIVER_LOCATIONS, 'CHANNEL_ERROR', error);
-      await flushPromises();
-      // Second CHANNEL_ERROR actually rejects
-      const callback = subscribeCallbacks.get(REALTIME_CHANNELS.DRIVER_LOCATIONS);
-      if (callback) callback('CHANNEL_ERROR', error);
+      const rejection = expect(subscribePromise).rejects.toThrow();
 
-      await expect(subscribePromise).rejects.toThrow();
+      // Retry #1 (driven through the auth flush), then exhaust the rest
+      await triggerSubscriptionAfterAuth(REALTIME_CHANNELS.DRIVER_LOCATIONS, 'CHANNEL_ERROR', error);
+      await waitForBackoff(1);
+      const callback = subscribeCallbacks.get(REALTIME_CHANNELS.DRIVER_LOCATIONS)!;
+      for (let attempt = 2; attempt <= CHANNEL_ERROR_MAX_RETRIES; attempt++) {
+        callback('CHANNEL_ERROR', error);
+        await waitForBackoff(attempt);
+      }
+      // One past the budget -> rejects and records error state
+      callback('CHANNEL_ERROR', error);
+
+      await rejection;
 
       const state = client.getConnectionState(REALTIME_CHANNELS.DRIVER_LOCATIONS);
       expect(state.state).toBe('error');

--- a/src/components/CateringRequest/__tests__/CateringRequestForm.test.tsx
+++ b/src/components/CateringRequest/__tests__/CateringRequestForm.test.tsx
@@ -263,9 +263,10 @@ describe("CateringRequestForm", () => {
       render(<CateringRequestForm />);
     });
 
-    // Check that key form elements are rendered
-    // There are 2 AddressSelectors (pickup and delivery)
-    expect(screen.getAllByTestId("mock-address-manager")).toHaveLength(2);
+    // Check that key form elements are rendered.
+    // The redesigned form renders ONE unified AddressSelector that takes both
+    // pickup and delivery props (was two separate selectors before the redesign).
+    expect(screen.getAllByTestId("mock-address-manager")).toHaveLength(1);
     // Form labels - component uses "Brokerage / Direct" label
     expect(screen.getByLabelText(/brokerage/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/order number/i)).toBeInTheDocument();

--- a/src/lib/monitoring/__tests__/sentry-filters.test.ts
+++ b/src/lib/monitoring/__tests__/sentry-filters.test.ts
@@ -1,5 +1,5 @@
 import type { ErrorEvent, EventHint } from '@sentry/nextjs';
-import { createBeforeSend } from '../sentry-filters';
+import { createBeforeSend, getSentryEnvironment } from '../sentry-filters';
 
 const beforeSend = createBeforeSend({ includeClientFilters: true });
 const noHint = {} as EventHint;
@@ -39,5 +39,66 @@ describe('createBeforeSend — Supabase auth navigator-lock AbortErrors', () => 
   it('keeps unrelated AbortErrors', () => {
     const event = abortEvent('The user aborted a request.');
     expect(beforeSend(event, noHint)).not.toBeNull();
+  });
+});
+
+describe('getSentryEnvironment — environment tag resolution', () => {
+  const ENV_KEYS = [
+    'NEXT_PUBLIC_SENTRY_ENVIRONMENT',
+    'NEXT_PUBLIC_VERCEL_ENV',
+    'VERCEL_ENV',
+    'NODE_ENV',
+  ] as const;
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = {};
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  it('prefers the explicit NEXT_PUBLIC_SENTRY_ENVIRONMENT override', () => {
+    process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT = 'development';
+    process.env.NEXT_PUBLIC_VERCEL_ENV = 'production';
+    process.env.NODE_ENV = 'production';
+    expect(getSentryEnvironment()).toBe('development');
+  });
+
+  it('falls back to NEXT_PUBLIC_VERCEL_ENV in the browser bundle', () => {
+    process.env.NEXT_PUBLIC_VERCEL_ENV = 'preview';
+    process.env.NODE_ENV = 'production';
+    expect(getSentryEnvironment()).toBe('preview');
+  });
+
+  it('falls back to VERCEL_ENV on server/edge when no public var is set', () => {
+    process.env.VERCEL_ENV = 'preview';
+    process.env.NODE_ENV = 'production';
+    expect(getSentryEnvironment()).toBe('preview');
+  });
+
+  it('does NOT report production from NODE_ENV alone when a Vercel env is present', () => {
+    // The core NEXTJS-1F mis-tag: dev deploy had NODE_ENV=production but
+    // VERCEL_ENV=preview — it must not surface as "production".
+    process.env.VERCEL_ENV = 'preview';
+    process.env.NODE_ENV = 'production';
+    expect(getSentryEnvironment()).not.toBe('production');
+  });
+
+  it('uses NODE_ENV only as a local-dev fallback', () => {
+    process.env.NODE_ENV = 'development';
+    expect(getSentryEnvironment()).toBe('development');
+  });
+
+  it('defaults to development when nothing is set', () => {
+    expect(getSentryEnvironment()).toBe('development');
   });
 });

--- a/src/lib/monitoring/sentry-filters.ts
+++ b/src/lib/monitoring/sentry-filters.ts
@@ -8,6 +8,36 @@
 import type { ErrorEvent, EventHint } from '@sentry/nextjs';
 
 /**
+ * Resolve the Sentry `environment` tag, shared by the client, server, and edge
+ * Sentry.init() sites so they always agree.
+ *
+ * `process.env.NODE_ENV` is NOT a usable signal here: Next.js forces it to
+ * `'production'` for every `next build` output, so the dev deployment
+ * (development.readysetllc.com) reported `environment: production` and its
+ * noise polluted the production Sentry environment.
+ *
+ * Resolution order (first defined wins):
+ *   1. NEXT_PUBLIC_SENTRY_ENVIRONMENT — explicit per-deployment override. Set
+ *      this to `development` in the ready-set-dev Vercel project. It is the only
+ *      fully reliable signal when a custom domain is served by a "production"
+ *      Vercel deployment of a non-prod project.
+ *   2. NEXT_PUBLIC_VERCEL_ENV / VERCEL_ENV — Vercel's env ('production' |
+ *      'preview' | 'development'). The NEXT_PUBLIC_ variant is the only one
+ *      readable in the browser bundle (requires Vercel's "expose system env
+ *      vars" setting); VERCEL_ENV covers server/edge runtimes.
+ *   3. NODE_ENV — local-dev fallback only.
+ */
+export function getSentryEnvironment(): string {
+  return (
+    process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ||
+    process.env.NEXT_PUBLIC_VERCEL_ENV ||
+    process.env.VERCEL_ENV ||
+    process.env.NODE_ENV ||
+    'development'
+  );
+}
+
+/**
  * Custom filter function type
  */
 export type CustomFilter = (event: ErrorEvent, hint: EventHint) => boolean;

--- a/src/lib/realtime/client.ts
+++ b/src/lib/realtime/client.ts
@@ -30,18 +30,17 @@ import { createClient as createBrowserClient } from '@/utils/supabase/client';
 // Environment validation is handled by the browser client in @/utils/supabase/client
 
 /**
- * CHANNEL_ERROR retry tuning.
+ * CHANNEL_ERROR retry budget.
  *
  * Supabase Realtime shuts the tenant down when idle and takes ~100-300ms to
  * cold-start its replication connection. The first subscribe after an idle
  * period races that boot window: the WebSocket closes mid-join and every
- * subscribed channel receives a transient CHANNEL_ERROR. A single immediate
- * retry frequently lands inside the same boot window and also fails, so we
- * retry a few times with incremental backoff before treating it as real.
- * See Sentry READY-SET-NEXTJS-1F.
+ * subscribed channel receives a transient CHANNEL_ERROR. The SDK auto-reconnects
+ * the socket (on its own rejoin backoff) and re-invokes the status callback, so
+ * a single CHANNEL_ERROR is usually noise. We tolerate a few of them before
+ * treating the failure as real. See Sentry READY-SET-NEXTJS-1F.
  */
 export const CHANNEL_ERROR_MAX_RETRIES = 3;
-export const CHANNEL_ERROR_BACKOFF_BASE_MS = 300;
 
 // ============================================================================
 // Authorization
@@ -470,19 +469,17 @@ export class RealtimeClient {
             resolve(channel);
           } else if (status === 'CHANNEL_ERROR') {
             // CHANNEL_ERROR is usually a transient Realtime tenant cold-start
-            // (see CHANNEL_ERROR_MAX_RETRIES note). Retry with incremental
-            // backoff before failing. Supabase auto-reconnects the socket and
-            // re-invokes this callback, so we refresh the token once (covers
-            // expired-token closes) and wait for the next status.
+            // (see CHANNEL_ERROR_MAX_RETRIES note). Supabase auto-reconnects the
+            // socket on its own rejoin backoff and re-invokes this callback, so
+            // we just cap how many CHANNEL_ERRORs we tolerate and refresh the
+            // token once (covers expired-token closes) before giving up.
             if (channelErrorRetries < CHANNEL_ERROR_MAX_RETRIES) {
               channelErrorRetries++;
-              const backoffMs = CHANNEL_ERROR_BACKOFF_BASE_MS * channelErrorRetries;
-              realtimeLogger.warn('Channel error, retrying with backoff', {
+              realtimeLogger.warn('Channel error, retrying', {
                 channelName,
                 metadata: {
                   attempt: channelErrorRetries,
                   maxRetries: CHANNEL_ERROR_MAX_RETRIES,
-                  backoffMs,
                 },
                 error,
               });
@@ -499,9 +496,7 @@ export class RealtimeClient {
                 }
               }
 
-              // Space out reconnect attempts so we don't burn every retry
-              // inside the same cold-start window.
-              await new Promise((r) => setTimeout(r, backoffMs));
+              // Wait for the SDK's next reconnect attempt to re-invoke this callback.
               return;
             }
 

--- a/src/lib/realtime/client.ts
+++ b/src/lib/realtime/client.ts
@@ -29,6 +29,20 @@ import { createClient as createBrowserClient } from '@/utils/supabase/client';
 
 // Environment validation is handled by the browser client in @/utils/supabase/client
 
+/**
+ * CHANNEL_ERROR retry tuning.
+ *
+ * Supabase Realtime shuts the tenant down when idle and takes ~100-300ms to
+ * cold-start its replication connection. The first subscribe after an idle
+ * period races that boot window: the WebSocket closes mid-join and every
+ * subscribed channel receives a transient CHANNEL_ERROR. A single immediate
+ * retry frequently lands inside the same boot window and also fails, so we
+ * retry a few times with incremental backoff before treating it as real.
+ * See Sentry READY-SET-NEXTJS-1F.
+ */
+export const CHANNEL_ERROR_MAX_RETRIES = 3;
+export const CHANNEL_ERROR_BACKOFF_BASE_MS = 300;
+
 // ============================================================================
 // Authorization
 // ============================================================================
@@ -432,7 +446,7 @@ export class RealtimeClient {
       userType: effectiveUserContext.userType,
     });
 
-    let hasRetriedOnError = false;
+    let channelErrorRetries = 0;
 
     return new Promise((resolve, reject) => {
       channel
@@ -455,24 +469,40 @@ export class RealtimeClient {
             callbacks?.onConnect?.();
             resolve(channel);
           } else if (status === 'CHANNEL_ERROR') {
-            // Retry once with a token refresh before failing
-            if (!hasRetriedOnError) {
-              hasRetriedOnError = true;
-              realtimeLogger.warn('Channel error, attempting token refresh and retry', {
+            // CHANNEL_ERROR is usually a transient Realtime tenant cold-start
+            // (see CHANNEL_ERROR_MAX_RETRIES note). Retry with incremental
+            // backoff before failing. Supabase auto-reconnects the socket and
+            // re-invokes this callback, so we refresh the token once (covers
+            // expired-token closes) and wait for the next status.
+            if (channelErrorRetries < CHANNEL_ERROR_MAX_RETRIES) {
+              channelErrorRetries++;
+              const backoffMs = CHANNEL_ERROR_BACKOFF_BASE_MS * channelErrorRetries;
+              realtimeLogger.warn('Channel error, retrying with backoff', {
                 channelName,
+                metadata: {
+                  attempt: channelErrorRetries,
+                  maxRetries: CHANNEL_ERROR_MAX_RETRIES,
+                  backoffMs,
+                },
                 error,
               });
 
-              try {
-                await this.supabase.auth.refreshSession();
-                // Supabase Realtime will auto-reconnect with the new token
-                return;
-              } catch (refreshError) {
-                realtimeLogger.error('Token refresh failed during channel error retry', {
-                  channelName,
-                  error: refreshError,
-                });
+              // Refresh the auth token once, on the first retry.
+              if (channelErrorRetries === 1) {
+                try {
+                  await this.supabase.auth.refreshSession();
+                } catch (refreshError) {
+                  realtimeLogger.warn('Token refresh failed during channel error retry', {
+                    channelName,
+                    error: refreshError,
+                  });
+                }
               }
+
+              // Space out reconnect attempts so we don't burn every retry
+              // inside the same cold-start window.
+              await new Promise((r) => setTimeout(r, backoffMs));
+              return;
             }
 
             const connectionError = new RealtimeConnectionError(
@@ -488,9 +518,13 @@ export class RealtimeClient {
             // Track error in metrics
             this.recordError(channelName, connectionError);
 
-            realtimeLogger.error('Channel subscription error', {
+            // Log as warning (not error) so transient cold-start churn that
+            // recovers via auto-reconnect / SSE fallback doesn't flood Sentry.
+            // Mirrors the TIMED_OUT handling below; the failure is still
+            // surfaced to callers via onError + reject. (Sentry NEXTJS-1F)
+            realtimeLogger.warn('Channel subscription failed after retries - may fallback to SSE', {
               channelName,
-              error: connectionError,
+              metadata: { retries: channelErrorRetries },
             });
 
             callbacks?.onError?.(connectionError);


### PR DESCRIPTION
## Summary

Targets Sentry issue **READY-SET-NEXTJS-1F** (`RealtimeConnectionError: Failed to subscribe to channel`) and fixes three pre-existing test failures discovered during ship.

**Realtime resilience (`3a8e686b`, `7ddd862a`)**
- Root cause (confirmed via Supabase Realtime logs on both `rs-dev` and `ready-set-web`): the Realtime tenant is shut down when idle and takes ~100-300ms to cold-start its replication connection. The first subscribe after idle races that boot window — the WebSocket closes mid-join (`_onConnClose` → `_triggerChanError`) and every channel gets a transient `CHANNEL_ERROR`. The old handler retried **once, immediately**, so the retry landed in the same boot window and also failed, then logged at `error` level → Sentry.
- `src/lib/realtime/client.ts` now tolerates up to 3 `CHANNEL_ERROR`s before failing, refreshing the token once on the first retry, and **downgrades the post-retry failure from `error` to `warn`** (mirrors the existing `TIMED_OUT` handling). The failure is still surfaced to callers via `onError` + reject and recorded in metrics — only the Sentry capture is silenced. DB remains the source of truth for status, so no driver-workflow data is at risk.
- Pre-landing review follow-up (`7ddd862a`): the original patch added a manual `await setTimeout(backoffMs)` before returning from the `CHANNEL_ERROR` handler with a comment claiming it "spaced out reconnect attempts." It did not — Supabase's phoenix channel drives reconnect on its own rejoin backoff and ignores this callback's return. Removed the no-op delay, the now-unused `CHANNEL_ERROR_BACKOFF_BASE_MS` constant, and the misleading comment. The retry budget (max 3) still bounds failure; runtime behavior is identical.

**Sentry environment mis-tag (`72eb586f`)**
- Both `instrumentation.ts` and `instrumentation-client.ts` used `environment: process.env.NODE_ENV`, which Next.js forces to `"production"` in **every** deployed build. As a result `development.readysetllc.com` reported `environment: production`.
- Added shared `getSentryEnvironment()` in `sentry-filters.ts` (resolution order: `NEXT_PUBLIC_SENTRY_ENVIRONMENT` > `NEXT_PUBLIC_VERCEL_ENV` > `VERCEL_ENV` > `NODE_ENV`), used in both inits, documented in `.env.example`.
- ⚠️ **Action required:** set `NEXT_PUBLIC_SENTRY_ENVIRONMENT=development` in the **ready-set-dev** Vercel project so the dev deploy stops reporting as production. (Note: in the browser bundle `VERCEL_ENV` is server-only and `NODE_ENV` is inlined to `production`, so this env var — or `NEXT_PUBLIC_VERCEL_ENV` via Vercel's "expose system env vars" — is what makes the client-side tag correct.)

**Pre-existing test fixes (`159d666f`)** — three suites were red on `development`, all stale tests not updated when their source changed (none caused by this branch):
- `order-files`: route added a driver-access check via `prisma.dispatch.findFirst`, but the test's prisma mock had no `dispatch` model. Added the mock model.
- `calculator/configurations`: `authorizeCalculatorAdmin` now resolves role via `supabase.from('profiles')…`, but the mock client only had `auth.getUser`. Added a `from()` chain.
- `CateringRequestForm`: the AddressSelector redesign unified pickup+delivery into one selector; updated the assertion from 2 nodes to 1.

**Housekeeping (`0851d395`)** — ignore the `.vercel` CLI directory.

## Test Coverage
- `src/lib/realtime/client.ts`: regression tests for transient recovery, retry exhaustion, and warn-not-error on exhaustion in `client.test.ts`. Tests simplified alongside `7ddd862a` (dropped the backoff-wait helper since there's no longer a delay to wait on).
- `sentry-filters.ts`: +6 tests for `getSentryEnvironment` precedence including the production mis-tag guard.
- Affected suites verified locally this ship: realtime client, sentry-filters, order-files, calculator/configurations — **93/93 passing**. Realtime suite runtime dropped ~7s → 0.87s after removing the real-timer backoff waits.

## Pre-Landing Review
Ran `/review` this session: full checklist (no SQL/shell/LLM trust-boundary surface, no new enum values), 3 specialist subagents (testing, maintainability, adversarial), and cross-model adversarial synthesis. One actionable finding — the no-op backoff delay + misleading comment — was fixed in `7ddd862a`. Remaining items are by-design tradeoffs noted inline (warn-level observability is the intent of the PR; the browser env-tag fallback is covered by the action item above). No critical issues.

## Versioning
No `package.json`/`CHANGELOG.md` edits — **release-please owns versioning** in this repo (conventional commits drive the bump on the next `development → main` sync).

## Notes
- Base branch is `development` per repo convention.
- Not on apex until the next `development → main` promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)