### PR TITLE
ci: build production image in CI and push to GHCR (self-host migration)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,44 @@
+# Keep the build context small + avoid leaking local state into the image.
+# (Without this, the 6 GB .next cache and node_modules get sent to the daemon.)
+
+# Dependencies & build output (rebuilt inside the image)
+node_modules
+.next
+out
+build
+dist
+
+# Local env / secrets — set these as Build Args / runtime env in Dokploy instead
+.env
+.env.*
+!.env.example
+
+# VCS & CI
+.git
+.gitignore
+.github
+.vercel
+
+# Tests, coverage, e2e artifacts (not needed at runtime)
+coverage
+playwright-report
+test-results
+.auth
+e2e
+
+# Editor / OS cruft
+.vscode
+.idea
+.DS_Store
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Docker meta
+Dockerfile
+.dockerignore
+
+# Misc local-only
+.husky
+*.local

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,105 @@
+name: Build & Push Image
+
+# Builds the production Docker image in CI (off the VPS) and pushes it to GHCR.
+# An existing Coolify host then pulls and runs the prebuilt image — so no
+# `next build` ever runs on the server. This is the replacement for Vercel's
+# (billed) build step.
+#
+# Required repo config (Settings -> Secrets and variables -> Actions):
+#   Variables (non-secret, baked into the client bundle at build time):
+#     NEXT_PUBLIC_SUPABASE_URL
+#     NEXT_PUBLIC_FF_USE_REALTIME_LOCATION_UPDATES
+#     NEXT_PUBLIC_FF_USE_REALTIME_ADMIN_DASHBOARD
+#     NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
+#     NEXT_PUBLIC_SENTRY_ENVIRONMENT
+#   Secrets:
+#     NEXT_PUBLIC_SUPABASE_ANON_KEY   (public anon key, but kept as secret)
+#     NEXT_PUBLIC_SENTRY_DSN
+#     BUILD_DATABASE_URL              (optional: only if pages hit the DB at build)
+#     BUILD_DIRECT_URL                (optional)
+#     COOLIFY_DEPLOY_WEBHOOK          (optional: Coolify app's deploy webhook URL)
+#     COOLIFY_API_TOKEN               (optional: bearer token for the webhook)
+#
+# NOTE: runtime server secrets (real DATABASE_URL, Supabase service key, Stripe,
+# SendGrid/Resend, Cloudinary, etc.) are set in COOLIFY's env, NOT here — they
+# are not needed to build the image.
+
+on:
+  push:
+    branches: [main, development]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }} # ReadySet1/ready-set -> ghcr.io/readyset1/ready-set
+
+jobs:
+  build-and-push:
+    name: Build and push to GHCR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha,format=short
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          # Serving host is the x86_64 Coolify box. If you later serve on the
+          # arm64 box, change this to linux/arm64 (or both, comma-separated).
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            NEXT_PUBLIC_SUPABASE_URL=${{ vars.NEXT_PUBLIC_SUPABASE_URL }}
+            NEXT_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+            NEXT_PUBLIC_FF_USE_REALTIME_LOCATION_UPDATES=${{ vars.NEXT_PUBLIC_FF_USE_REALTIME_LOCATION_UPDATES }}
+            NEXT_PUBLIC_FF_USE_REALTIME_ADMIN_DASHBOARD=${{ vars.NEXT_PUBLIC_FF_USE_REALTIME_ADMIN_DASHBOARD }}
+            NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=${{ vars.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN }}
+            NEXT_PUBLIC_SENTRY_DSN=${{ secrets.NEXT_PUBLIC_SENTRY_DSN }}
+            NEXT_PUBLIC_SENTRY_ENVIRONMENT=${{ vars.NEXT_PUBLIC_SENTRY_ENVIRONMENT }}
+            DATABASE_URL=${{ secrets.BUILD_DATABASE_URL }}
+            DIRECT_URL=${{ secrets.BUILD_DIRECT_URL }}
+
+      # Optional: tell Coolify to pull + redeploy the new image (closes the loop,
+      # giving you the Vercel-like "push -> live" flow). Safe to omit if you'd
+      # rather click Deploy in Coolify. No-op unless the webhook secret is set.
+      - name: Trigger Coolify redeploy
+        if: github.ref == 'refs/heads/main'
+        env:
+          WEBHOOK: ${{ secrets.COOLIFY_DEPLOY_WEBHOOK }}
+          TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+        run: |
+          if [ -z "$WEBHOOK" ]; then
+            echo "COOLIFY_DEPLOY_WEBHOOK not set — skipping auto-redeploy (deploy manually in Coolify)."
+            exit 0
+          fi
+          curl --fail --silent --show-error -X GET \
+            -H "Authorization: Bearer ${TOKEN}" \
+            "$WEBHOOK"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,72 +1,115 @@
-# syntax=docker.io/docker/dockerfile:1
+# syntax=docker/dockerfile:1.7
+#
+# Multi-stage production image for the Ready Set Next.js app.
+# - Uses Next.js standalone output (next.config -> output: "standalone").
+# - Debian "bookworm-slim" (glibc) base so Prisma's default `native` engine
+#   target works without adding binaryTargets to schema.prisma. Builds and runs
+#   on the SAME base image + arch, so this image is correct on both x86_64 and
+#   arm64 (the Hetzner ARM target box) when built natively on that host.
+# - pnpm pinned via corepack to match package.json "packageManager".
+#
+# Build is the memory-heavy step: the app's `build` script sets
+# NODE_OPTIONS=--max-old-space-size=4096. On an 8 GB host make sure swap is
+# enabled (see the migration plan) or the build can be OOM-killed.
 
