### PR TITLE
feat: outbound partner status webhooks + GET /orders/{id} (CaterCow integration)

### DIFF
--- a/docs/catercow/EMAIL_DRAFT_REPLY_NATE_2026-06-05.md
+++ b/docs/catercow/EMAIL_DRAFT_REPLY_NATE_2026-06-05.md
@@ -1,0 +1,64 @@
+# Email Draft — Reply to Nate (CaterCow API Integration)
+
+**Status:** Draft, pending review
+**Author:** Emmanuel Alanis
+**Date:** 2026-06-05
+**In reply to:** Nate (support@catercow.com), Fri Jun 5 2026 4:38 PM
+**Thread:** API Integration — Ready Set Partner API
+
+---
+
+## Headers
+
+**To:** support@catercow.com (Nate)
+**Cc:**
+- Gary Vinson `<gary@readysetllc.com>`
+- Mark Fuentes `<mark@readysetllc.com>`
+
+**Subject:** Re: API Integration — Ready Set Partner API
+
+---
+
+## Body
+
+Hi Nate,
+
+Thanks for pushing through the full lifecycle and for the clear notes — really helpful. Answers below.
+
+**1. Cancelling / updating a confirmed order**
+
+Your testing is correct, and I owe you a correction: a **confirmed order is locked** — you can't `update` it or cancel it via `confirm(isAccepted:false)` once it's in `CONFIRMED`. My earlier note that update/cancel "still works post-confirmation" was wrong; the cancel path applies to a **draft** (pre-confirmation) order, which matches the v0.1 contract. Sorry for the confusion.
+
+Given that, your plan is exactly right: **confirm ~24h before delivery.** Drafts can be freely `update`d (deliverables, addresses, contacts, timing) any number of times right up until you confirm, so confirming late costs you nothing and keeps the order fully editable through the window your customers actually make changes in. If you ever need to confirm earlier and then change something, the path today is cancel-the-draft-and-re-draft *before* confirming — but with a ~24h confirm window you shouldn't hit that.
+
+**2. Fetch / GET endpoint**
+
+Point taken — you've asked twice and it's a reasonable baseline expectation. We're going to add **`GET /orders/{id}`** (current status + recent lifecycle events) and have it ready for go-live so you have a resync path if a webhook is ever missed. I'll confirm the exact response shape when it lands.
+
+**3. Webhooks + signing secret**
+
+We've got your endpoints noted:
+- Staging: `https://api.staging.steerdelivery.com/webhooks/ready_set`
+- Production: `https://api.steerdelivery.com/webhooks/ready_set`
+
+I'm finishing the outbound dispatcher on our side so lifecycle callbacks (`ASSIGNED → PICKED_UP → ON_THE_WAY → ARRIVED → DELIVERED`, plus `CANCELLED`) fire to your URL, HMAC-signed. I'll send the **staging signing secret** (separate, 1Password share) the moment that's wired and your staging endpoint is reachable, so you're verifying against real traffic rather than silence. One correction to my earlier email: the signature header is **`x-readyset-signature`** (HMAC-SHA256 of the raw body) — please verify against that name.
+
+**4. steerdelivery.com**
+
+Thanks for confirming it's your delivery-comms microservice — that clears up the domain difference. We'll note it on the partner record so production credential exchange goes smoothly.
+
+I'll follow up as soon as the staging webhooks + secret are ready on our side. 
+
+Best,
+Emman
+
+---
+
+## Internal notes (do NOT send)
+
+These came out of verifying Nate's findings against the repo on 2026-06-05:
+
+- **Confirm-lock:** `isOrderEditable()` (`src/app/api/cater-valley/_lib/order-utils.ts:124`) allows only `PENDING`/`ACTIVE`. Draft → `ACTIVE`; confirm → `CONFIRMED` locks both update and cancel. Matches `API_CONTRACT.md:246`; the May 13 email was the thing that was wrong. Decision (2026-06-05): match the contract, no code change — tell Nate to confirm ~24h out.
+- **Outbound webhook gap:** the registry-driven dispatcher `src/lib/services/partnerWebhookService.ts` does **not** exist (tasks-board had it marked done — corrected). Status route dispatches only via `CARRIER_CONFIGS` (catervalley/ezcater); CaterCow gets zero callbacks until the dispatcher is built. Tracked as `catercow-dispatcher-refactor` (now open) and `catercow-webhook-preconfigure` (now open, blocked on it).
+- **GET endpoint:** committed for go-live — `catercow-get-orders-scope`, `IMPLEMENTATION_PLAN.md` Phase 4.1 (~half day).
+- **Header name:** code + contract use `x-readyset-signature`; the May 13 email said `X-Ready-Set-Signature` + `X-Ready-Set-Timestamp`. Reply above uses the code/contract name and drops the timestamp header (not implemented). If we want replay protection via timestamp, that's a small extra addition to scope.

