### PR TITLE
security: harden driver tracking routes against IDOR + SQL injection (OWASP A01/A03)

### DIFF
--- a/src/__tests__/api/tracking/drivers.test.ts
+++ b/src/__tests__/api/tracking/drivers.test.ts
@@ -18,8 +18,14 @@ jest.mock('pg', () => {
   };
 });
 
+// Route gained withAuth in the security-hardening pass — mock it (default ADMIN).
+jest.mock('@/lib/auth-middleware', () => ({ withAuth: jest.fn() }));
+
 import { GET, POST, PUT } from '@/app/api/tracking/drivers/route';
+import { withAuth } from '@/lib/auth-middleware';
 import type * as pg from 'pg';
+
+const mockWithAuth = withAuth as jest.Mock;
 
 // Access the mock query function
 const { __mockQuery: mockQuery } = jest.requireMock<typeof pg & { __mockQuery: jest.Mock }>('pg');
@@ -27,6 +33,10 @@ const { __mockQuery: mockQuery } = jest.requireMock<typeof pg & { __mockQuery: j
 describe('/api/tracking/drivers', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockWithAuth.mockResolvedValue({
+      success: true,
+      context: { user: { id: 'admin-1', type: 'ADMIN' } },
+    });
   });
 
   describe('GET /api/tracking/drivers', () => {

--- a/src/__tests__/api/tracking/locations.test.ts
+++ b/src/__tests__/api/tracking/locations.test.ts
@@ -29,6 +29,11 @@ jest.mock('pg', () => {
 // Export mocks for the pg mock to access
 module.exports = { mocks };
 
+// Route gained withAuth in the security-hardening pass — mock it (default ADMIN).
+jest.mock('@/lib/auth-middleware', () => ({ withAuth: jest.fn() }));
+import { withAuth } from '@/lib/auth-middleware';
+const mockWithAuth = withAuth as jest.Mock;
+
 import { GET, POST } from '@/app/api/tracking/locations/route';
 import {
   createGetRequest,
@@ -40,6 +45,10 @@ import {
 describe('/api/tracking/locations API', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockWithAuth.mockResolvedValue({
+      success: true,
+      context: { user: { id: 'admin-1', type: 'ADMIN' } },
+    });
     // Reset connect mock to return a client with query and release
     mocks.connect.mockResolvedValue({
       query: mocks.clientQuery,
@@ -352,10 +361,12 @@ describe('/api/tracking/locations API', () => {
 
         await POST(request);
 
-        // Verify driver update query was called with correct POINT string
+        // Verify driver update used the parameterized geometry (security hardening:
+        // coordinates are bound as numeric params, never string-interpolated).
         const updateCall = mocks.clientQuery.mock.calls[3];
         expect(updateCall[0]).toContain('UPDATE drivers');
-        expect(updateCall[1]).toContain('POINT(-97.7431 30.2672)');
+        expect(updateCall[0]).toContain('ST_MakePoint');
+        expect(updateCall[1]).toEqual([-97.7431, 30.2672, 'driver-123']);
       });
 
       it('should rollback transaction on error', async () => {

--- a/src/app/actions/tracking/__tests__/delivery-actions.security.test.ts
+++ b/src/app/actions/tracking/__tests__/delivery-actions.security.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Security tests for the updateDeliveryStatus server action.
+ *
+ * Guards added in the driver-redesign hardening pass (OWASP A01 / IDOR):
+ *  - the caller must be authenticated
+ *  - a non-admin caller may only mutate a delivery assigned to their own driver
+ *  - the deliveryId must be a valid UUID before it reaches raw SQL
+ */
+
+import { updateDeliveryStatus } from "../delivery-actions";
+import { prisma } from "@/utils/prismaDB";
+import { createClient } from "@/utils/supabase/server";
+import { getUserRole } from "@/lib/auth";
+import { DriverStatus } from "@/types/user";
+
+jest.mock("@/utils/prismaDB", () => ({
+  prisma: {
+    $queryRawUnsafe: jest.fn(),
+    $executeRawUnsafe: jest.fn(),
+  },
+}));
+jest.mock("@/utils/supabase/server", () => ({ createClient: jest.fn() }));
+jest.mock("@/lib/auth", () => ({ getUserRole: jest.fn() }));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+
+const mockPrisma = prisma as unknown as {
+  $queryRawUnsafe: jest.Mock;
+  $executeRawUnsafe: jest.Mock;
+};
+const mockCreateClient = createClient as jest.Mock;
+const mockGetUserRole = getUserRole as jest.Mock;
+
+const VALID_ID = "11111111-1111-4111-8111-111111111111";
+
+function mockAuth(user: { id: string } | null) {
+  mockCreateClient.mockResolvedValue({
+    auth: { getUser: jest.fn().mockResolvedValue({ data: { user } }) },
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPrisma.$executeRawUnsafe.mockResolvedValue(undefined);
+});
+
+describe("updateDeliveryStatus security", () => {
+  it("rejects an invalid deliveryId before touching the DB", async () => {
+    const res = await updateDeliveryStatus("not-a-uuid", DriverStatus.PICKED_UP);
+    expect(res).toEqual({ success: false, error: "Invalid deliveryId" });
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unauthenticated caller", async () => {
+    mockAuth(null);
+    const res = await updateDeliveryStatus(VALID_ID, DriverStatus.PICKED_UP);
+    expect(res).toEqual({ success: false, error: "Authentication required" });
+    expect(mockPrisma.$executeRawUnsafe).not.toHaveBeenCalled();
+  });
+
+  it("denies a driver who does not own the delivery (IDOR)", async () => {
+    mockAuth({ id: "user-attacker" });
+    mockGetUserRole.mockResolvedValue("DRIVER");
+    mockPrisma.$queryRawUnsafe.mockImplementation((sql: string) => {
+      if (sql.includes("FROM deliveries")) return Promise.resolve([{ driver_id: "driver-victim" }]);
+      if (sql.includes("FROM drivers")) return Promise.resolve([]); // not owned
+      return Promise.resolve([]);
+    });
+
+    const res = await updateDeliveryStatus(VALID_ID, DriverStatus.PICKED_UP);
+    expect(res).toEqual({ success: false, error: "Access denied" });
+    expect(mockPrisma.$executeRawUnsafe).not.toHaveBeenCalled();
+  });
+
+  it("allows the assigned driver to advance their own delivery", async () => {
+    mockAuth({ id: "user-owner" });
+    mockGetUserRole.mockResolvedValue("DRIVER");
+    mockPrisma.$queryRawUnsafe.mockImplementation((sql: string) => {
+      if (sql.includes("FROM deliveries")) return Promise.resolve([{ driver_id: "driver-1" }]);
+      if (sql.includes("FROM drivers")) return Promise.resolve([{ id: "driver-1" }]);
+      return Promise.resolve([]);
+    });
+
+    const res = await updateDeliveryStatus(VALID_ID, DriverStatus.PICKED_UP);
+    expect(res).toEqual({ success: true });
+    expect(mockPrisma.$executeRawUnsafe).toHaveBeenCalled();
+  });
+
+  it("lets an admin advance any delivery without an ownership row", async () => {
+    mockAuth({ id: "user-admin" });
+    mockGetUserRole.mockResolvedValue("ADMIN");
+    mockPrisma.$queryRawUnsafe.mockImplementation((sql: string) => {
+      if (sql.includes("FROM deliveries")) return Promise.resolve([{ driver_id: "driver-1" }]);
+      return Promise.resolve([]); // ownership lookup must NOT be required
+    });
+
+    const res = await updateDeliveryStatus(VALID_ID, DriverStatus.PICKED_UP);
+    expect(res).toEqual({ success: true });
+  });
+
+  it("does not write a location when coordinates are out of range", async () => {
+    mockAuth({ id: "user-owner" });
+    mockGetUserRole.mockResolvedValue("DRIVER");
+    mockPrisma.$queryRawUnsafe.mockImplementation((sql: string) => {
+      if (sql.includes("FROM deliveries")) return Promise.resolve([{ driver_id: "driver-1" }]);
+      if (sql.includes("FROM drivers")) return Promise.resolve([{ id: "driver-1" }]);
+      return Promise.resolve([]);
+    });
+
+    await updateDeliveryStatus(VALID_ID, DriverStatus.PICKED_UP, {
+      driverId: "driver-1",
+      coordinates: { lat: 999, lng: 999 }, // invalid
+      accuracy: 0,
+      speed: 0,
+      heading: 0,
+      isMoving: false,
+      activityType: "stationary",
+      timestamp: new Date(),
+    });
+
+    // Only the deliveries UPDATE should run — never the drivers location UPDATE.
+    const ranLocationUpdate = mockPrisma.$executeRawUnsafe.mock.calls.some(
+      ([sql]) => typeof sql === "string" && sql.includes("UPDATE drivers"),
+    );
+    expect(ranLocationUpdate).toBe(false);
+  });
+});

--- a/src/app/actions/tracking/delivery-actions.ts
+++ b/src/app/actions/tracking/delivery-actions.ts
@@ -6,6 +6,8 @@ import { revalidatePath } from 'next/cache';
 import type { LocationUpdate, DeliveryTracking } from '@/types/tracking';
 import { DriverStatus } from '@/types/user';
 import { getTimestampUpdatesForStatus } from '@/lib/delivery-status-transitions';
+import { createClient } from '@/utils/supabase/server';
+import { getUserRole } from '@/lib/auth';
 
 /**
  * Update delivery status with location and optional proof of delivery
@@ -18,6 +20,22 @@ export async function updateDeliveryStatus(
   notes?: string
 ): Promise<{ success: boolean; error?: string }> {
   try {
+    // Validate the id shape before it touches raw SQL.
+    if (!z.string().uuid().safeParse(deliveryId).success) {
+      return { success: false, error: 'Invalid deliveryId' };
+    }
+
+    // AuthN: the caller must be signed in.
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return { success: false, error: 'Authentication required' };
+    }
+    const role = (await getUserRole(user.id))?.toUpperCase();
+    const isPrivileged = role === 'ADMIN' || role === 'SUPER_ADMIN';
+
     // Get current delivery info
     const delivery = await prisma.$queryRawUnsafe<{
       driver_id: string;
@@ -32,6 +50,18 @@ export async function updateDeliveryStatus(
     }
 
     const deliveryRecord = delivery[0];
+
+    // AuthZ: a non-admin caller may only mutate a delivery assigned to their
+    // own driver record (drivers.user_id === auth user id). Prevents one driver
+    // from advancing another driver's delivery (IDOR).
+    if (!isPrivileged) {
+      const owns = await prisma.$queryRawUnsafe<{ id: string }[]>(`
+        SELECT id FROM drivers WHERE id = $1::uuid AND user_id = $2::uuid
+      `, deliveryRecord?.driver_id, user.id);
+      if (owns.length === 0) {
+        return { success: false, error: 'Access denied' };
+      }
+    }
 
     // Prepare update fields
     const updateFields: string[] = ['status = $2', 'updated_at = NOW()'];
@@ -65,18 +95,32 @@ export async function updateDeliveryStatus(
       WHERE id = $1::uuid
     `, ...params);
 
-    // Update driver location if provided
-    if (location && deliveryRecord?.driver_id) {
+    // Update driver location if provided. Coordinates are validated and bound
+    // as numeric params (ST_MakePoint) — never string-interpolated into SQL.
+    const lng = location?.coordinates?.lng;
+    const lat = location?.coordinates?.lat;
+    const validCoords =
+      typeof lng === 'number' &&
+      typeof lat === 'number' &&
+      Number.isFinite(lng) &&
+      Number.isFinite(lat) &&
+      lat >= -90 &&
+      lat <= 90 &&
+      lng >= -180 &&
+      lng <= 180;
+
+    if (validCoords && deliveryRecord?.driver_id) {
       await prisma.$executeRawUnsafe(`
-        UPDATE drivers 
-        SET 
-          last_known_location = ST_GeogFromText($2),
+        UPDATE drivers
+        SET
+          last_known_location = ST_SetSRID(ST_MakePoint($2, $3), 4326)::geography,
           last_location_update = NOW(),
           updated_at = NOW()
         WHERE id = $1::uuid
       `,
         deliveryRecord.driver_id,
-        `POINT(${location.coordinates.lng} ${location.coordinates.lat})`
+        lng,
+        lat
       );
     }
 

--- a/src/app/api/orders/[order_number]/route.ts
+++ b/src/app/api/orders/[order_number]/route.ts
@@ -411,6 +411,38 @@ export async function PATCH(
       return NextResponse.json({ message: "Order not found" }, { status: 404 });
     }
 
+    // AuthZ for driver-status updates (OWASP A01 / IDOR): a DRIVER may only
+    // advance the status of an order assigned to THEM via Dispatch. Dispatch.driver
+    // references Profile, whose id equals the auth user id. Admins/helpdesk are
+    // exempt (they manage all orders). Without this, any authenticated driver
+    // could advance any order's driverStatus.
+    if (driverStatus) {
+      const { data: callerProfile } = await supabase
+        .from('profiles')
+        .select('type')
+        .eq('id', user.id)
+        .single();
+      const callerType = callerProfile?.type?.toUpperCase();
+      const privileged =
+        callerType === 'ADMIN' ||
+        callerType === 'SUPER_ADMIN' ||
+        callerType === 'HELPDESK';
+
+      if (!privileged) {
+        const dispatches = (existingOrder as any).dispatches;
+        const assignedDriverProfileId =
+          Array.isArray(dispatches) && dispatches.length > 0
+            ? dispatches[0]?.driver?.id
+            : undefined;
+        if (!assignedDriverProfileId || assignedDriverProfileId !== user.id) {
+          return NextResponse.json(
+            { message: "You are not assigned to this delivery" },
+            { status: 403 },
+          );
+        }
+      }
+    }
+
     // For full field updates (not just status), check permissions and terminal status
     if (hasFieldUpdates) {
       // Get user profile to check role

--- a/src/app/api/tracking/drivers/route.ts
+++ b/src/app/api/tracking/drivers/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { withAuth } from '@/lib/auth-middleware';
 // import { Pool } from 'pg';
 const Pool = require('pg').Pool;
 
@@ -38,8 +39,15 @@ interface DriverLocation {
   longitude: number;
 }
 
-// GET - List all drivers
+// GET - List drivers (admins) / own record (drivers)
 export async function GET(request: NextRequest) {
+  // AuthZ: drivers see only themselves; admins/helpdesk see all.
+  const auth = await withAuth(request, {
+    allowedRoles: ['DRIVER', 'ADMIN', 'SUPER_ADMIN', 'HELPDESK'],
+    requireAuth: true,
+  });
+  if (!auth.success) return auth.response;
+
   try {
     const { searchParams } = new URL(request.url);
     const isActive = searchParams.get('active');
@@ -73,6 +81,13 @@ export async function GET(request: NextRequest) {
     
     const params: (string | number | boolean)[] = [];
     let paramCounter = 1;
+
+    // Drivers are scoped to their own record (drivers.user_id === auth user id).
+    if (auth.context.user.type === 'DRIVER') {
+      query += ` AND user_id = $${paramCounter}`;
+      params.push(auth.context.user.id);
+      paramCounter++;
+    }
 
     if (isActive !== null) {
       query += ` AND is_active = $${paramCounter}`;
@@ -119,8 +134,14 @@ export async function GET(request: NextRequest) {
   }
 }
 
-// POST - Create new driver
+// POST - Create new driver (admins only)
 export async function POST(request: NextRequest) {
+  const auth = await withAuth(request, {
+    allowedRoles: ['ADMIN', 'SUPER_ADMIN'],
+    requireAuth: true,
+  });
+  if (!auth.success) return auth.response;
+
   try {
     const body = await request.json();
     const {
@@ -202,8 +223,14 @@ export async function POST(request: NextRequest) {
   }
 }
 
-// PUT - Update driver location
+// PUT - Update driver location / duty (drivers: own record only)
 export async function PUT(request: NextRequest) {
+  const auth = await withAuth(request, {
+    allowedRoles: ['DRIVER', 'ADMIN', 'SUPER_ADMIN'],
+    requireAuth: true,
+  });
+  if (!auth.success) return auth.response;
+
   try {
     const body = await request.json();
     const { driver_id, location, is_on_duty } = body;
@@ -215,14 +242,36 @@ export async function PUT(request: NextRequest) {
       );
     }
 
+    // A DRIVER may only update their own record.
+    if (auth.context.user.type === 'DRIVER') {
+      const owns = await pool.query(
+        'SELECT id FROM drivers WHERE id = $1 AND user_id = $2',
+        [driver_id, auth.context.user.id]
+      );
+      if (owns.rows.length === 0) {
+        return NextResponse.json(
+          { success: false, error: 'Access denied' },
+          { status: 403 }
+        );
+      }
+    }
+
     let query = 'UPDATE drivers SET last_location_update = NOW()';
     const params: (string | number | boolean)[] = [];
     let paramCounter = 1;
 
-    if (location && location.latitude && location.longitude) {
-      query += `, last_known_location = ST_GeogFromText($${paramCounter})`;
-      params.push(`POINT(${location.longitude} ${location.latitude})`);
-      paramCounter++;
+    if (
+      location &&
+      typeof location.latitude === 'number' &&
+      typeof location.longitude === 'number' &&
+      location.latitude >= -90 &&
+      location.latitude <= 90 &&
+      location.longitude >= -180 &&
+      location.longitude <= 180
+    ) {
+      query += `, last_known_location = ST_SetSRID(ST_MakePoint($${paramCounter}, $${paramCounter + 1}), 4326)::geography`;
+      params.push(location.longitude, location.latitude);
+      paramCounter += 2;
     }
 
     if (typeof is_on_duty === 'boolean') {
@@ -274,8 +323,14 @@ export async function PUT(request: NextRequest) {
   }
 }
 
-// DELETE - Delete driver
+// DELETE - Delete driver (admins only)
 export async function DELETE(request: NextRequest) {
+  const auth = await withAuth(request, {
+    allowedRoles: ['ADMIN', 'SUPER_ADMIN'],
+    requireAuth: true,
+  });
+  if (!auth.success) return auth.response;
+
   try {
     const url = new URL(request.url);
     const pathParts = url.pathname.split('/');

--- a/src/app/api/tracking/locations/__tests__/route.test.ts
+++ b/src/app/api/tracking/locations/__tests__/route.test.ts
@@ -45,6 +45,11 @@ jest.mock("pg", () => {
   };
 });
 
+// Mock auth middleware (the route gained withAuth in the security-hardening pass)
+jest.mock("@/lib/auth-middleware", () => ({ withAuth: jest.fn() }));
+import { withAuth } from "@/lib/auth-middleware";
+const mockWithAuth = withAuth as jest.Mock;
+
 // Import route handlers after mocking
 import { POST, GET } from "../route";
 
@@ -87,6 +92,14 @@ describe("/api/tracking/locations", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    // Default: an authenticated ADMIN (matches the route's pre-hardening
+    // behavior — no per-driver ownership scoping). Security-specific cases
+    // below override this with a DRIVER / unauthenticated context.
+    mockWithAuth.mockResolvedValue({
+      success: true,
+      context: { user: { id: "admin-1", type: "ADMIN" } },
+    });
 
     // Reset connect to return our mock client
     mockPoolInstance.connect.mockResolvedValue(mockClient);
@@ -610,6 +623,81 @@ describe("/api/tracking/locations", () => {
 
         expect(data.details).toBeDefined();
       });
+    });
+  });
+
+  describe("Security (auth + ownership)", () => {
+    it("POST: returns 401 when unauthenticated", async () => {
+      mockWithAuth.mockResolvedValue({
+        success: false,
+        response: { status: 401 },
+        context: {},
+      });
+      const response = await POST(
+        createPostRequest("http://localhost:3000/api/tracking/locations", mockLocationData),
+      );
+      expect(response.status).toBe(401);
+      expect(mockPoolInstance.connect).not.toHaveBeenCalled();
+    });
+
+    it("POST: denies a driver writing a foreign driver_id (403)", async () => {
+      mockWithAuth.mockResolvedValue({
+        success: true,
+        context: { user: { id: "attacker", type: "DRIVER" } },
+      });
+      mockClient.query.mockImplementation((sql: string) => {
+        if (sql.includes("SELECT id FROM drivers")) return Promise.resolve({ rows: [] });
+        return Promise.resolve({ rows: [] });
+      });
+      const response = await POST(
+        createPostRequest("http://localhost:3000/api/tracking/locations", mockLocationData),
+      );
+      expect(response.status).toBe(403);
+      const data = await response.json();
+      expect(data.error).toBe("Access denied");
+    });
+
+    it("POST: allows the owning driver and scopes the check to their auth id (201)", async () => {
+      mockWithAuth.mockResolvedValue({
+        success: true,
+        context: { user: { id: "user-owner", type: "DRIVER" } },
+      });
+      const response = await POST(
+        createPostRequest("http://localhost:3000/api/tracking/locations", mockLocationData),
+      );
+      expect(response.status).toBe(201);
+      const ownershipCall = mockClient.query.mock.calls.find(
+        ([sql]: [string]) => typeof sql === "string" && sql.includes("AND user_id"),
+      );
+      expect(ownershipCall?.[1]).toEqual([mockDriverId, "user-owner"]);
+    });
+
+    it("GET: returns 401 when unauthenticated", async () => {
+      mockWithAuth.mockResolvedValue({
+        success: false,
+        response: { status: 401 },
+        context: {},
+      });
+      const response = await GET(
+        createRequestWithParams("http://localhost:3000/api/tracking/locations", {
+          driver_id: mockDriverId,
+        }),
+      );
+      expect(response.status).toBe(401);
+    });
+
+    it("GET: denies a driver reading a foreign driver's history (403)", async () => {
+      mockWithAuth.mockResolvedValue({
+        success: true,
+        context: { user: { id: "attacker", type: "DRIVER" } },
+      });
+      mockPoolInstance.query.mockResolvedValue({ rows: [] }); // ownership lookup → not owned
+      const response = await GET(
+        createRequestWithParams("http://localhost:3000/api/tracking/locations", {
+          driver_id: "driver-victim",
+        }),
+      );
+      expect(response.status).toBe(403);
     });
   });
 });

--- a/src/app/api/tracking/locations/route.ts
+++ b/src/app/api/tracking/locations/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { withAuth } from '@/lib/auth-middleware';
 // import { Pool } from 'pg';
 const Pool = require('pg').Pool;
 
@@ -23,11 +24,18 @@ interface LocationUpdate {
 
 // POST - Record driver location
 export async function POST(request: NextRequest) {
+  // AuthZ: only authenticated drivers/admins may write locations.
+  const auth = await withAuth(request, {
+    allowedRoles: ['DRIVER', 'ADMIN', 'SUPER_ADMIN'],
+    requireAuth: true,
+  });
+  if (!auth.success) return auth.response;
+
   const client = await pool.connect();
-  
+
   try {
     await client.query('BEGIN');
-    
+
     const body = await request.json();
     const {
       driver_id,
@@ -61,17 +69,30 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Check if driver exists
-    const driverCheck = await client.query(
-      'SELECT id FROM drivers WHERE id = $1 AND is_active = true',
-      [driver_id]
-    );
+    // Check if driver exists. A DRIVER may only write their OWN location:
+    // verify the target driver row belongs to the authenticated user
+    // (drivers.user_id === auth user id). Admins may write for any driver.
+    const isDriver = auth.context.user.type === 'DRIVER';
+    const driverCheck = isDriver
+      ? await client.query(
+          'SELECT id FROM drivers WHERE id = $1 AND user_id = $2 AND is_active = true',
+          [driver_id, auth.context.user.id]
+        )
+      : await client.query(
+          'SELECT id FROM drivers WHERE id = $1 AND is_active = true',
+          [driver_id]
+        );
 
     if (driverCheck.rows.length === 0) {
       await client.query('ROLLBACK');
       return NextResponse.json(
-        { success: false, error: 'Driver not found or inactive' },
-        { status: 404 }
+        {
+          success: false,
+          error: isDriver
+            ? 'Access denied'
+            : 'Driver not found or inactive',
+        },
+        { status: isDriver ? 403 : 404 }
       );
     }
 
@@ -89,8 +110,8 @@ export async function POST(request: NextRequest) {
         activity_type,
         recorded_at
       )
-      VALUES ($1, ST_GeogFromText($2), $3, $4, $5, $6, $7, $8, $9, NOW())
-      RETURNING 
+      VALUES ($1, ST_SetSRID(ST_MakePoint($2, $3), 4326)::geography, $4, $5, $6, $7, $8, $9, $10, NOW())
+      RETURNING
         id,
         ST_AsGeoJSON(location) as location_geojson,
         accuracy,
@@ -106,7 +127,8 @@ export async function POST(request: NextRequest) {
 
     const locationResult = await client.query(locationQuery, [
       driver_id,
-      `POINT(${longitude} ${latitude})`,
+      longitude,
+      latitude,
       accuracy,
       speed,
       heading,
@@ -118,13 +140,13 @@ export async function POST(request: NextRequest) {
 
     // Update driver's last known location
     await client.query(`
-      UPDATE drivers 
-      SET 
-        last_known_location = ST_GeogFromText($1),
+      UPDATE drivers
+      SET
+        last_known_location = ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography,
         last_location_update = NOW(),
         updated_at = NOW()
-      WHERE id = $2
-    `, [`POINT(${longitude} ${latitude})`, driver_id]);
+      WHERE id = $3
+    `, [longitude, latitude, driver_id]);
 
     await client.query('COMMIT');
 
@@ -156,17 +178,39 @@ export async function POST(request: NextRequest) {
 
 // GET - Get location history for a driver
 export async function GET(request: NextRequest) {
+  // AuthZ: drivers/admins only.
+  const auth = await withAuth(request, {
+    allowedRoles: ['DRIVER', 'ADMIN', 'SUPER_ADMIN'],
+    requireAuth: true,
+  });
+  if (!auth.success) return auth.response;
+
   try {
     const { searchParams } = new URL(request.url);
     const driver_id = searchParams.get('driver_id');
-    const hours = parseInt(searchParams.get('hours') || '24');
-    const limit = parseInt(searchParams.get('limit') || '100');
+    // Clamp to sane bounds (also keeps the interpolated INTERVAL numeric).
+    const hours = Math.min(Math.max(parseInt(searchParams.get('hours') || '24', 10) || 24, 1), 168);
+    const limit = Math.min(Math.max(parseInt(searchParams.get('limit') || '100', 10) || 100, 1), 1000);
 
     if (!driver_id) {
       return NextResponse.json(
         { success: false, error: 'Missing driver_id parameter' },
         { status: 400 }
       );
+    }
+
+    // A DRIVER may only read their own location history.
+    if (auth.context.user.type === 'DRIVER') {
+      const owns = await pool.query(
+        'SELECT id FROM drivers WHERE id = $1 AND user_id = $2',
+        [driver_id, auth.context.user.id]
+      );
+      if (owns.rows.length === 0) {
+        return NextResponse.json(
+          { success: false, error: 'Access denied' },
+          { status: 403 }
+        );
+      }
     }
 
     const query = `


### PR DESCRIPTION
## What

Fixes **five pre-existing critical vulnerabilities** on the live driver tracking surface (OWASP A01 Broken Access Control + A03 Injection). All fixes are auth- and ownership-scoped and **change no request/response shapes** — safe to ship ahead of the driver UI redesign.

## Fixes

| Route | Issue | Fix |
|---|---|---|
| `PATCH /api/orders/[order_number]` | Any authenticated driver could advance **any** order's `driverStatus` (IDOR) | Driver may only advance an order assigned to them via Dispatch; admins/helpdesk exempt; `403` otherwise |
| `updateDeliveryStatus` action | No caller auth/ownership; `POINT()` string interpolation | UUID validation + caller auth + ownership (`drivers.user_id`) + parameterized `ST_MakePoint` with lat/lng range checks |
| `POST/GET /api/tracking/locations` | Unauthenticated writes/reads; `POINT()` interpolation | `withAuth` gate + driver self-scoping (`403` on mismatch) + parameterized geometry + clamped `hours`/`limit` |
| `/api/tracking/drivers` (all verbs) | No auth; `POINT()` interpolation | `withAuth` on every verb; GET scoped to own record for drivers; POST/DELETE admin-only; PUT own-record only; parameterized geometry |

## Tests

- New `delivery-actions.security.test.ts` — IDOR / unauth / admin / bad-coords cases.
- Added a `withAuth` mock (default `ADMIN` = pre-hardening behavior) to the locations and drivers route suites (both the `src/app/api/...` and `src/__tests__/api/...` copies, which double-cover these routes).
- +5 driver-scoping cases on the locations suite; `POINT()`→`ST_MakePoint` param assertion updated.

Validated in isolation (UI redesign work stashed): **14 suites / 308 tests pass**, full typecheck green.

## Notes

- Split out of the in-progress `feature/driver-mobile-redesign` branch so these prod-facing security fixes can land independently of the UI.
- Follow-up (out of scope): `PUT /api/tracking/deliveries/[id]` still string-interpolates `POINT()` — low severity (auth + ownership protected), worth parameterizing later for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)