-FROM node:18-alpine AS base
+ARG NODE_IMAGE=node:22-bookworm-slim
 
-# Install dependencies only when needed
-FROM base AS deps
-# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add --no-cache libc6-compat
+# ---------- deps: install node_modules only (cached layer) ----------
+FROM ${NODE_IMAGE} AS deps
 WORKDIR /app
 
-# Copy package files and required directories for installation
-COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* ./
-COPY prisma ./prisma
-COPY scripts ./scripts
+# Prisma needs openssl at install/generate time.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
-# Install dependencies based on the preferred package manager
-RUN \
-  if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
-  elif [ -f package-lock.json ]; then npm ci; \
-  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
-  else echo "Lockfile not found." && exit 1; \
-  fi
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+# Skip the postinstall `prisma generate` here; we run it explicitly in builder
+# once the full schema is present.
+ENV PRISMA_SKIP_POSTINSTALL_GENERATE=true
+RUN corepack enable
 
+COPY package.json pnpm-lock.yaml .npmrc* ./
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile
 
-# Rebuild the source code only when needed
-FROM base AS builder
+# ---------- builder: prisma generate + next build ----------
+FROM ${NODE_IMAGE} AS builder
 WORKDIR /app
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+RUN corepack enable
+
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-# Next.js collects completely anonymous telemetry data about general usage.
-# Learn more here: https://nextjs.org/telemetry
-# Uncomment the following line in case you want to disable telemetry during the build.
-ENV NEXT_TELEMETRY_DISABLED=1
-# Disable Husky during build to avoid git-related errors
-ENV HUSKY=0
+# --- Build-time public env (Next.js inlines NEXT_PUBLIC_* at build) ---
+# Set these as Build Args in Dokploy (Application -> Build -> Build Args).
+# They MUST be present at build time or the client bundle ships with blanks.
+ARG NEXT_PUBLIC_SUPABASE_URL
+ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
+ARG NEXT_PUBLIC_FF_USE_REALTIME_LOCATION_UPDATES
+ARG NEXT_PUBLIC_FF_USE_REALTIME_ADMIN_DASHBOARD
+ARG NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
+ARG NEXT_PUBLIC_SENTRY_DSN
+ARG NEXT_PUBLIC_SENTRY_ENVIRONMENT
+# Some pages may read these during `next build` (static generation / data collect).
+ARG DATABASE_URL
+ARG DIRECT_URL
 