--- a/prisma/migrations/20260605000000_add_order_status_history/migration.sql
+++ b/prisma/migrations/20260605000000_add_order_status_history/migration.sql
@@ -1,0 +1,36 @@
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "order_status_history" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "catering_request_id" UUID NOT NULL,
+    "partner_status" TEXT NOT NULL,
+    "driver_status" "DriverStatus",
+    "changed_by" UUID,
+    "location" JSONB,
+    "notes" TEXT,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "order_status_history_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX IF NOT EXISTS "order_status_history_catering_request_id_created_at_idx" ON "order_status_history"("catering_request_id", "created_at");
+
+-- AddForeignKey
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'order_status_history_catering_request_id_fkey'
+    ) THEN
+        ALTER TABLE "order_status_history"
+            ADD CONSTRAINT "order_status_history_catering_request_id_fkey"
+            FOREIGN KEY ("catering_request_id") REFERENCES "catering_requests"("id")
+            ON DELETE CASCADE ON UPDATE NO ACTION;
+    END IF;
+END $$;
+
+-- Enable Row-Level Security with no policies. This table is only ever
+-- read/written server-side via Prisma (service_role) — the partner
+-- GET /orders/{id} endpoint and the outbound webhook dispatcher. RLS
+-- with no policies makes it inaccessible from anon / authenticated
+-- roles, matching the posture of api_partners.
+ALTER TABLE "order_status_history" ENABLE ROW LEVEL SECURITY;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -301,6 +301,7 @@ model CateringRequest {
   archiveBatch      ArchiveBatch?    @relation(fields: [archiveBatchId], references: [id], onDelete: SetNull)
   dispatches        Dispatch[]
   fileUploads       FileUpload[]
+  statusHistory     OrderStatusHistory[]
 
   @@index([userId])
   @@index([status])
@@ -314,6 +315,30 @@ model CateringRequest {
   @@index([archiveBatchId])
   @@schema("public")
   @@map("catering_requests")
+}
+
+/// Append-only log of partner-facing lifecycle events for an order
+/// (ASSIGNED → PICKED_UP → ON_THE_WAY → ARRIVED → DELIVERED, plus
+/// CANCELLED). One row is written each time we emit a partner status
+/// webhook, so the partner GET /orders/{id} endpoint can return the
+/// recent lifecycle and partners can resync after a missed callback.
+/// `partnerStatus` is the contract-facing value; `driverStatus` is the
+/// internal status that triggered it (null for CANCELLED, which is a
+/// CateringStatus change with no driver leg).
+model OrderStatusHistory {
+  id                String          @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  cateringRequestId String          @map("catering_request_id") @db.Uuid
+  partnerStatus     String          @map("partner_status")
+  driverStatus      DriverStatus?   @map("driver_status")
+  changedBy         String?         @map("changed_by") @db.Uuid
+  location          Json?
+  notes             String?
+  createdAt         DateTime        @default(now()) @map("created_at") @db.Timestamptz(6)
+  cateringRequest   CateringRequest @relation(fields: [cateringRequestId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@index([cateringRequestId, createdAt])
+  @@schema("public")
+  @@map("order_status_history")
 }
 
 model Dispatch {

--- a/scripts/set-partner-webhook.ts
+++ b/scripts/set-partner-webhook.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env tsx
+/**
+ * Configure a partner's outbound status webhook (URL + HMAC secret).
+ *
+ * Sets `webhook_url` and `webhook_secret` on an existing api_partners
+ * row. If no secret is supplied one is generated (256-bit, matching
+ * `openssl rand -hex 32`) and printed to stdout exactly ONCE — operator
+ * captures it, stores in 1Password, shares with the partner, and clears
+ * terminal scrollback. The secret is the shared key the partner uses to
+ * verify the `x-readyset-signature` header on each callback.
+ *
+ * The partner row must already exist (see seed-catercow-partner.ts).
+ *
+ * Usage:
+ *   PARTNER_SLUG=catercow \
+ *   WEBHOOK_URL=https://api.staging.steerdelivery.com/webhooks/ready_set \
+ *   DATABASE_URL=$STAGING_DATABASE_URL \
+ *     pnpm tsx scripts/set-partner-webhook.ts
+ *
+ *   # Reuse an existing secret instead of generating one:
+ *   WEBHOOK_SECRET=<hex> ... pnpm tsx scripts/set-partner-webhook.ts
+ *
+ *   # Production requires an explicit flag:
+ *   ... DATABASE_URL=$PROD_DATABASE_URL pnpm tsx scripts/set-partner-webhook.ts --confirm-prod
+ */
+
+import { randomBytes } from 'node:crypto';
+import { config } from 'dotenv';
+import { PrismaClient } from '@prisma/client';
+
+config({ path: '.env.local' });
+config({ path: '.env.development.local' });
+config({ path: '.env' });
+
+function generateSecret(): string {
+  return randomBytes(32).toString('hex');
+}
+
+function isProductionDatabase(): boolean {
+  const url = process.env.DATABASE_URL ?? '';
+  return /prod|production/i.test(url) || /readyset.*\.supabase\.co/i.test(url);
+}
+
+async function main(): Promise<void> {
+  const slug = process.env.PARTNER_SLUG;
+  const webhookUrl = process.env.WEBHOOK_URL;
+
+  if (!slug) {
+    console.error('[set-partner-webhook] PARTNER_SLUG is required.');
+    process.exit(1);
+  }
+  if (!webhookUrl) {
+    console.error('[set-partner-webhook] WEBHOOK_URL is required.');
+    process.exit(1);
+  }
+  try {
+    // Fail fast on obviously-malformed URLs before touching the DB.
+    const parsed = new URL(webhookUrl);
+    if (parsed.protocol !== 'https:') {
+      console.error('[set-partner-webhook] WEBHOOK_URL must be https.');
+      process.exit(1);
+    }
+  } catch {
+    console.error(`[set-partner-webhook] WEBHOOK_URL is not a valid URL: ${webhookUrl}`);
+    process.exit(1);
+  }
+
+  if (isProductionDatabase() && !process.argv.includes('--confirm-prod')) {
+    console.error('[set-partner-webhook] DATABASE_URL looks like production. Pass --confirm-prod to proceed.');
+    process.exit(1);
+  }
+
+  const providedSecret = process.env.WEBHOOK_SECRET?.trim();
+  const secret = providedSecret && providedSecret.length > 0 ? providedSecret : generateSecret();
+  const generated = !providedSecret;
+  const env = isProductionDatabase() ? 'production' : 'staging-or-dev';
+
+  const prisma = new PrismaClient();
+  try {
+    const existing = await prisma.apiPartner.findFirst({
+      where: { slug, deletedAt: null },
+      select: { id: true },
+    });
+    if (!existing) {
+      console.error(
+        `[set-partner-webhook] No active api_partners row for slug "${slug}". ` +
+          `Seed the partner first (e.g. scripts/seed-${slug}-partner.ts).`
+      );
+      process.exit(1);
+    }
+
+    const row = await prisma.apiPartner.update({
+      where: { id: existing.id },
+      data: { webhookUrl, webhookSecret: secret },
+      select: { id: true, slug: true, webhookUrl: true },
+    });
+
+    const banner = '='.repeat(72);
+    console.log(banner);
+    console.log('PARTNER WEBHOOK CONFIGURED');
+    console.log(banner);
+    console.log(`env:         ${env}`);
+    console.log(`slug:        ${row.slug}`);
+    console.log(`id:          ${row.id}`);
+    console.log(`webhook URL: ${row.webhookUrl}`);
+    console.log(`secret:      ${generated ? 'generated (shown below)' : 'reused from WEBHOOK_SECRET (not shown)'}`);
+    if (generated) {
+      console.log('');
+      console.log('HMAC SIGNING SECRET — STORE IMMEDIATELY, THIS WILL NOT BE SHOWN AGAIN:');
+      console.log(secret);
+      console.log('');
+      console.log('Next steps:');
+      console.log(`  1. Copy into 1Password: "Ready Set / Partner API Keys / ${row.slug} webhook secret"`);
+      console.log('  2. Clear your terminal scrollback (Cmd+K on macOS Terminal/iTerm).');
+      console.log('  3. Deliver to the partner via 1Password share link only.');
+    }
+    console.log(banner);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  console.error('[set-partner-webhook] Failed:', err);
+  process.exit(1);
+});

--- a/src/__tests__/api/cater-valley/orders-get.test.ts
+++ b/src/__tests__/api/cater-valley/orders-get.test.ts
@@ -1,0 +1,122 @@
+// src/__tests__/api/cater-valley/orders-get.test.ts
+//
+// GET /api/cater-valley/orders/{id} (aliased at /api/partners/orders/{id}):
+// returns current status + recent lifecycle events, enforces ownership,
+// and 404s on unknown/soft-deleted orders.
+
+import { GET } from '@/app/api/cater-valley/orders/[id]/route';
+import { prisma } from '@/lib/db/prisma';
+
+jest.mock('@/lib/db/prisma', () => ({
+  prisma: { cateringRequest: { findUnique: jest.fn() } },
+}));
+
+jest.mock('@/lib/services/partner-registry', () => ({
+  authenticatePartner: jest.fn(async (req: Request) => {
+    const slug = req.headers.get('partner');
+    const apiKey = req.headers.get('x-api-key');
+    if (!slug) return { ok: false, reason: 'missing_partner_header' };
+    if (!apiKey) return { ok: false, reason: 'missing_api_key' };
+    if (slug === 'catercow' && apiKey === 'cc-test-key') {
+      return {
+        ok: true,
+        partner: {
+          id: 'partner-cc-id',
+          slug: 'catercow',
+          displayName: 'CaterCow',
+          orderPrefix: 'CC-',
+          webhookUrl: null,
+          webhookSecret: null,
+          rateLimitPerMin: 100,
+          isActive: true,
+        },
+      };
+    }
+    return { ok: false, reason: 'invalid_key' };
+  }),
+}));
+
+const ORDER_ID = '123e4567-e89b-12d3-a456-426614174000';
+
+function makeRequest(headers: Record<string, string>) {
+  return new Request(`http://localhost/api/cater-valley/orders/${ORDER_ID}`, { headers }) as any;
+}
+
+const ctx = (id: string) => ({ params: Promise.resolve({ id }) });
+
+const authHeaders = { partner: 'catercow', 'x-api-key': 'cc-test-key' };
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('GET /api/cater-valley/orders/{id}', () => {
+  it('401s without credentials', async () => {
+    const res = await GET(makeRequest({}), ctx(ORDER_ID));
+    expect(res.status).toBe(401);
+  });
+
+  it('400s on a non-UUID id', async () => {
+    const res = await GET(makeRequest(authHeaders), ctx('not-a-uuid'));
+    expect(res.status).toBe(400);
+  });
+
+  it('404s when the order does not exist', async () => {
+    (prisma.cateringRequest.findUnique as jest.Mock).mockResolvedValueOnce(null);
+    const res = await GET(makeRequest(authHeaders), ctx(ORDER_ID));
+    expect(res.status).toBe(404);
+  });
+
+  it('404s when the order is soft-deleted', async () => {
+    (prisma.cateringRequest.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: ORDER_ID,
+      orderNumber: 'CC-12345',
+      deletedAt: new Date(),
+      user: { email: 'system@catercow.com' },
+      statusHistory: [],
+    });
+    const res = await GET(makeRequest(authHeaders), ctx(ORDER_ID));
+    expect(res.status).toBe(404);
+  });
+
+  it("403s when the order belongs to a different partner", async () => {
+    (prisma.cateringRequest.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: ORDER_ID,
+      orderNumber: 'CV-999', // not CaterCow's prefix
+      deletedAt: null,
+      status: 'CONFIRMED',
+      arrivalDateTime: null,
+      user: { email: 'system@catervalley.com' },
+      statusHistory: [],
+    });
+    const res = await GET(makeRequest(authHeaders), ctx(ORDER_ID));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns current status + lifecycle events for an owned order', async () => {
+    (prisma.cateringRequest.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: ORDER_ID,
+      orderNumber: 'CC-12345',
+      deletedAt: null,
+      status: 'CONFIRMED',
+      arrivalDateTime: new Date('2026-06-15T18:30:00Z'),
+      user: { email: 'system@catercow.com' },
+      statusHistory: [
+        { partnerStatus: 'PICKED_UP', driverStatus: 'PICKED_UP', createdAt: new Date('2026-06-15T17:00:00Z'), location: null, notes: null },
+        { partnerStatus: 'ASSIGNED', driverStatus: 'ASSIGNED', createdAt: new Date('2026-06-15T16:00:00Z'), location: null, notes: null },
+      ],
+    });
+
+    const res = await GET(makeRequest(authHeaders), ctx(ORDER_ID));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('SUCCESS');
+    expect(body.order).toMatchObject({
+      id: ORDER_ID,
+      orderCode: '12345',
+      orderNumber: 'CC-12345',
+      orderStatus: 'CONFIRMED',
+      lifecycleStatus: 'PICKED_UP', // newest event
+    });
+    expect(body.order.events).toHaveLength(2);
+    expect(body.order.events[0]).toMatchObject({ status: 'PICKED_UP', driverStatus: 'PICKED_UP' });
+  });
+});

--- a/src/__tests__/services/partnerWebhookService.test.ts
+++ b/src/__tests__/services/partnerWebhookService.test.ts
@@ -1,0 +1,162 @@
+// src/__tests__/services/partnerWebhookService.test.ts
+//
+// Unit tests for the registry-driven partner webhook dispatcher:
+// status mapping, the skip-when-unconfigured guard, HMAC-signed POST,
+// no-retry-on-4xx, and the record+dispatch orchestration (history write,
+// legacy-carrier guard, non-partner no-op).
+
+import {
+  dispatchPartnerWebhook,
+  recordAndDispatchLifecycleEvent,
+  DRIVER_STATUS_TO_PARTNER_LIFECYCLE,
+} from '@/lib/services/partnerWebhookService';
+import { prisma } from '@/lib/db/prisma';
+import { getPartnerByOrderNumber } from '@/lib/services/partner-registry';
+import { signPayload } from '@/lib/security/hmac';
+
+jest.mock('@/lib/db/prisma', () => ({
+  prisma: { orderStatusHistory: { create: jest.fn() } },
+}));
+
+jest.mock('@/lib/services/partner-registry', () => ({
+  getPartnerByOrderNumber: jest.fn(),
+}));
+
+jest.mock('@/lib/security/hmac', () => ({
+  SIGNATURE_HEADER: 'x-readyset-signature',
+  signPayload: jest.fn(async () => 'sig123'),
+}));
+
+jest.mock('@/lib/services/webhook-logger', () => ({
+  webhookLogger: { logSuccess: jest.fn(), logFailure: jest.fn() },
+}));
+
+jest.mock('@/utils/logger', () => ({
+  carrierLogger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+const PARTNER = {
+  id: 'partner-cc-id',
+  slug: 'catercow',
+  displayName: 'CaterCow',
+  orderPrefix: 'CC-',
+  webhookUrl: 'https://hook.example.com/ready_set',
+  webhookSecret: 'shared-secret',
+  rateLimitPerMin: 100,
+  isActive: true,
+};
+
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  global.fetch = mockFetch as unknown as typeof fetch;
+});
+
+describe('DRIVER_STATUS_TO_PARTNER_LIFECYCLE', () => {
+  it('maps client-leg statuses to partner lifecycle and vendor-leg to null', () => {
+    expect(DRIVER_STATUS_TO_PARTNER_LIFECYCLE.ASSIGNED).toBe('ASSIGNED');
+    expect(DRIVER_STATUS_TO_PARTNER_LIFECYCLE.PICKED_UP).toBe('PICKED_UP');
+    expect(DRIVER_STATUS_TO_PARTNER_LIFECYCLE.EN_ROUTE_TO_CLIENT).toBe('ON_THE_WAY');
+    expect(DRIVER_STATUS_TO_PARTNER_LIFECYCLE.ARRIVED_TO_CLIENT).toBe('ARRIVED');
+    expect(DRIVER_STATUS_TO_PARTNER_LIFECYCLE.COMPLETED).toBe('DELIVERED');
+    expect(DRIVER_STATUS_TO_PARTNER_LIFECYCLE.EN_ROUTE_TO_VENDOR).toBeNull();
+    expect(DRIVER_STATUS_TO_PARTNER_LIFECYCLE.ARRIVED_AT_VENDOR).toBeNull();
+  });
+});
+
+describe('dispatchPartnerWebhook', () => {
+  const baseInput = {
+    partner: PARTNER,
+    orderId: 'order-uuid',
+    orderCode: '12345',
+    orderNumber: 'CC-12345',
+    status: 'ASSIGNED' as const,
+  };
+
+  it('skips (no fetch) when the partner has no webhook URL or secret', async () => {
+    const result = await dispatchPartnerWebhook({
+      ...baseInput,
+      partner: { ...PARTNER, webhookUrl: null },
+    });
+
+    expect(result).toEqual({ delivered: false, skipped: 'misconfigured', attempts: 0, httpStatus: null });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('POSTs an HMAC-signed payload and reports delivery on 200', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) });
+
+    const result = await dispatchPartnerWebhook(baseInput);
+
+    expect(result).toEqual({ delivered: true, attempts: 1, httpStatus: 200 });
+    expect(signPayload).toHaveBeenCalledWith('shared-secret', expect.any(String));
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe(PARTNER.webhookUrl);
+    expect(init.method).toBe('POST');
+    expect(init.headers['x-readyset-signature']).toBe('sig123');
+    const body = JSON.parse(init.body);
+    expect(body).toMatchObject({ orderId: 'order-uuid', orderCode: '12345', orderNumber: 'CC-12345', status: 'ASSIGNED' });
+    expect(typeof body.timestamp).toBe('string');
+  });
+
+  it('does not retry on a 4xx response', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 400, json: async () => ({}) });
+
+    const result = await dispatchPartnerWebhook(baseInput);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ delivered: false, httpStatus: 400 });
+  });
+});
+
+describe('recordAndDispatchLifecycleEvent', () => {
+  it('no-ops for legacy CARRIER_CONFIGS orders (CV-) without resolving a partner', async () => {
+    await recordAndDispatchLifecycleEvent({
+      orderId: 'o1',
+      orderNumber: 'CV-999',
+      partnerStatus: 'ASSIGNED',
+    });
+
+    expect(getPartnerByOrderNumber).not.toHaveBeenCalled();
+    expect(prisma.orderStatusHistory.create).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('records history and dispatches for a registry partner order', async () => {
+    (getPartnerByOrderNumber as jest.Mock).mockResolvedValueOnce(PARTNER);
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) });
+
+    await recordAndDispatchLifecycleEvent({
+      orderId: 'order-uuid',
+      orderNumber: 'CC-12345',
+      partnerStatus: 'DELIVERED',
+      driverStatus: 'COMPLETED',
+      changedBy: 'driver-1',
+    });
+
+    expect(prisma.orderStatusHistory.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        cateringRequestId: 'order-uuid',
+        partnerStatus: 'DELIVERED',
+        driverStatus: 'COMPLETED',
+        changedBy: 'driver-1',
+      }),
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('no-ops when the order is not owned by any registry partner', async () => {
+    (getPartnerByOrderNumber as jest.Mock).mockResolvedValueOnce(null);
+
+    await recordAndDispatchLifecycleEvent({
+      orderId: 'o2',
+      orderNumber: 'XX-1', // not a legacy carrier, no registry match
+      partnerStatus: 'ASSIGNED',
+    });
+
+    expect(prisma.orderStatusHistory.create).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/cater-valley/orders/[id]/route.ts
+++ b/src/app/api/cater-valley/orders/[id]/route.ts
@@ -1,0 +1,106 @@
+/**
+ * Partner Order API — Read endpoint.
+ *
+ * Returns the current status plus the recent partner-facing lifecycle
+ * events for a single order, so a partner can resync after a missed
+ * webhook callback. Same partner identity resolution and ownership check
+ * as the write endpoints: partner A can't read partner B's orders even
+ * with valid credentials.
+ *
+ * Available at both `/api/cater-valley/orders/{id}` and
+ * `/api/partners/orders/{id}`.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { prisma } from '@/lib/db/prisma';
+import { enforceRateLimit } from '@/lib/security/rate-limit';
+import { authenticatePartnerRequest, isPartnerOrder } from '@/app/api/cater-valley/_lib';
+
+const HISTORY_LIMIT = 10;
+
+const IdSchema = z.string().uuid('Invalid order ID format');
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    const auth = await authenticatePartnerRequest(request);
+    if (!auth.ok) return auth.response;
+    const { partner } = auth;
+
+    const rateLimitReject = await enforceRateLimit(partner.slug, 'orders.get');
+    if (rateLimitReject) return rateLimitReject;
+
+    const { id } = await context.params;
+    const idResult = IdSchema.safeParse(id);
+    if (!idResult.success) {
+      return NextResponse.json(
+        { status: 'ERROR', message: 'Invalid order ID format' },
+        { status: 400 }
+      );
+    }
+
+    const order = await prisma.cateringRequest.findUnique({
+      where: { id: idResult.data },
+      include: {
+        user: true,
+        statusHistory: {
+          orderBy: { createdAt: 'desc' },
+          take: HISTORY_LIMIT,
+        },
+      },
+    });
+
+    // Soft-deleted orders read as not-found across the partner boundary.
+    if (!order || order.deletedAt) {
+      return NextResponse.json(
+        { status: 'ERROR', message: 'Order not found' },
+        { status: 404 }
+      );
+    }
+
+    if (!isPartnerOrder(order.orderNumber, order.user.email, partner)) {
+      return NextResponse.json(
+        { status: 'ERROR', message: 'This order cannot be read via the partner API' },
+        { status: 403 }
+      );
+    }
+
+    const orderCode = order.orderNumber.startsWith(partner.orderPrefix)
+      ? order.orderNumber.slice(partner.orderPrefix.length)
+      : order.orderNumber;
+
+    // The partner-facing lifecycle status is the latest recorded event
+    // (history is ordered newest-first). Null until the order is dispatched.
+    const lifecycleStatus = order.statusHistory[0]?.partnerStatus ?? null;
+
+    return NextResponse.json({
+      status: 'SUCCESS',
+      order: {
+        id: order.id,
+        orderCode,
+        orderNumber: order.orderNumber,
+        // Internal order state (ACTIVE = draft, CONFIRMED, CANCELLED, …).
+        orderStatus: order.status,
+        // Latest partner-facing lifecycle event, if any.
+        lifecycleStatus,
+        deliveryDate: order.arrivalDateTime?.toISOString() ?? null,
+        events: order.statusHistory.map((e) => ({
+          status: e.partnerStatus,
+          driverStatus: e.driverStatus,
+          timestamp: e.createdAt.toISOString(),
+          location: e.location ?? undefined,
+          notes: e.notes ?? undefined,
+        })),
+      },
+    });
+  } catch (error) {
+    console.error('Error reading partner order:', error);
+    return NextResponse.json(
+      { status: 'ERROR', message: 'Internal server error - failed to read order' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/cater-valley/orders/confirm/route.ts
+++ b/src/app/api/cater-valley/orders/confirm/route.ts
@@ -20,6 +20,7 @@ import {
   isOrderEditable,
   isPartnerOrder,
 } from '@/app/api/cater-valley/_lib';
+import { recordAndDispatchLifecycleEvent } from '@/lib/services/partnerWebhookService';
 
 const ConfirmOrderSchema = z.object({
   id: z.string().uuid('Invalid order ID format'),
@@ -153,6 +154,16 @@ export async function POST(request: NextRequest) {
             : existingOrder.specialNotes,
           updatedAt: new Date(),
         },
+      });
+
+      // Notify the partner of the cancellation (records to
+      // order_status_history + POSTs a signed CANCELLED webhook). The
+      // helper self-guards against legacy carriers and never throws.
+      await recordAndDispatchLifecycleEvent({
+        orderId: cancelledOrder.id,
+        orderNumber: cancelledOrder.orderNumber,
+        partnerStatus: 'CANCELLED',
+        notes: validatedData.reason,
       });
 
       return storeAndReturnResponse(idempotency, 200, {

--- a/src/app/api/catering-requests/[orderId]/status/route.ts
+++ b/src/app/api/catering-requests/[orderId]/status/route.ts
@@ -7,6 +7,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { prisma } from '@/lib/db/prisma';
 import { CarrierService, CarrierWebhookService } from '@/lib/services/carrierService';
+import {
+  recordAndDispatchLifecycleEvent,
+  DRIVER_STATUS_TO_PARTNER_LIFECYCLE,
+} from '@/lib/services/partnerWebhookService';
 import { DriverStatus } from '@/types/prisma';
 import { DriverStatus as DriverStatusEnum } from '@/types/user';
 import { getEmailPreferencesForUser } from "@/lib/email-preferences";
@@ -108,6 +112,7 @@ export async function PATCH(
               select: {
                 id: true,
                 name: true,
+                contactNumber: true,
               },
             },
           },
@@ -249,6 +254,33 @@ export async function PATCH(
           error: error instanceof Error ? error.message : 'Unknown ezCater error',
         };
       }
+    }
+
+    // 5c. Registry-driven partner webhooks (e.g. CaterCow) — partners in
+    //     api_partners that aren't hardcoded in CARRIER_CONFIGS. Maps the
+    //     internal driver status to the partner-facing lifecycle, records
+    //     it to order_status_history, and POSTs a signed webhook. The
+    //     helper self-guards against legacy carriers and non-partner
+    //     orders, and never throws.
+    const partnerLifecycle = DRIVER_STATUS_TO_PARTNER_LIFECYCLE[validatedData.driverStatus];
+    if (partnerLifecycle) {
+      const driverProfile = order.dispatches[0]?.driver;
+      const driver =
+        driverProfile?.name && driverProfile?.contactNumber
+          ? { name: driverProfile.name, phone: driverProfile.contactNumber }
+          : undefined;
+      await recordAndDispatchLifecycleEvent({
+        orderId: order.id,
+        orderNumber: order.orderNumber,
+        partnerStatus: partnerLifecycle,
+        driverStatus: validatedData.driverStatus,
+        changedBy: validatedData.driverId ?? driverProfile?.id ?? null,
+        driver,
+        location: validatedData.location
+          ? { lat: validatedData.location.latitude, lng: validatedData.location.longitude }
+          : undefined,
+        notes: validatedData.notes,
+      });
     }
 
     // 6. Create dispatch record if driver is assigned

--- a/src/app/api/partners/orders/[id]/route.ts
+++ b/src/app/api/partners/orders/[id]/route.ts
@@ -1,0 +1,5 @@
+/**
+ * Canonical partner-API read endpoint. See draft/route.ts for the
+ * URL-aliasing rationale.
+ */
+export { GET } from '@/app/api/cater-valley/orders/[id]/route';

--- a/src/data/tasks-board.json
+++ b/src/data/tasks-board.json
@@ -1,13 +1,14 @@
 {
   "title": "Ready Set — Tasks Board",
-  "subtitle": "Action items from the Dev Team Meetings on May 4, May 11, and May 19, 2026 — status as of May 19.",
-  "generated": "2026-05-19",
+  "subtitle": "Action items from the Dev Team Meetings on May 4 – June 1, 2026 — status as of June 1.",
+  "generated": "2026-06-01",
   "sources": [
     "meetings/shared/2026-05-04-dev-team-meeting.md",
     "meetings/shared/2026-05-11-dev-team-meeting.md",
     "meetings/shared/2026-05-11-may4-action-item-review.md",
     "meetings/shared/2026-05-11-weekly-recap.md",
-    "meetings/shared/2026-05-19-dev-team-meeting.md"
+    "meetings/shared/2026-05-19-dev-team-meeting.md",
+    "meetings/shared/2026-06-01-dev-team-meeting.md"
   ],
   "columns": [
     {
@@ -24,7 +25,7 @@
     },
     {
       "key": "new",
-      "title": "★ New — May 19"
+      "title": "★ New — Jun 1"
     }
   ],
   "owners": {
@@ -36,6 +37,7 @@
     "may4": "May 4",
     "may11": "May 11",
     "may19": "May 19",
+    "jun1": "June 1",
     "qa": "QA",
     "catercow": "CaterCow"
   },
@@ -94,7 +96,7 @@
       "title": "Resolve driver tracking sync issues",
       "owner": "emmanuel",
       "source": "may11",
-      "description": "Status sync between dashboard ↔ driver interface + intermittent websocket connections. Prioritize distance calculations before map drawing."
+      "description": "Status sync between dashboard ↔ driver interface + intermittent websocket connections. Prioritize distance calculations before map drawing. <strong>Jun 1 update:</strong> tracking-error code is fixed; verification testing scheduled across this week."
     },
     {
       "id": "driver-phone-storage",
@@ -212,7 +214,7 @@
     },
     {
       "id": "rea-drt-07-supabase-browser-session-bridge",
-      "status": "open",
+      "status": "done",
       "title": "REA-DRT-07 — Bridge SSR cookie to browser supabase-js session (Realtime never initializes)",
       "owner": "emmanuel",
       "source": "qa",
@@ -221,7 +223,7 @@
         "bug",
         "critical"
       ],
-      "description": "<strong>Root cause (investigated 2026-05-19):</strong> server-side cookie defaults force <code>httpOnly: true</code> on every cookie they write — including the <code>sb-&lt;ref&gt;-auth-token</code> chunks. <code>src/utils/supabase/server.ts:10-16</code> and <code>src/utils/supabase/middleware.ts:6-12</code> both define <code>{ httpOnly: true, ...options }</code> defaults, and <code>@supabase/ssr</code> doesn't override <code>httpOnly</code>, so the auth cookies land HttpOnly. The browser supabase-js client (<code>src/utils/supabase/client.ts:19-28</code>) reads cookies via <code>document.cookie</code>, which by spec cannot see HttpOnly cookies — so <code>getSession()</code> returns null, Realtime channels never authenticate, and <code>TokenRefreshService</code> throws <code>REFRESH_FAILED</code> (the symptom #404 patched as graceful failure). Regression introduced in commit <code>f49f6ec5</code> (2026-01-07 mobile-Safari ITP fix); the <code>sameSite: 'lax'</code> + request+response sync changes in that commit were correct, only <code>httpOnly: true</code> was wrong. <strong>Fix:</strong> drop <code>httpOnly: true</code> from <code>getDefaultCookieOptions</code> (server.ts) and <code>getCookieOptions</code> (middleware.ts); auth cookies must be JS-readable for the <code>@supabase/ssr</code> SSR↔browser bridge. ~2-line change in 2 files. Add a browser <code>getSession()</code> smoke test in <code>src/lib/auth/__tests__/token-refresh-and-session.test.ts</code> that fails if auth cookies are written HttpOnly. <strong>Tradeoff:</strong> XSS-exfiltrable auth tokens in principle; mitigated by existing CSP + dompurify + Supabase's short-lived JWT + refresh-token rotation. <strong>Keep #404 patch in place</strong> — graceful sign-in redirect on legitimate session expiry is still correct behavior. <strong>Out of scope:</strong> Realtime reconnect handler (see <code>docs/architecture/REMEDIATION_PLAN.md</code>). See <code>docs/JOURNAL.md</code> 2026-05-19 for full trace."
+      "description": "<strong>DONE — shipped in PR #409 (merged 2026-05-22), live on apex via #412.</strong> Remaining: confirm Sentry READY-SET-NEXTJS-1S goes silent with an authenticated apex check. <strong>Root cause (investigated 2026-05-19):</strong> server-side cookie defaults force <code>httpOnly: true</code> on every cookie they write — including the <code>sb-&lt;ref&gt;-auth-token</code> chunks. <code>src/utils/supabase/server.ts:10-16</code> and <code>src/utils/supabase/middleware.ts:6-12</code> both define <code>{ httpOnly: true, ...options }</code> defaults, and <code>@supabase/ssr</code> doesn't override <code>httpOnly</code>, so the auth cookies land HttpOnly. The browser supabase-js client (<code>src/utils/supabase/client.ts:19-28</code>) reads cookies via <code>document.cookie</code>, which by spec cannot see HttpOnly cookies — so <code>getSession()</code> returns null, Realtime channels never authenticate, and <code>TokenRefreshService</code> throws <code>REFRESH_FAILED</code> (the symptom #404 patched as graceful failure). Regression introduced in commit <code>f49f6ec5</code> (2026-01-07 mobile-Safari ITP fix); the <code>sameSite: 'lax'</code> + request+response sync changes in that commit were correct, only <code>httpOnly: true</code> was wrong. <strong>Fix:</strong> drop <code>httpOnly: true</code> from <code>getDefaultCookieOptions</code> (server.ts) and <code>getCookieOptions</code> (middleware.ts); auth cookies must be JS-readable for the <code>@supabase/ssr</code> SSR↔browser bridge. ~2-line change in 2 files. Add a browser <code>getSession()</code> smoke test in <code>src/lib/auth/__tests__/token-refresh-and-session.test.ts</code> that fails if auth cookies are written HttpOnly. <strong>Tradeoff:</strong> XSS-exfiltrable auth tokens in principle; mitigated by existing CSP + dompurify + Supabase's short-lived JWT + refresh-token rotation. <strong>Keep #404 patch in place</strong> — graceful sign-in redirect on legitimate session expiry is still correct behavior. <strong>Out of scope:</strong> Realtime reconnect handler (see <code>docs/architecture/REMEDIATION_PLAN.md</code>). See <code>docs/JOURNAL.md</code> 2026-05-19 for full trace."
     },
     {
       "id": "test-telnyx-integration",
@@ -293,7 +295,7 @@
       "title": "Pre-configure CaterCow staging webhook URL",
       "owner": "emmanuel",
       "source": "catercow",
-      "description": "Dispatcher landed (<code>src/lib/services/partnerWebhookService.ts</code>) and wired into the status route; <code>scripts/update-partner-webhook.ts</code> is ready. Still need to run it against the staging DB: <code>PARTNER_SLUG=catercow WEBHOOK_URL=https://api.staging.steerdelivery.com/webhooks/ready_set pnpm tsx scripts/update-partner-webhook.ts</code>. Their endpoint isn't live yet, so dispatcher will log <code>[partner-webhook] misconfigured</code> until <code>webhookSecret</code> is also set."
+      "description": "Dispatcher code is shipped (<code>catercow-dispatcher-refactor</code>); <code>scripts/set-partner-webhook.ts</code> is ready. Remaining (ops): run against staging to set CaterCow's <code>webhook_url</code> = <code>https://api.staging.steerdelivery.com/webhooks/ready_set</code> and a generated secret. CaterCow dev row exists (CC-, active, url/secret still null → dispatcher logs <code>[partner-webhook] skipped</code> until set)."
     },
     {
       "id": "catercow-dispatcher-refactor",
@@ -301,15 +303,15 @@
       "title": "Generalize outbound webhook dispatcher (partner-registry-driven)",
       "owner": "emmanuel",
       "source": "catercow",
-      "description": "New <code>src/lib/services/partnerWebhookService.ts</code> reads <code>webhookUrl</code>/<code>webhookSecret</code> from the <code>api_partners</code> row at send time. Wired into <code>/api/catering-requests/[orderId]/status/route.ts</code> for partners not in <code>CARRIER_CONFIGS</code>. HMAC-SHA256 signed per <code>API_CONTRACT.md</code> (<code>x-readyset-signature</code>); 3-attempt retry, no-retry on 4xx; 6 new unit tests; existing 161 cater-valley tests still green."
+      "description": "<strong>Built</strong> on <code>feature/catercow-partner-webhooks</code> (commit <code>50d78873</code>, off <code>development</code>). New <code>src/lib/services/partnerWebhookService.ts</code> reads <code>webhookUrl</code>/<code>webhookSecret</code> from the resolved <code>api_partners</code> row; builds the contract payload, HMAC-SHA256 signs it (<code>x-readyset-signature</code>), 3-attempt backoff (no retry on 4xx), skips with a logged notice when unconfigured. <code>recordAndDispatchLifecycleEvent</code> writes history + dispatches, self-guarding against <code>CARRIER_CONFIGS</code> and non-partner orders. Added <code>getPartnerByOrderNumber</code> (registry, prefix-match, cached). Wired into the driver status route (<code>driverStatus</code>→ASSIGNED/PICKED_UP/ON_THE_WAY/ARRIVED/DELIVERED) and the confirm cancel branch (CANCELLED). 7 unit tests green."
     },
     {
       "id": "catercow-hmac-secret",
-      "status": "new",
+      "status": "progress",
       "title": "Generate + deliver CaterCow webhook HMAC secret",
       "owner": "emmanuel",
       "source": "catercow",
-      "description": "Generate a 256-bit secret (<code>crypto.randomBytes(32)</code>), set <code>webhookSecret</code> on the staging row, deliver to CaterCow via 1Password share link (7-day expiry). Trigger: their webhook endpoint becomes reachable."
+      "description": "Generation + delivery now handled by <code>scripts/set-partner-webhook.ts</code> (generates a 256-bit secret, prints once for 1Password). Run: <code>PARTNER_SLUG=catercow WEBHOOK_URL=https://api.staging.steerdelivery.com/webhooks/ready_set DATABASE_URL=$STAGING_DATABASE_URL pnpm tsx scripts/set-partner-webhook.ts</code>, capture secret → 1Password → share with Nate. Trigger: their staging endpoint reachable (Nate says it's ready)."
     },
     {
       "id": "catercow-steerdelivery-domain-check",
@@ -321,11 +323,11 @@
     },
     {
       "id": "catercow-get-orders-scope",
-      "status": "open",
-      "title": "Scope GET /orders/{id} for partner API v1.x",
+      "status": "done",
+      "title": "GET /orders/{id} for partner API",
       "owner": "emmanuel",
       "source": "catercow",
-      "description": "Pre-scoped in <code>docs/catercow/IMPLEMENTATION_PLAN.md</code> Phase 4.1 (~half day). Reads from <code>catering_requests</code> filtered by <code>brokerage = partner.displayName</code>, returns status + last 10 lifecycle events. Pull forward only if CaterCow flags as a go-live blocker."
+      "description": "<strong>Built</strong> (commit <code>50d78873</code>). <code>GET /api/partners/orders/{id}</code> (+ cater-valley alias) returns current status + last 10 lifecycle events from the new <code>order_status_history</code> table, with the same partner-ownership check as the writes. Backed by migration <code>20260605000000_add_order_status_history</code> (applied to dev Supabase). 6 endpoint tests green."
     },
     {
       "id": "catercow-openapi-export",
@@ -345,11 +347,11 @@
     },
     {
       "id": "fernando-redesign-address-manager",
-      "status": "new",
-      "title": "Redesign address manager — 3 proposals",
+      "status": "done",
+      "title": "Redesign address manager",
       "owner": "fernando",
       "source": "may19",
-      "description": "Current UI is confusing for selecting or adding addresses during new catering / on-demand orders. Develop 3 design proposals and review with Iman to pick the one that fits current architecture."
+      "description": "Current UI is confusing for selecting or adding addresses during new catering / on-demand orders. <strong>DONE — shipped in PR #417 (merged 2026-05-25):</strong> AddressSelector redesigned with RouteBuilder, MiniMap & geocoding + mobile-responsive pass; CateringRequestForm unified to a single AddressSelector. Superseded the original 3-proposal-review-with-Iman approach by shipping the redesign directly."
     },
     {
       "id": "push-jitter-dev-code",
@@ -361,14 +363,14 @@
     },
     {
       "id": "driver-integration-realworld-test",
-      "status": "new",
+      "status": "done",
       "title": "Real-world driver integration test (Thursday 2026-05-21)",
       "owner": "emmanuel",
       "source": "may19",
       "tags": [
         "critical"
       ],
-      "description": "Real-world test with Gary + Mark on Thursday 2026-05-21. Monitor logs, identify + resolve errors. Co-owners: Fernando (testing), Gary (field). First step of the 3-week phased rollout (2–3 drivers at a time) leading to the July Cool Fire sunset."
+      "description": "Real-world test with Gary + Mark on Thursday 2026-05-21. Monitor logs, identify + resolve errors. Co-owners: Fernando (testing), Gary (field). First step of the 3-week phased rollout (2–3 drivers at a time) leading to the July Cool Fire sunset. <strong>Jun 1 update:</strong> device testing on Android + Apple ran (week of May 29); surfaced a refresh-rate issue. Continued testing tracked under <code>mobile-refresh-rate-testing</code>."
     },
     {
       "id": "gary-review-hours-file",
@@ -404,7 +406,7 @@
     },
     {
       "id": "rea-367-realtime-channel-off-cleanup",
-      "status": "progress",
+      "status": "done",
       "title": "REA-367 — Realtime <code>channel.off()</code> cleanup throws (channel closes ~1ms after subscribe)",
       "owner": "emmanuel",
       "source": "qa",
@@ -414,7 +416,7 @@
         "bug",
         "critical"
       ],
-      "description": "<code>RealtimeChannelManager.off()</code> (<code>src/lib/realtime/channels.ts:168-173</code>) calls <code>this.channel.off('broadcast', { event }, listener)</code>, but the Supabase <code>RealtimeChannel</code> has no runtime <code>.off()</code> — that's a Phoenix Channels method present only via a <code>.d.ts</code> type augmentation. So cleanup throws <code>TypeError: this.channel.off is not a function</code>; the <code>catch</code> only swallows 'closed' / 'not found' / 'already removed' messages, so it logs a WARN and the channel tears down — the admin <code>driver-locations</code> channel reaches <code>subscribed</code> then closes ~1ms later. <strong>Fix:</strong> drop the per-event <code>off()</code> path and tear down via <code>client.removeChannel(channel)</code> / <code>channel.unsubscribe()</code> (supabase-js v2 has no per-callback removal). Confirmed live during REA-DRT-07 verification on 2026-05-20 (channel <code>subscribed</code> → cleanup TypeError → <code>closed</code>). Blocks DRT-06+. Promoted from QA fail <strong>REA-DRT-05</strong> (sub-step DT5-01, Critical). <strong>In progress:</strong> fixed in PR #410 (stable broadcast dispatcher; removed the phantom <code>channel.off()</code> + its <code>.d.ts</code> augmentation; 38 tests). The TypeError + cleanup WARN are verified gone. The remaining subscribe→close (StrictMode) is split to <code>rea-367b-realtime-strictmode-resubscribe</code>."
+      "description": "<code>RealtimeChannelManager.off()</code> (<code>src/lib/realtime/channels.ts:168-173</code>) calls <code>this.channel.off('broadcast', { event }, listener)</code>, but the Supabase <code>RealtimeChannel</code> has no runtime <code>.off()</code> — that's a Phoenix Channels method present only via a <code>.d.ts</code> type augmentation. So cleanup throws <code>TypeError: this.channel.off is not a function</code>; the <code>catch</code> only swallows 'closed' / 'not found' / 'already removed' messages, so it logs a WARN and the channel tears down — the admin <code>driver-locations</code> channel reaches <code>subscribed</code> then closes ~1ms later. <strong>Fix:</strong> drop the per-event <code>off()</code> path and tear down via <code>client.removeChannel(channel)</code> / <code>channel.unsubscribe()</code> (supabase-js v2 has no per-callback removal). Confirmed live during REA-DRT-07 verification on 2026-05-20 (channel <code>subscribed</code> → cleanup TypeError → <code>closed</code>). Blocks DRT-06+. Promoted from QA fail <strong>REA-DRT-05</strong> (sub-step DT5-01, Critical). <strong>DONE (PR #410, merged 2026-05-22, live via #412):</strong> fixed in PR #410 (stable broadcast dispatcher; removed the phantom <code>channel.off()</code> + its <code>.d.ts</code> augmentation; 38 tests). The TypeError + cleanup WARN are verified gone. The remaining subscribe→close (StrictMode) is split to <code>rea-367b-realtime-strictmode-resubscribe</code>."
     },
     {
       "id": "rea-367b-realtime-strictmode-resubscribe",
@@ -428,6 +430,93 @@
         "bug"
       ],
       "description": "Split from REA-367. After the <code>channel.off</code> fix (PR #410), the admin <code>driver-locations</code> channel still reaches <code>subscribed</code> then closes ~1ms later in dev and does not re-subscribe. Root cause is a React <strong>StrictMode</strong> double-invoke race in <code>useAdminRealtimeTracking</code> (<code>src/hooks/tracking/useAdminRealtimeTracking.ts:512-534</code>): mount 1's deferred <code>.then</code> cleanup (lines 518-523) calls <code>removeChannel('driver-locations')</code> on the channel mount 2 established (the RealtimeClient dedups by channel name), tearing it down with no re-subscribe. StrictMode double-invoke is <strong>dev-only</strong>, so production single-mount is unaffected — but it blocks dev/QA (DRT-06+). <strong>Fix direction:</strong> ref-count or guard the shared channel so a stale mount's cleanup can't remove a channel a live mount owns (or key channels per-subscriber). Verify on <code>development.readysetllc.com</code> (prod build, no StrictMode double-invoke) after #410 merges. Found during #410 verification on 2026-05-20."
+    },
+    {
+      "id": "migrate-vercel-to-vps",
+      "status": "progress",
+      "title": "Migrate all sites/apps from Vercel → Hetzner VPS",
+      "owner": "emmanuel",
+      "source": "jun1",
+      "tags": [
+        "critical"
+      ],
+      "description": "<strong>Decision aligned Jun 1.</strong> Vercel now bills per-deployment (cost creep; $24 pending) and has had security issues; consolidate all live websites + tracking apps onto a single Hetzner VPS for cost control, performance, and direct management (~5 hrs/month maintenance). In progress on branch <code>chore/self-host-image-envs</code> (CI builds the prod image → GHCR). See <code>docs/STATUS.md</code> → infra."
+    },
+    {
+      "id": "migrate-error-tracking-self-host",
+      "status": "new",
+      "title": "Self-host the error-tracking app on the VPS",
+      "owner": "emmanuel",
+      "source": "jun1",
+      "description": "The free hosted error-tracking tier hit its event-capture limit. Relocate the error-tracking app to the dedicated VPS to remove usage caps. Part of the Vercel → VPS migration."
+    },
+    {
+      "id": "driver-photo-signature-required",
+      "status": "new",
+      "title": "Mandatory driver photo + signature capture",
+      "owner": "emmanuel",
+      "source": "jun1",
+      "description": "<strong>Decision aligned Jun 1.</strong> Driver interface must enforce as mandatory fields: photo of food at the vendor (pickup), photo of the setup at completion, and a signature on completion — or the recipient's name if a signature is refused. For driver accountability."
+    },
+    {
+      "id": "mobile-refresh-rate-testing",
+      "status": "progress",
+      "title": "Fix mobile refresh-rate issue + continue device testing",
+      "owner": "emmanuel",
+      "source": "jun1",
+      "tags": [
+        "bug"
+      ],
+      "description": "Android + Apple device testing (week of May 29) surfaced a refresh-rate issue in the driver/tracking UI. Fix it and run further functional-error testing across this week. Co-owners: Fernando (testing), Gary (field screenshots)."
+    },
+    {
+      "id": "dashboard-redesign-helpdesk",
+      "status": "progress",
+      "title": "Help-desk dashboard front-end redesign",
+      "owner": "emmanuel",
+      "source": "jun1",
+      "description": "Redesign in progress: simpler, more organized view for the help-desk team. Mobile-first, dark mode, in-app error reporting, improved responsiveness."
+    },
+    {
+      "id": "gary-email-cater-client",
+      "status": "new",
+      "title": "Email CaterCow re: API endpoint + timeline",
+      "owner": "gary",
+      "source": "jun1",
+      "description": "No recent updates from CaterCow on their webhook/API endpoint or testing. Gary to email (referencing the May 13 correspondence) requesting an update and pushing them to proceed to production. Unblocks the CaterCow webhook work (<code>catercow-webhook-preconfigure</code>, <code>catercow-hmac-secret</code>)."
+    },
+    {
+      "id": "emmanuel-forward-cater-email",
+      "status": "new",
+      "title": "Forward prior CaterCow correspondence to Gary",
+      "owner": "emmanuel",
+      "source": "jun1",
+      "description": "Forward the previous CaterCow email thread to Gary so he can follow up (see <code>gary-email-cater-client</code>)."
+    },
+    {
+      "id": "gary-screenshot-layout-errors",
+      "status": "new",
+      "title": "Capture screenshots of layout problems / errors",
+      "owner": "gary",
+      "source": "jun1",
+      "description": "Gary to capture and provide screenshots of any layout issues or errors encountered while using the app, to feed the bug queue."
+    },
+    {
+      "id": "fernando-verify-driver-pay",
+      "status": "new",
+      "title": "Verify driver payment calculation accuracy",
+      "owner": "fernando",
+      "source": "jun1",
+      "description": "Fernando shifting toward help-desk ops; review the testing results to confirm driver payment amounts calculate correctly."
+    },
+    {
+      "id": "catercow-durable-webhook-retry",
+      "status": "open",
+      "owner": "emmanuel",
+      "source": "catercow",
+      "title": "Durable webhook retry queue (fast-follow)",
+      "description": "v1 dispatcher does in-request retries (3 attempts, short backoff). The contract promises “5 attempts over ~30 min”, which needs a queue/cron, not in-request retries. Build a <code>partner_webhook_deliveries</code> table + cron worker on top of the existing <code>order_status_history</code> table. Not a go-live blocker — missed callbacks are recoverable via <code>GET /orders/{id}</code>.",
+      "tags": []
     }
   ]
 }

