### PR TITLE
fix: bundle Prisma query engine into standalone output (GHCR image)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,9 +120,9 @@ RUN groupadd --system --gid 1001 nodejs \
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
-# Ensure the Prisma client + query engine are present for the runtime server
-# (standalone tracing occasionally misses the engine binary).
-COPY --from=builder --chown=nextjs:nodejs /app/node_modules/.prisma ./node_modules/.prisma
+# The Prisma client + native query engine are pulled into .next/standalone by
+# next.config.js `outputFileTracingIncludes` (the standalone copy above already
+# carries them at their resolved pnpm path), so no separate engine COPY here.
 
 USER nextjs
 EXPOSE 3000

--- a/next.config.js
+++ b/next.config.js
@@ -124,6 +124,13 @@ const nextConfig = {
   },
 
   serverExternalPackages: ['@prisma/client', 'prisma', 'jsdom'],
+  // Prisma's native query-engine binary isn't followed by static import tracing,
+  // so `output: "standalone"` ships without it and the server can't connect at
+  // runtime. Force the generated client + engine into the trace. pnpm stores it
+  // under .pnpm/<hashed-dir>, hence the wildcard.
+  outputFileTracingIncludes: {
+    '*': ['./node_modules/.pnpm/@prisma+client*/node_modules/.prisma/client/**'],
+  },
   skipTrailingSlashRedirect: true,
   // Ensure all API routes are treated as dynamic
   async rewrites() {


### PR DESCRIPTION
Follow-up to #425/#426. The second GHCR build (run 26787984834) compiled the app fully but failed at the runner stage:

```
failed to compute cache key: "/app/.../.prisma": not found
```

The runner's manual `.prisma` COPY assumed an npm-flat layout. Under **pnpm**, `prisma generate` emits into the pnpm store (`.pnpm/@prisma+client@<hash>/.../.prisma`) — there's no top-level `.prisma` dir. And even with the path corrected, Next's static import tracing copies `@prisma/client` into `.next/standalone` but doesn't follow the native query-engine binary, so the standalone server would fail to connect at runtime.

## Fix

Let Next place the engine at its own resolved path instead of hand-copying:
- **next.config.js** — add `outputFileTracingIncludes` for the pnpm `.prisma/client` dir so the engine is traced into `.next/standalone`.
- **Dockerfile** — drop the brittle, wrong-path manual `.prisma` COPY; the standalone copy now carries the engine.

`serverExternalPackages` already marks Prisma external, so the client itself was traced; this only adds the missing binary. Harmless to the Vercel build (just adds the engine to its trace, which Vercel already handles).

No prod impact — still just builds + pushes an image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