-RUN \
-  if [ -f yarn.lock ]; then yarn run build; \
-  elif [ -f package-lock.json ]; then npm run build; \
-  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
-  else echo "Lockfile not found." && exit 1; \
-  fi
+ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL \
+    NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY \
+    NEXT_PUBLIC_FF_USE_REALTIME_LOCATION_UPDATES=$NEXT_PUBLIC_FF_USE_REALTIME_LOCATION_UPDATES \
+    NEXT_PUBLIC_FF_USE_REALTIME_ADMIN_DASHBOARD=$NEXT_PUBLIC_FF_USE_REALTIME_ADMIN_DASHBOARD \
+    NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN=$NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN \
+    NEXT_PUBLIC_SENTRY_DSN=$NEXT_PUBLIC_SENTRY_DSN \
+    NEXT_PUBLIC_SENTRY_ENVIRONMENT=$NEXT_PUBLIC_SENTRY_ENVIRONMENT \
+    DATABASE_URL=$DATABASE_URL \
+    DIRECT_URL=$DIRECT_URL \
+    HUSKY=0 \
+    NEXT_TELEMETRY_DISABLED=1 \
+    CI=true
 
-# Production image, copy all the files and run next
-FROM base AS runner
+# `pnpm build` runs `prisma generate && next build` (both with the 4 GB heap).
+RUN pnpm build
+
+# ---------- runner: minimal standalone server ----------
+FROM ${NODE_IMAGE} AS runner
 WORKDIR /app
 
-ENV NODE_ENV=production
-# Disable telemetry during runtime.
-ENV NEXT_TELEMETRY_DISABLED=1
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
 
-COPY --from=builder /app/public ./public
+# Run as non-root.
+RUN groupadd --system --gid 1001 nodejs \
+  && useradd --system --uid 1001 --gid nodejs nextjs
 
-# Automatically leverage output traces to reduce image size
-# https://nextjs.org/docs/advanced-features/output-file-tracing
+# Standalone output bundles a minimal node_modules + server.js.
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+# Ensure the Prisma client + query engine are present for the runtime server
+# (standalone tracing occasionally misses the engine binary).
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/.prisma ./node_modules/.prisma
 
 USER nextjs
-
 EXPOSE 3000
 
-ENV PORT=3000
+# Lightweight container healthcheck (Dokploy/Swarm reads this). /api/health
+# returns the package.json version per the project docs.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||3000)+'/api/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 
-# server.js is created by next build from the standalone output
-# https://nextjs.org/docs/pages/api-reference/config/next-config-js/output
-ENV HOSTNAME="0.0.0.0"
 CMD ["node", "server.js"]


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow that builds the standalone Next.js image **off the VPS** and pushes it to GHCR, so `next build` never runs on the server. This replaces Vercel's billed build step — step 1 of the self-host migration (Option B; see `docs/ready-set/reports/2026-05-30-coolify-to-dokploy-migration.md`).

- Rewrites the `Dockerfile` for Node 22 / glibc (Debian bookworm-slim) / standalone output, non-root runner, container healthcheck on `/api/health`.
- Adds `.dockerignore`.
- Adds `.github/workflows/build-and-push.yml` (triggers on push to `main`/`development` + `workflow_dispatch`).

## Build-arg fixes (would have shipped broken)

While wiring CI vars I found the build-args didn't match what the app actually reads:

- `NEXT_PUBLIC_MAPBOX_TOKEN` → **`NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN`** — the app reads the `_ACCESS_TOKEN` name; the old arg left Mapbox blank in the client bundle.
- `SENTRY_ENVIRONMENT` → **`NEXT_PUBLIC_SENTRY_ENVIRONMENT`** — the only var `getSentryEnvironment()` reads in the browser bundle (server-only `SENTRY_ENVIRONMENT` was dead, would have fallen through to `NODE_ENV`).

## CI config (already set on the repo)

Variables: `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_FF_USE_REALTIME_LOCATION_UPDATES`, `NEXT_PUBLIC_FF_USE_REALTIME_ADMIN_DASHBOARD`, `NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN`, `NEXT_PUBLIC_SENTRY_ENVIRONMENT=production` (copied from the production Vercel env).
Secrets: `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `NEXT_PUBLIC_SENTRY_DSN`, `BUILD_DATABASE_URL`, `BUILD_DIRECT_URL`.

## Scope / no prod impact

This only builds + pushes an image. No Coolify resource, no DNS cutover, no production change. Those remain follow-ups in the migration runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)