--- a/src/lib/services/partner-registry.ts
+++ b/src/lib/services/partner-registry.ts
@@ -57,6 +57,7 @@ interface CacheEntry {
 
 const cacheByHash = new Map<string, CacheEntry>();
 const cacheBySlug = new Map<string, { partner: ResolvedPartner; expiresAt: number }>();
+let cacheActivePartners: { partners: ResolvedPartner[]; expiresAt: number } | null = null;
 
 function bypassCache(): boolean {
   return process.env.NODE_ENV === 'test';
@@ -132,6 +133,39 @@ export async function getPartnerBySlug(slug: string): Promise<ResolvedPartner | 
 }
 
 /**
+ * Resolve the partner that owns an order from its order number. Orders
+ * are persisted with `orderNumber = <orderPrefix><orderCode>` (e.g.
+ * `CC-12345`), so we match the order number against each active
+ * partner's `orderPrefix`. Used by the outbound webhook dispatcher to
+ * find the `webhookUrl` / `webhookSecret` for a status change.
+ *
+ * The active-partner list is tiny and cached for 60s, so this stays off
+ * the hot path of every driver status update. When prefixes overlap the
+ * longest match wins, so a more specific prefix can't be shadowed.
+ */
+export async function getPartnerByOrderNumber(orderNumber: string): Promise<ResolvedPartner | null> {
+  if (!orderNumber) return null;
+
+  let partners: ResolvedPartner[];
+  if (!bypassCache() && cacheActivePartners && cacheActivePartners.expiresAt > Date.now()) {
+    partners = cacheActivePartners.partners;
+  } else {
+    const rows = await prisma.apiPartner.findMany({
+      where: { deletedAt: null, isActive: true },
+    });
+    partners = rows.map(toResolvedPartner);
+    if (!bypassCache()) {
+      cacheActivePartners = { partners, expiresAt: Date.now() + POSITIVE_TTL_MS };
+    }
+  }
+
+  const match = partners
+    .filter((p) => p.orderPrefix && orderNumber.startsWith(p.orderPrefix))
+    .sort((a, b) => b.orderPrefix.length - a.orderPrefix.length)[0];
+  return match ?? null;
+}
+
+/**
  * Authenticate a partner request. Reads the `partner` and `x-api-key`
  * headers, hashes the key, looks up the partner row, and verifies that
  * the resolved row's slug matches the header value. Active flag is
@@ -198,6 +232,7 @@ export async function authenticatePartner(request: NextRequest | Request): Promi
 export function _resetPartnerCacheForTests(): void {
   cacheByHash.clear();
   cacheBySlug.clear();
+  cacheActivePartners = null;
 }
 
 /**

--- a/src/lib/services/partnerWebhookService.ts
+++ b/src/lib/services/partnerWebhookService.ts
@@ -1,0 +1,248 @@
+/**
+ * Partner outbound webhook dispatcher (registry-driven).
+ *
+ * The legacy `CarrierWebhookService` only knows about partners hardcoded
+ * in `CARRIER_CONFIGS` (CaterValley, ezCater). This service is the
+ * general path for any partner in the `api_partners` registry — it reads
+ * `webhookUrl` / `webhookSecret` off the resolved partner row at send
+ * time and POSTs the contract-shaped status payload, HMAC-SHA256 signed
+ * with the `x-readyset-signature` header (see `docs/catercow/API_CONTRACT.md`).
+ *
+ * Retry model (v1): up to 3 synchronous attempts with exponential
+ * backoff, no retry on 4xx. The contract's "5 attempts over ~30 min"
+ * durability needs a queue/cron and is a planned fast-follow; until then
+ * a missed callback is recoverable by the partner via GET /orders/{id}.
+ */
+
+import { DriverStatus } from '@/types/prisma';
+import { prisma } from '@/lib/db/prisma';
+import { signPayload, SIGNATURE_HEADER } from '@/lib/security/hmac';
+import { getPartnerByOrderNumber, type ResolvedPartner } from '@/lib/services/partner-registry';
+import { CarrierServiceClient } from '@/lib/services/carrier-service-client';
+import { webhookLogger } from '@/lib/services/webhook-logger';
+import { carrierLogger } from '@/utils/logger';
+
+/** Partner-facing lifecycle states, per the v0.1 API contract. */
+export type PartnerLifecycleStatus =
+  | 'ASSIGNED'
+  | 'PICKED_UP'
+  | 'ON_THE_WAY'
+  | 'ARRIVED'
+  | 'DELIVERED'
+  | 'CANCELLED';
+
+/**
+ * Map our internal driver status to the partner-facing lifecycle event.
+ * `null` means "no partner event for this internal transition" — the
+ * vendor-leg states are operational detail we don't surface to partners.
+ * `CANCELLED` is not here because it isn't a driver-status change; it's
+ * emitted directly from the confirm/cancel path.
+ */
+export const DRIVER_STATUS_TO_PARTNER_LIFECYCLE: Record<DriverStatus, PartnerLifecycleStatus | null> = {
+  ASSIGNED: 'ASSIGNED',
+  EN_ROUTE_TO_VENDOR: null,
+  ARRIVED_AT_VENDOR: null,
+  PICKED_UP: 'PICKED_UP',
+  EN_ROUTE_TO_CLIENT: 'ON_THE_WAY',
+  ARRIVED_TO_CLIENT: 'ARRIVED',
+  COMPLETED: 'DELIVERED',
+};
+
+export interface PartnerWebhookInput {
+  /** Resolved partner row (carries webhookUrl / webhookSecret). */
+  partner: ResolvedPartner;
+  /** Ready Set order UUID. */
+  orderId: string;
+  /** Partner's original order code (order number with the prefix stripped). */
+  orderCode: string;
+  /** Ready Set order number (e.g. `CC-12345`). */
+  orderNumber: string;
+  status: PartnerLifecycleStatus;
+  driver?: { name: string; phone: string };
+  location?: { lat: number; lng: number };
+  notes?: string;
+}
+
+export type PartnerWebhookResult =
+  | { delivered: true; attempts: number; httpStatus: number }
+  | { delivered: false; skipped: 'misconfigured'; attempts: 0; httpStatus: null }
+  | { delivered: false; attempts: number; lastError: string; httpStatus: number | null };
+
+const RETRY = { maxAttempts: 3, baseDelayMs: 1000, timeoutMs: 10_000 };
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Send a single status webhook to a partner. Best-effort: never throws —
+ * callers fire-and-forget after the order state is already committed, so
+ * a delivery failure must not roll back or fail the originating request.
+ */
+export async function dispatchPartnerWebhook(input: PartnerWebhookInput): Promise<PartnerWebhookResult> {
+  const { partner } = input;
+
+  if (!partner.webhookUrl || !partner.webhookSecret) {
+    carrierLogger.info(
+      `[partner-webhook] skipped — partner ${partner.slug} has no webhook ${
+        !partner.webhookUrl ? 'URL' : 'secret'
+      } configured (order ${input.orderNumber}, status ${input.status})`
+    );
+    return { delivered: false, skipped: 'misconfigured', attempts: 0, httpStatus: null };
+  }
+
+  const payload = {
+    orderId: input.orderId,
+    orderCode: input.orderCode,
+    orderNumber: input.orderNumber,
+    status: input.status,
+    timestamp: new Date().toISOString(),
+    ...(input.driver ? { driver: input.driver } : {}),
+    ...(input.location ? { location: input.location } : {}),
+    ...(input.notes ? { notes: input.notes } : {}),
+  };
+  const body = JSON.stringify(payload);
+  const signature = await signPayload(partner.webhookSecret, body);
+
+  let lastError = 'unknown error';
+  let lastStatus: number | null = null;
+
+  for (let attempt = 1; attempt <= RETRY.maxAttempts; attempt++) {
+    const start = Date.now();
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), RETRY.timeoutMs);
+
+    try {
+      const res = await fetch(partner.webhookUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          [SIGNATURE_HEADER]: signature,
+        },
+        body,
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+      lastStatus = res.status;
+      const responseTime = Date.now() - start;
+
+      if (res.ok) {
+        await webhookLogger.logSuccess({
+          carrierId: partner.slug,
+          orderNumber: input.orderNumber,
+          status: input.status,
+          responseTime,
+        });
+        return { delivered: true, attempts: attempt, httpStatus: res.status };
+      }
+
+      lastError = `HTTP ${res.status}`;
+      await webhookLogger.logFailure({
+        carrierId: partner.slug,
+        orderNumber: input.orderNumber,
+        status: input.status,
+        errorMessage: lastError,
+        responseTime,
+      });
+
+      // 4xx is a client error on the partner's side — retrying won't help.
+      if (res.status >= 400 && res.status < 500) break;
+    } catch (err) {
+      clearTimeout(timeoutId);
+      lastError =
+        err instanceof Error
+          ? err.name === 'AbortError'
+            ? `request timed out after ${RETRY.timeoutMs}ms`
+            : err.message
+          : 'unknown error';
+      await webhookLogger.logFailure({
+        carrierId: partner.slug,
+        orderNumber: input.orderNumber,
+        status: input.status,
+        errorMessage: lastError,
+        responseTime: Date.now() - start,
+      });
+    }
+
+    if (attempt < RETRY.maxAttempts) {
+      await sleep(RETRY.baseDelayMs * Math.pow(2, attempt - 1));
+    }
+  }
+
+  return { delivered: false, attempts: RETRY.maxAttempts, lastError, httpStatus: lastStatus };
+}
+
+function stripPrefix(orderNumber: string, prefix: string): string {
+  return prefix && orderNumber.startsWith(prefix) ? orderNumber.slice(prefix.length) : orderNumber;
+}
+
+export interface LifecycleEventInput {
+  /** Ready Set order UUID (catering_requests.id). */
+  orderId: string;
+  /** Ready Set order number (e.g. `CC-12345`). */
+  orderNumber: string;
+  partnerStatus: PartnerLifecycleStatus;
+  /** Internal status that triggered the event; null for CANCELLED. */
+  driverStatus?: DriverStatus | null;
+  /** Profile id of whoever drove the change (driver/admin), if known. */
+  changedBy?: string | null;
+  driver?: { name: string; phone: string };
+  location?: { lat: number; lng: number };
+  notes?: string;
+}
+
+/**
+ * Record a partner lifecycle event to `order_status_history` and dispatch
+ * the outbound webhook. Self-contained and best-effort — never throws, so
+ * callers can fire it after the order state is already committed:
+ *
+ *  - Resolves the owning partner from the order number; no-ops if the
+ *    order isn't owned by a registry partner.
+ *  - Skips partners handled by the legacy `CARRIER_CONFIGS` path
+ *    (CaterValley / ezCater) so we never double-send.
+ *  - Persists the history row first so GET /orders/{id} reflects the
+ *    event even when webhook delivery fails.
+ */
+export async function recordAndDispatchLifecycleEvent(input: LifecycleEventInput): Promise<void> {
+  try {
+    // Legacy carriers own their outbound path; don't duplicate here.
+    if (CarrierServiceClient.detectCarrier(input.orderNumber)) return;
+
+    const partner = await getPartnerByOrderNumber(input.orderNumber);
+    if (!partner) return;
+
+    try {
+      await prisma.orderStatusHistory.create({
+        data: {
+          cateringRequestId: input.orderId,
+          partnerStatus: input.partnerStatus,
+          driverStatus: input.driverStatus ?? null,
+          changedBy: input.changedBy ?? null,
+          location: input.location ?? undefined,
+          notes: input.notes,
+        },
+      });
+    } catch (err) {
+      carrierLogger.error(
+        `[partner-webhook] failed to record status history for ${input.orderNumber}:`,
+        err
+      );
+    }
+
+    await dispatchPartnerWebhook({
+      partner,
+      orderId: input.orderId,
+      orderCode: stripPrefix(input.orderNumber, partner.orderPrefix),
+      orderNumber: input.orderNumber,
+      status: input.partnerStatus,
+      driver: input.driver,
+      location: input.location,
+      notes: input.notes,
+    });
+  } catch (err) {
+    carrierLogger.error(
+      `[partner-webhook] lifecycle dispatch failed for ${input.orderNumber}:`,
+      err
+    );
+  }
+}


