### PR TITLE
ci: pause GHCR auto-builds until self-host VPS is ready

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -34,8 +34,13 @@ name: Build & Push Image
 # are not needed to build the image.
 
 on:
-  push:
-    branches: [main, development]
+  # Auto-build on push is intentionally PAUSED until the self-host VPS/Coolify
+  # target is ready (no point spending ~12 min/build on an image nobody pulls).
+  # To re-enable push builds, restore:
+  #   push:
+  #     branches: [main, development]
+  # Manual dispatch via the Actions tab / `gh workflow run build-and-push.yml`
+  # becomes available once this file lands on the default branch (main).
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Per the decision to wait for the self-host VPS before deploying, this removes the `push` triggers from the GHCR image build workflow so it no longer spends ~12 min building on every `development`/`main` push while nothing pulls the image yet.

- Keeps `workflow_dispatch` for manual runs (becomes available once this file is on the default branch, `main`).
- Inline comment documents how to restore the `push` block to re-enable auto-builds when the VPS is ready.

Context: the self-host image pipeline (#425/#426/#427) is verified — `ghcr.io/readyset1/ready-set:development` + `:sha-a963d07` built and pushed successfully. Nothing is deployed; the image just sits in GHCR. This PR only changes when the build runs, nothing about the image itself.

No prod impact. Merging this does **not** trigger a build (the merged workflow has no push trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)