### PR DESCRIPTION
Closes the outbound-webhook gap in the CaterCow partner integration: lifecycle callbacks now fire to registry partners, and partners get a read endpoint to resync after a missed callback.

## What this adds
- **`order_status_history` table** (migration `20260605000000_add_order_status_history`) — append-only log of partner-facing lifecycle events; substrate for the GET endpoint and a future durable retry queue. Applied to the **dev** Supabase project; prod applies on merge (`CREATE TABLE IF NOT EXISTS`, RLS-no-policies).
- **`partnerWebhookService.ts`** — registry-driven dispatcher. Reads `webhookUrl`/`webhookSecret` off the resolved `api_partners` row, builds the contract payload, HMAC-SHA256 signs it (`x-readyset-signature`), 3-attempt backoff (no retry on 4xx), and skips with a logged notice when unconfigured. `recordAndDispatchLifecycleEvent` writes history + dispatches, self-guarding against legacy `CARRIER_CONFIGS` carriers and non-partner orders.
- **`getPartnerByOrderNumber`** — resolves the owning partner from an order number by `orderPrefix` (cached).
- **Wiring** — driver status route maps internal `driverStatus` → `ASSIGNED/PICKED_UP/ON_THE_WAY/ARRIVED/DELIVERED`; confirm cancel branch emits `CANCELLED`.
- **`GET /api/partners/orders/{id}`** (+ cater-valley alias) — current status + last 10 lifecycle events, same ownership check as the writes.
- **`scripts/set-partner-webhook.ts`** — set webhook url + (generated) HMAC secret on a partner row, print-once for 1Password delivery.

## Tests / gates
- New: dispatcher unit tests (7) + GET endpoint tests (6) — green.
- `typecheck`, `prisma validate`, lint clean; existing partner/status tests (39) still pass.

## Notes for reviewers
- **Retry durability:** v1 is in-request best-effort. The contract's "5 attempts / ~30 min" needs a queue/cron — tracked as a fast-follow (`partner_webhook_deliveries` + worker) on top of the history table. Not a go-live blocker (missed callbacks recover via `GET /orders/{id}`).
- **Latency:** dispatch is awaited inside the driver status update (same as the existing CaterValley path), so a slow/down partner endpoint can add up to ~3s. The durable-queue fast-follow removes this.
- **Post-deploy ops (not in this PR):** run `set-partner-webhook.ts` against staging to set CaterCow's `webhook_url` + deliver the generated secret to the partner via 1Password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)