### PR TITLE
fix: route driver-tracking endpoints through the shared pooled Prisma client

### DIFF
--- a/src/__tests__/api/tracking/drivers.test.ts
+++ b/src/__tests__/api/tracking/drivers.test.ts
@@ -1,34 +1,25 @@
 import { NextRequest } from 'next/server';
 
-// Mock pg Pool - the route uses PostgreSQL directly, not Supabase
-// This must be set up before the route imports to ensure the pool created
-// at module load time (route.ts line 6) uses our mock
-jest.mock('pg', () => {
-  // Create the mock inside the factory to avoid hoisting issues
-  const mq = jest.fn();
-
-  return {
-    Pool: jest.fn(() => ({
-      query: mq,
-      connect: jest.fn(),
-      end: jest.fn(),
-    })),
-    // Export the mock query so we can access it in tests
-    __mockQuery: mq,
-  };
-});
+// The route uses the shared pooled-Prisma raw helpers (`@/lib/db/raw`) instead
+// of its own pg.Pool. Mock `rawQuery` (the only helper the drivers route uses).
+jest.mock('@/lib/db/raw', () => ({
+  __esModule: true,
+  rawQuery: jest.fn(),
+  rawExec: jest.fn(),
+  withRawTx: jest.fn(),
+  TRACKING_STATEMENT_TIMEOUT_MS: 8000,
+  DbHttpError: class DbHttpError extends Error {},
+}));
 
 // Route gained withAuth in the security-hardening pass — mock it (default ADMIN).
 jest.mock('@/lib/auth-middleware', () => ({ withAuth: jest.fn() }));
 
 import { GET, POST, PUT } from '@/app/api/tracking/drivers/route';
 import { withAuth } from '@/lib/auth-middleware';
-import type * as pg from 'pg';
+import { rawQuery } from '@/lib/db/raw';
 
 const mockWithAuth = withAuth as jest.Mock;
-
-// Access the mock query function
-const { __mockQuery: mockQuery } = jest.requireMock<typeof pg & { __mockQuery: jest.Mock }>('pg');
+const mockRawQuery = rawQuery as jest.Mock;
 
 describe('/api/tracking/drivers', () => {
   beforeEach(() => {
@@ -84,11 +75,7 @@ describe('/api/tracking/drivers', () => {
         },
       ];
 
-      // Mock successful pg query response
-      mockQuery.mockResolvedValue({
-        rows: mockDrivers,
-        rowCount: mockDrivers.length,
-      });
+      mockRawQuery.mockResolvedValue(mockDrivers);
 
       const request = new NextRequest('http://localhost:3000/api/tracking/drivers');
       const response = await GET(request);
@@ -96,7 +83,6 @@ describe('/api/tracking/drivers', () => {
 
       expect(response.status).toBe(200);
       expect(data.success).toBe(true);
-      // Route returns { success: true, data: drivers[], pagination: {...} }
       expect(data.data).toEqual(mockDrivers);
       expect(data.pagination.total).toBe(mockDrivers.length);
       expect(data.pagination.limit).toBe(50); // default limit
@@ -105,19 +91,9 @@ describe('/api/tracking/drivers', () => {
 
     it('filters drivers by status when status parameter provided', async () => {
       const mockActiveDrivers = [
-        {
-          id: 'driver-1',
-          employee_id: 'EMP001',
-          vehicle_number: 'VEH001',
-          is_active: true,
-          is_on_duty: true,
-        },
+        { id: 'driver-1', employee_id: 'EMP001', vehicle_number: 'VEH001', is_active: true, is_on_duty: true },
       ];
-
-      mockQuery.mockResolvedValue({
-        rows: mockActiveDrivers,
-        rowCount: 1,
-      });
+      mockRawQuery.mockResolvedValue(mockActiveDrivers);
 
       const request = new NextRequest('http://localhost:3000/api/tracking/drivers?active=true');
       const response = await GET(request);
@@ -128,21 +104,17 @@ describe('/api/tracking/drivers', () => {
       expect(data.data).toHaveLength(1);
     });
 
-    it('returns 400 for invalid status parameter', async () => {
-      // Route doesn't validate status parameter - this test should be removed or route updated
-      const mockDrivers: any[] = [];
-      mockQuery.mockResolvedValue({ rows: mockDrivers, rowCount: 0 });
-
+    it('returns 200 with empty data for unknown status parameter (no validation)', async () => {
+      mockRawQuery.mockResolvedValue([]);
       const request = new NextRequest('http://localhost:3000/api/tracking/drivers?status=invalid');
       const response = await GET(request);
 
-      // Route returns 200 with empty data, not 400
       expect(response.status).toBe(200);
       expect(await response.json()).toMatchObject({ success: true, data: [] });
     });
 
     it('handles database errors gracefully', async () => {
-      mockQuery.mockRejectedValue(new Error('Database connection failed'));
+      mockRawQuery.mockRejectedValue(new Error('Database connection failed'));
 
       const request = new NextRequest('http://localhost:3000/api/tracking/drivers');
       const response = await GET(request);
@@ -155,19 +127,9 @@ describe('/api/tracking/drivers', () => {
 
     it('limits results when limit parameter provided', async () => {
       const mockLimitedDrivers = [
-        {
-          id: 'driver-1',
-          employee_id: 'EMP001',
-          vehicle_number: 'VEH001',
-          is_active: true,
-          is_on_duty: true,
-        },
+        { id: 'driver-1', employee_id: 'EMP001', vehicle_number: 'VEH001', is_active: true, is_on_duty: true },
       ];
-
-      mockQuery.mockResolvedValue({
-        rows: mockLimitedDrivers,
-        rowCount: 1,
-      });
+      mockRawQuery.mockResolvedValue(mockLimitedDrivers);
 
       const request = new NextRequest('http://localhost:3000/api/tracking/drivers?limit=1');
       const response = await GET(request);
@@ -179,16 +141,12 @@ describe('/api/tracking/drivers', () => {
       expect(data.pagination.limit).toBe(1);
     });
 
-    it('returns 400 for invalid limit parameter', async () => {
-      // Route parses limit with parseInt which returns NaN for invalid - uses default 50
-      const mockDrivers: any[] = [];
-      mockQuery.mockResolvedValue({ rows: mockDrivers, rowCount: 0 });
-
+    it('falls back to the default limit for an invalid limit parameter', async () => {
+      mockRawQuery.mockResolvedValue([]);
       const request = new NextRequest('http://localhost:3000/api/tracking/drivers?limit=invalid');
       const response = await GET(request);
       const data = await response.json();
 
-      // Route returns 200 with default limit (NaN becomes 50), not 400
       expect(response.status).toBe(200);
       expect(data.success).toBe(true);
     });
@@ -203,7 +161,6 @@ describe('/api/tracking/drivers', () => {
         vehicle_number: 'V003',
         phone_number: '+1234567890',
       };
-
       const createdDriver = {
         id: 'driver-3',
         user_id: 'user-3',
@@ -216,16 +173,12 @@ describe('/api/tracking/drivers', () => {
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
       };
-
-      mockQuery.mockResolvedValue({
-        rows: [createdDriver],
-      });
+      mockRawQuery.mockResolvedValue([createdDriver]);
 
       const request = new NextRequest('http://localhost:3000/api/tracking/drivers', {
         method: 'POST',
         body: JSON.stringify(newDriver),
       });
-
       const response = await POST(request);
       const data = await response.json();
 
@@ -236,17 +189,10 @@ describe('/api/tracking/drivers', () => {
     });
 
     it('returns 400 when no identifier is provided', async () => {
-      const invalidDriver = {
-        vehicle_number: 'V003',
-        phone_number: '+1234567890',
-        // Missing employee_id, profile_id, and user_id
-      };
-
       const request = new NextRequest('http://localhost:3000/api/tracking/drivers', {
         method: 'POST',
-        body: JSON.stringify(invalidDriver),
+        body: JSON.stringify({ vehicle_number: 'V003', phone_number: '+1234567890' }),
       });
-
       const response = await POST(request);
       const data = await response.json();
 
@@ -255,21 +201,15 @@ describe('/api/tracking/drivers', () => {
       expect(data.error).toContain('Missing required fields');
     });
 
-    it('handles database insertion errors', async () => {
-      const newDriver = {
-        employee_id: 'EMP003',
-      };
-
-      // Mock duplicate employee_id error (PostgreSQL unique constraint violation)
+    it('handles database insertion errors (unique violation → 409)', async () => {
       const duplicateError = new Error('duplicate key value violates unique constraint') as any;
       duplicateError.code = '23505';
-      mockQuery.mockRejectedValue(duplicateError);
+      mockRawQuery.mockRejectedValue(duplicateError);
 
       const request = new NextRequest('http://localhost:3000/api/tracking/drivers', {
         method: 'POST',
-        body: JSON.stringify(newDriver),
+        body: JSON.stringify({ employee_id: 'EMP003' }),
       });
-
       const response = await POST(request);
       const data = await response.json();
 
@@ -279,10 +219,6 @@ describe('/api/tracking/drivers', () => {
     });
 
     it('accepts driver with only profile_id', async () => {
-      const newDriver = {
-        profile_id: 'profile-4',
-      };
-
       const createdDriver = {
         id: 'driver-4',
         user_id: null,
@@ -295,16 +231,12 @@ describe('/api/tracking/drivers', () => {
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
       };
-
-      mockQuery.mockResolvedValue({
-        rows: [createdDriver],
-      });
+      mockRawQuery.mockResolvedValue([createdDriver]);
 
       const request = new NextRequest('http://localhost:3000/api/tracking/drivers', {
         method: 'POST',
-        body: JSON.stringify(newDriver),
+        body: JSON.stringify({ profile_id: 'profile-4' }),
       });
-
       const response = await POST(request);
       const data = await response.json();
 
@@ -314,10 +246,6 @@ describe('/api/tracking/drivers', () => {
     });
 
     it('accepts driver with only user_id', async () => {
-      const newDriver = {
-        user_id: 'user-5',
-      };
-
       const createdDriver = {
         id: 'driver-5',
         user_id: 'user-5',
@@ -330,16 +258,12 @@ describe('/api/tracking/drivers', () => {
         created_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
       };
-
-      mockQuery.mockResolvedValue({
-        rows: [createdDriver],
-      });
+      mockRawQuery.mockResolvedValue([createdDriver]);
 
       const request = new NextRequest('http://localhost:3000/api/tracking/drivers', {
         method: 'POST',
-        body: JSON.stringify(newDriver),
+        body: JSON.stringify({ user_id: 'user-5' }),
       });
-
       const response = await POST(request);
       const data = await response.json();
 
@@ -352,15 +276,6 @@ describe('/api/tracking/drivers', () => {
   describe('PUT /api/tracking/drivers', () => {
     it('updates driver information successfully', async () => {
       const driverId = 'driver-1';
-      const updateData = {
-        driver_id: driverId,
-        location: {
-          latitude: 40.7128,
-          longitude: -74.006,
-        },
-        is_on_duty: true,
-      };
-
       const updatedDriver = {
         id: driverId,
         employee_id: 'EMP001',
@@ -369,16 +284,16 @@ describe('/api/tracking/drivers', () => {
         location_geojson: JSON.stringify({ type: 'Point', coordinates: [-74.006, 40.7128] }),
         last_location_update: new Date().toISOString(),
       };
+      mockRawQuery.mockResolvedValue([updatedDriver]);
 
-      mockQuery.mockResolvedValue({
-        rows: [updatedDriver],
-      });
-
-      const request = new NextRequest(`http://localhost:3000/api/tracking/drivers`, {
+      const request = new NextRequest('http://localhost:3000/api/tracking/drivers', {
         method: 'PUT',
-        body: JSON.stringify(updateData),
+        body: JSON.stringify({
+          driver_id: driverId,
+          location: { latitude: 40.7128, longitude: -74.006 },
+          is_on_duty: true,
+        }),
       });
-
       const response = await PUT(request);
       const data = await response.json();
 
@@ -389,16 +304,10 @@ describe('/api/tracking/drivers', () => {
     });
 
     it('returns 400 for invalid update data', async () => {
-      const invalidUpdate = {
-        // Missing driver_id which is required
-        location: { latitude: 40.7128, longitude: -74.006 },
-      };
-
-      const request = new NextRequest(`http://localhost:3000/api/tracking/drivers`, {
+      const request = new NextRequest('http://localhost:3000/api/tracking/drivers', {
         method: 'PUT',
-        body: JSON.stringify(invalidUpdate),
+        body: JSON.stringify({ location: { latitude: 40.7128, longitude: -74.006 } }),
       });
-
       const response = await PUT(request);
       const data = await response.json();
 
@@ -408,22 +317,11 @@ describe('/api/tracking/drivers', () => {
     });
 
     it('returns 404 when driver not found', async () => {
-      const driverId = 'non-existent-driver';
-      const updateData = {
-        driver_id: driverId,
-        is_on_duty: false,
-      };
-
-      // Mock query returning no rows (driver not found)
-      mockQuery.mockResolvedValue({
-        rows: [],
-      });
-
-      const request = new NextRequest(`http://localhost:3000/api/tracking/drivers`, {
+      mockRawQuery.mockResolvedValue([]);
+      const request = new NextRequest('http://localhost:3000/api/tracking/drivers', {
         method: 'PUT',
-        body: JSON.stringify(updateData),
+        body: JSON.stringify({ driver_id: 'non-existent-driver', is_on_duty: false }),
       });
-
       const response = await PUT(request);
       const data = await response.json();
 
@@ -433,19 +331,11 @@ describe('/api/tracking/drivers', () => {
     });
 
     it('handles database update errors', async () => {
-      const driverId = 'driver-1';
-      const updateData = {
-        driver_id: driverId,
-        is_on_duty: true,
-      };
-
-      mockQuery.mockRejectedValue(new Error('Update failed'));
-
-      const request = new NextRequest(`http://localhost:3000/api/tracking/drivers`, {
+      mockRawQuery.mockRejectedValue(new Error('Update failed'));
+      const request = new NextRequest('http://localhost:3000/api/tracking/drivers', {
         method: 'PUT',
-        body: JSON.stringify(updateData),
+        body: JSON.stringify({ driver_id: 'driver-1', is_on_duty: true }),
       });
-
       const response = await PUT(request);
       const data = await response.json();
 
@@ -456,11 +346,6 @@ describe('/api/tracking/drivers', () => {
 
     it('updates only is_on_duty when location not provided', async () => {
       const driverId = 'driver-1';
-      const updateData = {
-        driver_id: driverId,
-        is_on_duty: false,
-      };
-
       const updatedDriver = {
         id: driverId,
         employee_id: 'EMP001',
@@ -469,16 +354,12 @@ describe('/api/tracking/drivers', () => {
         location_geojson: null,
         last_location_update: new Date().toISOString(),
       };
+      mockRawQuery.mockResolvedValue([updatedDriver]);
 
-      mockQuery.mockResolvedValue({
-        rows: [updatedDriver],
-      });
-
-      const request = new NextRequest(`http://localhost:3000/api/tracking/drivers`, {
+      const request = new NextRequest('http://localhost:3000/api/tracking/drivers', {
         method: 'PUT',
-        body: JSON.stringify(updateData),
+        body: JSON.stringify({ driver_id: driverId, is_on_duty: false }),
       });
-
       const response = await PUT(request);
       const data = await response.json();
 
@@ -494,11 +375,9 @@ describe('/api/tracking/drivers', () => {
         method: 'POST',
         body: 'invalid-json',
       });
-
       const response = await POST(request);
       const data = await response.json();
 
-      // Route catches JSON parse error and returns 500, not 400
       expect(response.status).toBe(500);
       expect(data.success).toBe(false);
       expect(data.error).toBe('Failed to create driver');
@@ -509,7 +388,6 @@ describe('/api/tracking/drivers', () => {
         method: 'POST',
         body: JSON.stringify({}),
       });
-
       const response = await POST(request);
       const data = await response.json();
 
@@ -519,8 +397,7 @@ describe('/api/tracking/drivers', () => {
     });
 
     it('handles database query errors gracefully', async () => {
-      mockQuery.mockRejectedValue(new Error('Database connection error'));
-
+      mockRawQuery.mockRejectedValue(new Error('Database connection error'));
       const request = new NextRequest('http://localhost:3000/api/tracking/drivers');
       const response = await GET(request);
       const data = await response.json();
@@ -535,7 +412,6 @@ describe('/api/tracking/drivers', () => {
         method: 'PUT',
         body: JSON.stringify({}),
       });
-
       const response = await PUT(request);
       const data = await response.json();
 

--- a/src/__tests__/api/tracking/locations.test.ts
+++ b/src/__tests__/api/tracking/locations.test.ts
@@ -1,39 +1,34 @@
 // src/__tests__/api/tracking/locations.test.ts
 
-// Create shared mock storage - the actual mock functions get assigned in beforeEach
-const mocks = {
-  clientQuery: jest.fn(),
-  release: jest.fn(),
-  poolQuery: jest.fn(),
-  connect: jest.fn(),
-};
-
-// Must mock pg before importing the route
-jest.mock('pg', () => {
-  // Access mocks through the shared object to avoid hoisting issues
-  const getMocks = () => require('./locations.test').mocks || {
-    clientQuery: jest.fn(),
-    release: jest.fn(),
-    poolQuery: jest.fn(),
-    connect: jest.fn(),
-  };
-
+// The route uses the shared pooled-Prisma raw helpers (`@/lib/db/raw`) instead
+// of its own pg.Pool. Mock those helpers. DbHttpError is defined here so the
+// route's `throw new DbHttpError` / `instanceof DbHttpError` use the same class.
+jest.mock('@/lib/db/raw', () => {
+  class DbHttpError extends Error {
+    status: number;
+    body: any;
+    constructor(status: number, body: any) {
+      super('db-http-error');
+      this.name = 'DbHttpError';
+      this.status = status;
+      this.body = body;
+    }
+  }
   return {
-    Pool: jest.fn().mockImplementation(() => ({
-      connect: (...args: unknown[]) => getMocks().connect(...args),
-      query: (...args: unknown[]) => getMocks().poolQuery(...args),
-    })),
+    __esModule: true,
+    DbHttpError,
+    TRACKING_STATEMENT_TIMEOUT_MS: 8000,
+    withRawTx: jest.fn(),
+    rawQuery: jest.fn(),
+    rawExec: jest.fn(),
   };
 });
 
-// Export mocks for the pg mock to access
-module.exports = { mocks };
-
 // Route gained withAuth in the security-hardening pass — mock it (default ADMIN).
 jest.mock('@/lib/auth-middleware', () => ({ withAuth: jest.fn() }));
-import { withAuth } from '@/lib/auth-middleware';
-const mockWithAuth = withAuth as jest.Mock;
 
+import { withAuth } from '@/lib/auth-middleware';
+import { withRawTx, rawQuery } from '@/lib/db/raw';
 import { GET, POST } from '@/app/api/tracking/locations/route';
 import {
   createGetRequest,
@@ -42,6 +37,23 @@ import {
   expectErrorResponse,
 } from '@/__tests__/helpers/api-test-helpers';
 
+const mockWithAuth = withAuth as jest.Mock;
+const mockWithRawTx = withRawTx as jest.Mock;
+const mockRawQuery = rawQuery as jest.Mock;
+
+// Fake interactive-transaction client.
+const mockTxQuery = jest.fn();
+const mockTxExec = jest.fn();
+
+/** Configure the POST transaction to return a given location row on INSERT. */
+function txReturning(record: any, driverRows: any[] = [{ id: 'driver-123' }]) {
+  mockTxQuery.mockImplementation((sql: string) => {
+    if (sql.includes('SELECT id FROM drivers')) return Promise.resolve(driverRows);
+    if (sql.includes('INSERT INTO driver_locations')) return Promise.resolve([record]);
+    return Promise.resolve([]);
+  });
+}
+
 describe('/api/tracking/locations API', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -49,11 +61,18 @@ describe('/api/tracking/locations API', () => {
       success: true,
       context: { user: { id: 'admin-1', type: 'ADMIN' } },
     });
-    // Reset connect mock to return a client with query and release
-    mocks.connect.mockResolvedValue({
-      query: mocks.clientQuery,
-      release: mocks.release,
+    mockWithRawTx.mockImplementation((fn: any) =>
+      fn({ $queryRawUnsafe: mockTxQuery, $executeRawUnsafe: mockTxExec }),
+    );
+    mockTxExec.mockResolvedValue(1);
+    // Default: driver exists, insert echoes a basic record.
+    txReturning({
+      id: 'location-default',
+      location_geojson: JSON.stringify({ type: 'Point', coordinates: [-97.7431, 30.2672] }),
+      recorded_at: new Date().toISOString(),
+      created_at: new Date().toISOString(),
     });
+    mockRawQuery.mockResolvedValue([]);
   });
 
   describe('POST /api/tracking/locations - Record Driver Location', () => {
@@ -72,39 +91,23 @@ describe('/api/tracking/locations API', () => {
           activity_type: 'driving',
         };
 
-        // Mock transaction queries
-        mocks.clientQuery
-          .mockResolvedValueOnce({}) // BEGIN
-          .mockResolvedValueOnce({ rows: [{ id: 'driver-123' }] }) // Driver check
-          .mockResolvedValueOnce({
-            rows: [
-              {
-                id: 'location-1',
-                location_geojson: JSON.stringify({
-                  type: 'Point',
-                  coordinates: [-97.7431, 30.2672],
-                }),
-                accuracy: 10.5,
-                speed: 25.0,
-                heading: 180,
-                altitude: 150,
-                battery_level: 85,
-                is_moving: true,
-                activity_type: 'driving',
-                recorded_at: new Date().toISOString(),
-                created_at: new Date().toISOString(),
-              },
-            ],
-          }) // INSERT location
-          .mockResolvedValueOnce({}) // UPDATE driver location
-          .mockResolvedValueOnce({}); // COMMIT
+        txReturning({
+          id: 'location-1',
+          location_geojson: JSON.stringify({ type: 'Point', coordinates: [-97.7431, 30.2672] }),
+          accuracy: 10.5,
+          speed: 25.0,
+          heading: 180,
+          altitude: 150,
+          battery_level: 85,
+          is_moving: true,
+          activity_type: 'driving',
+          recorded_at: new Date().toISOString(),
+          created_at: new Date().toISOString(),
+        });
 
-        const request = createPostRequest(
-          'http://localhost:3000/api/tracking/locations',
-          locationData
+        const response = await POST(
+          createPostRequest('http://localhost:3000/api/tracking/locations', locationData),
         );
-
-        const response = await POST(request);
         const data = await expectSuccessResponse(response, 201);
 
         expect(data.success).toBe(true);
@@ -114,300 +117,217 @@ describe('/api/tracking/locations API', () => {
       });
 
       it('should record location with minimal required fields', async () => {
-        const locationData = {
-          driver_id: 'driver-123',
-          latitude: 30.2672,
-          longitude: -97.7431,
-        };
+        txReturning({
+          id: 'location-2',
+          location_geojson: JSON.stringify({ type: 'Point', coordinates: [-97.7431, 30.2672] }),
+          accuracy: null,
+          speed: null,
+          heading: null,
+          altitude: null,
+          battery_level: null,
+          is_moving: null,
+          activity_type: null,
+          recorded_at: new Date().toISOString(),
+          created_at: new Date().toISOString(),
+        });
 
-        mocks.clientQuery
-          .mockResolvedValueOnce({}) // BEGIN
-          .mockResolvedValueOnce({ rows: [{ id: 'driver-123' }] }) // Driver check
-          .mockResolvedValueOnce({
-            rows: [
-              {
-                id: 'location-2',
-                location_geojson: JSON.stringify({
-                  type: 'Point',
-                  coordinates: [-97.7431, 30.2672],
-                }),
-                accuracy: null,
-                speed: null,
-                heading: null,
-                altitude: null,
-                battery_level: null,
-                is_moving: null,
-                activity_type: null,
-                recorded_at: new Date().toISOString(),
-                created_at: new Date().toISOString(),
-              },
-            ],
-          }) // INSERT location
-          .mockResolvedValueOnce({}) // UPDATE driver
-          .mockResolvedValueOnce({}); // COMMIT
-
-        const request = createPostRequest(
-          'http://localhost:3000/api/tracking/locations',
-          locationData
+        const response = await POST(
+          createPostRequest('http://localhost:3000/api/tracking/locations', {
+            driver_id: 'driver-123',
+            latitude: 30.2672,
+            longitude: -97.7431,
+          }),
         );
-
-        const response = await POST(request);
         expect(response.status).toBe(201);
       });
     });
 
     describe('Validation Tests', () => {
       it('should return 400 for missing driver_id', async () => {
-        const request = createPostRequest(
-          'http://localhost:3000/api/tracking/locations',
-          {
+        const response = await POST(
+          createPostRequest('http://localhost:3000/api/tracking/locations', {
             latitude: 30.2672,
             longitude: -97.7431,
-          }
+          }),
         );
-
-        const response = await POST(request);
         await expectErrorResponse(response, 400, /Missing required fields/i);
       });
 
       it('should return 400 for missing latitude', async () => {
-        const request = createPostRequest(
-          'http://localhost:3000/api/tracking/locations',
-          {
+        const response = await POST(
+          createPostRequest('http://localhost:3000/api/tracking/locations', {
             driver_id: 'driver-123',
             longitude: -97.7431,
-          }
+          }),
         );
-
-        const response = await POST(request);
         await expectErrorResponse(response, 400, /Missing required fields/i);
       });
 
       it('should return 400 for missing longitude', async () => {
-        const request = createPostRequest(
-          'http://localhost:3000/api/tracking/locations',
-          {
+        const response = await POST(
+          createPostRequest('http://localhost:3000/api/tracking/locations', {
             driver_id: 'driver-123',
             latitude: 30.2672,
-          }
+          }),
         );
-
-        const response = await POST(request);
         await expectErrorResponse(response, 400, /Missing required fields/i);
       });
 
       it('should return 400 for invalid latitude (out of range)', async () => {
-        const request = createPostRequest(
-          'http://localhost:3000/api/tracking/locations',
-          {
+        const response = await POST(
+          createPostRequest('http://localhost:3000/api/tracking/locations', {
             driver_id: 'driver-123',
-            latitude: 91, // Invalid: > 90
+            latitude: 91,
             longitude: -97.7431,
-          }
+          }),
         );
-
-        const response = await POST(request);
         await expectErrorResponse(response, 400, /Invalid coordinates/i);
       });
 
       it('should return 400 for invalid latitude (negative out of range)', async () => {
-        const request = createPostRequest(
-          'http://localhost:3000/api/tracking/locations',
-          {
+        const response = await POST(
+          createPostRequest('http://localhost:3000/api/tracking/locations', {
             driver_id: 'driver-123',
-            latitude: -91, // Invalid: < -90
+            latitude: -91,
             longitude: -97.7431,
-          }
+          }),
         );
-
-        const response = await POST(request);
         await expectErrorResponse(response, 400, /Invalid coordinates/i);
       });
 
       it('should return 400 for invalid longitude (out of range)', async () => {
-        const request = createPostRequest(
-          'http://localhost:3000/api/tracking/locations',
-          {
+        const response = await POST(
+          createPostRequest('http://localhost:3000/api/tracking/locations', {
             driver_id: 'driver-123',
             latitude: 30.2672,
-            longitude: 181, // Invalid: > 180
-          }
+            longitude: 181,
+          }),
         );
-
-        const response = await POST(request);
         await expectErrorResponse(response, 400, /Invalid coordinates/i);
       });
 
       it('should return 400 for invalid longitude (negative out of range)', async () => {
-        const request = createPostRequest(
-          'http://localhost:3000/api/tracking/locations',
-          {
+        const response = await POST(
+          createPostRequest('http://localhost:3000/api/tracking/locations', {
             driver_id: 'driver-123',
             latitude: 30.2672,
-            longitude: -181, // Invalid: < -180
-          }
+            longitude: -181,
+          }),
         );
-
-        const response = await POST(request);
         await expectErrorResponse(response, 400, /Invalid coordinates/i);
       });
 
       it('should accept valid boundary coordinates', async () => {
-        const locationData = {
-          driver_id: 'driver-123',
-          latitude: 90, // Valid boundary
-          longitude: 180, // Valid boundary
-        };
+        txReturning({
+          id: 'location-3',
+          location_geojson: JSON.stringify({ type: 'Point', coordinates: [180, 90] }),
+          recorded_at: new Date().toISOString(),
+          created_at: new Date().toISOString(),
+        });
 
-        mocks.clientQuery
-          .mockResolvedValueOnce({}) // BEGIN
-          .mockResolvedValueOnce({ rows: [{ id: 'driver-123' }] }) // Driver check
-          .mockResolvedValueOnce({
-            rows: [
-              {
-                id: 'location-3',
-                location_geojson: JSON.stringify({
-                  type: 'Point',
-                  coordinates: [180, 90],
-                }),
-                recorded_at: new Date().toISOString(),
-                created_at: new Date().toISOString(),
-              },
-            ],
-          })
-          .mockResolvedValueOnce({})
-          .mockResolvedValueOnce({});
-
-        const request = createPostRequest(
-          'http://localhost:3000/api/tracking/locations',
-          locationData
+        const response = await POST(
+          createPostRequest('http://localhost:3000/api/tracking/locations', {
+            driver_id: 'driver-123',
+            latitude: 90,
+            longitude: 180,
+          }),
         );
-
-        const response = await POST(request);
         expect(response.status).toBe(201);
       });
     });
 
     describe('Driver Verification', () => {
       it('should return 404 for non-existent driver', async () => {
-        mocks.clientQuery
-          .mockResolvedValueOnce({}) // BEGIN
-          .mockResolvedValueOnce({ rows: [] }); // Driver check - no driver found
-
-        const request = createPostRequest(
-          'http://localhost:3000/api/tracking/locations',
-          {
+        mockTxQuery.mockImplementation((sql: string) => {
+          if (sql.includes('SELECT id FROM drivers')) return Promise.resolve([]);
+          return Promise.resolve([]);
+        });
+        const response = await POST(
+          createPostRequest('http://localhost:3000/api/tracking/locations', {
             driver_id: 'non-existent',
             latitude: 30.2672,
             longitude: -97.7431,
-          }
+          }),
         );
-
-        const response = await POST(request);
         await expectErrorResponse(response, 404, /Driver not found or inactive/i);
       });
 
       it('should return 404 for inactive driver', async () => {
-        // Driver exists but is_active = false won't be returned by the query
-        mocks.clientQuery
-          .mockResolvedValueOnce({}) // BEGIN
-          .mockResolvedValueOnce({ rows: [] }); // Driver check - inactive drivers not returned
-
-        const request = createPostRequest(
-          'http://localhost:3000/api/tracking/locations',
-          {
+        mockTxQuery.mockImplementation((sql: string) => {
+          if (sql.includes('SELECT id FROM drivers')) return Promise.resolve([]);
+          return Promise.resolve([]);
+        });
+        const response = await POST(
+          createPostRequest('http://localhost:3000/api/tracking/locations', {
             driver_id: 'inactive-driver',
             latitude: 30.2672,
             longitude: -97.7431,
-          }
+          }),
         );
-
-        const response = await POST(request);
         await expectErrorResponse(response, 404, /Driver not found or inactive/i);
       });
     });
 
     describe('Database State Verification', () => {
-      it('should update driver last_known_location after recording', async () => {
-        const locationData = {
-          driver_id: 'driver-123',
-          latitude: 30.2672,
-          longitude: -97.7431,
-        };
+      it('should update driver last_known_location with parameterized geometry', async () => {
+        txReturning({
+          id: 'location-4',
+          location_geojson: JSON.stringify({ type: 'Point', coordinates: [-97.7431, 30.2672] }),
+          recorded_at: new Date().toISOString(),
+          created_at: new Date().toISOString(),
+        });
 
-        mocks.clientQuery
-          .mockResolvedValueOnce({}) // BEGIN
-          .mockResolvedValueOnce({ rows: [{ id: 'driver-123' }] }) // Driver check
-          .mockResolvedValueOnce({
-            rows: [
-              {
-                id: 'location-4',
-                location_geojson: JSON.stringify({
-                  type: 'Point',
-                  coordinates: [-97.7431, 30.2672],
-                }),
-                recorded_at: new Date().toISOString(),
-                created_at: new Date().toISOString(),
-              },
-            ],
-          })
-          .mockResolvedValueOnce({}) // UPDATE driver location
-          .mockResolvedValueOnce({}); // COMMIT
-
-        const request = createPostRequest(
-          'http://localhost:3000/api/tracking/locations',
-          locationData
-        );
-
-        await POST(request);
-
-        // Verify driver update used the parameterized geometry (security hardening:
-        // coordinates are bound as numeric params, never string-interpolated).
-        const updateCall = mocks.clientQuery.mock.calls[3];
-        expect(updateCall[0]).toContain('UPDATE drivers');
-        expect(updateCall[0]).toContain('ST_MakePoint');
-        expect(updateCall[1]).toEqual([-97.7431, 30.2672, 'driver-123']);
-      });
-
-      it('should rollback transaction on error', async () => {
-        mocks.clientQuery
-          .mockResolvedValueOnce({}) // BEGIN
-          .mockResolvedValueOnce({ rows: [{ id: 'driver-123' }] }) // Driver check
-          .mockRejectedValueOnce(new Error('Database error')); // INSERT fails
-
-        const request = createPostRequest(
-          'http://localhost:3000/api/tracking/locations',
-          {
+        await POST(
+          createPostRequest('http://localhost:3000/api/tracking/locations', {
             driver_id: 'driver-123',
             latitude: 30.2672,
             longitude: -97.7431,
-          }
+          }),
         );
 
-        const response = await POST(request);
-        expect(response.status).toBe(500);
+        // Security hardening: coordinates are bound as numeric params via
+        // ST_MakePoint, never string-interpolated. The denormalized driver
+        // update is the $executeRawUnsafe call.
+        const updateCall = mockTxExec.mock.calls[0];
+        expect(updateCall[0]).toContain('UPDATE drivers');
+        expect(updateCall[0]).toContain('ST_MakePoint');
+        expect(updateCall.slice(1)).toEqual([-97.7431, 30.2672, 'driver-123']);
+      });
 
-        // Verify ROLLBACK was called
-        expect(mocks.clientQuery).toHaveBeenCalledWith('ROLLBACK');
+      it('should not apply the driver update when the insert fails (atomic rollback)', async () => {
+        mockTxQuery.mockImplementation((sql: string) => {
+          if (sql.includes('SELECT id FROM drivers')) return Promise.resolve([{ id: 'driver-123' }]);
+          if (sql.includes('INSERT INTO driver_locations')) return Promise.reject(new Error('Database error'));
+          return Promise.resolve([]);
+        });
+
+        const response = await POST(
+          createPostRequest('http://localhost:3000/api/tracking/locations', {
+            driver_id: 'driver-123',
+            latitude: 30.2672,
+            longitude: -97.7431,
+          }),
+        );
+        expect(response.status).toBe(500);
+        // Transaction rolls back (Prisma) — the UPDATE drivers statement never runs.
+        expect(mockTxExec).not.toHaveBeenCalled();
       });
     });
 
     describe('Error Handling', () => {
-      it('should handle database connection errors', async () => {
-        mocks.connect.mockRejectedValueOnce(new Error('Connection failed'));
+      it('should return 500 when the transaction fails to start (connection error)', async () => {
+        mockWithRawTx.mockRejectedValueOnce(new Error('Connection failed'));
 
-        const request = createPostRequest(
-          'http://localhost:3000/api/tracking/locations',
-          {
+        const response = await POST(
+          createPostRequest('http://localhost:3000/api/tracking/locations', {
             driver_id: 'driver-123',
             latitude: 30.2672,
             longitude: -97.7431,
-          }
+          }),
         );
-
-        // Note: Connection errors occur before the try-catch in the route,
-        // so we expect the error to propagate (status 500 or thrown error)
-        await expect(POST(request)).rejects.toThrow('Connection failed');
+        // All DB access is now inside the try/catch, so a connection failure is a
+        // graceful 500 rather than an unhandled throw.
+        await expectErrorResponse(response, 500, /Failed to record location/i);
       });
     });
   });
@@ -418,10 +338,7 @@ describe('/api/tracking/locations API', () => {
         const mockLocations = [
           {
             id: 'loc-1',
-            location_geojson: JSON.stringify({
-              type: 'Point',
-              coordinates: [-97.7431, 30.2672],
-            }),
+            location_geojson: JSON.stringify({ type: 'Point', coordinates: [-97.7431, 30.2672] }),
             accuracy: 10,
             speed: 25,
             heading: 180,
@@ -434,10 +351,7 @@ describe('/api/tracking/locations API', () => {
           },
           {
             id: 'loc-2',
-            location_geojson: JSON.stringify({
-              type: 'Point',
-              coordinates: [-97.7531, 30.2772],
-            }),
+            location_geojson: JSON.stringify({ type: 'Point', coordinates: [-97.7531, 30.2772] }),
             accuracy: 15,
             speed: 30,
             heading: 90,
@@ -450,13 +364,11 @@ describe('/api/tracking/locations API', () => {
           },
         ];
 
-        mocks.poolQuery.mockResolvedValueOnce({ rows: mockLocations });
+        mockRawQuery.mockResolvedValueOnce(mockLocations);
 
-        const request = createGetRequest(
-          'http://localhost:3000/api/tracking/locations?driver_id=driver-123'
+        const response = await GET(
+          createGetRequest('http://localhost:3000/api/tracking/locations?driver_id=driver-123'),
         );
-
-        const response = await GET(request);
         const data = await expectSuccessResponse(response, 200);
 
         expect(data.success).toBe(true);
@@ -467,67 +379,39 @@ describe('/api/tracking/locations API', () => {
       });
 
       it('should use default hours parameter (24)', async () => {
-        mocks.poolQuery.mockResolvedValueOnce({ rows: [] });
-
-        const request = createGetRequest(
-          'http://localhost:3000/api/tracking/locations?driver_id=driver-123'
-        );
-
-        await GET(request);
-
-        const queryCall = mocks.poolQuery.mock.calls[0];
-        expect(queryCall[0]).toContain("24 hours");
+        mockRawQuery.mockResolvedValueOnce([]);
+        await GET(createGetRequest('http://localhost:3000/api/tracking/locations?driver_id=driver-123'));
+        const queryCall = mockRawQuery.mock.calls[0];
+        expect(queryCall[0]).toContain('24 hours');
       });
 
       it('should use custom hours parameter', async () => {
-        mocks.poolQuery.mockResolvedValueOnce({ rows: [] });
-
-        const request = createGetRequest(
-          'http://localhost:3000/api/tracking/locations?driver_id=driver-123&hours=48'
-        );
-
-        await GET(request);
-
-        const queryCall = mocks.poolQuery.mock.calls[0];
-        expect(queryCall[0]).toContain("48 hours");
+        mockRawQuery.mockResolvedValueOnce([]);
+        await GET(createGetRequest('http://localhost:3000/api/tracking/locations?driver_id=driver-123&hours=48'));
+        const queryCall = mockRawQuery.mock.calls[0];
+        expect(queryCall[0]).toContain('48 hours');
       });
 
       it('should use default limit (100)', async () => {
-        mocks.poolQuery.mockResolvedValueOnce({ rows: [] });
-
-        const request = createGetRequest(
-          'http://localhost:3000/api/tracking/locations?driver_id=driver-123'
-        );
-
-        await GET(request);
-
-        const queryCall = mocks.poolQuery.mock.calls[0];
-        expect(queryCall[1]).toContain(100); // limit parameter
+        mockRawQuery.mockResolvedValueOnce([]);
+        await GET(createGetRequest('http://localhost:3000/api/tracking/locations?driver_id=driver-123'));
+        const queryCall = mockRawQuery.mock.calls[0];
+        expect(queryCall[1]).toContain(100); // [driver_id, limit]
       });
 
       it('should use custom limit parameter', async () => {
-        mocks.poolQuery.mockResolvedValueOnce({ rows: [] });
-
-        const request = createGetRequest(
-          'http://localhost:3000/api/tracking/locations?driver_id=driver-123&limit=50'
-        );
-
-        await GET(request);
-
-        const queryCall = mocks.poolQuery.mock.calls[0];
+        mockRawQuery.mockResolvedValueOnce([]);
+        await GET(createGetRequest('http://localhost:3000/api/tracking/locations?driver_id=driver-123&limit=50'));
+        const queryCall = mockRawQuery.mock.calls[0];
         expect(queryCall[1]).toContain(50);
       });
 
       it('should return empty array when no locations found', async () => {
-        mocks.poolQuery.mockResolvedValueOnce({ rows: [] });
-
-        const request = createGetRequest(
-          'http://localhost:3000/api/tracking/locations?driver_id=driver-123'
+        mockRawQuery.mockResolvedValueOnce([]);
+        const response = await GET(
+          createGetRequest('http://localhost:3000/api/tracking/locations?driver_id=driver-123'),
         );
-
-        const response = await GET(request);
         const data = await expectSuccessResponse(response, 200);
-
         expect(data.success).toBe(true);
         expect(data.data).toHaveLength(0);
         expect(data.metadata.total_points).toBe(0);
@@ -536,24 +420,17 @@ describe('/api/tracking/locations API', () => {
 
     describe('Validation Tests', () => {
       it('should return 400 for missing driver_id', async () => {
-        const request = createGetRequest(
-          'http://localhost:3000/api/tracking/locations'
-        );
-
-        const response = await GET(request);
+        const response = await GET(createGetRequest('http://localhost:3000/api/tracking/locations'));
         await expectErrorResponse(response, 400, /Missing driver_id parameter/i);
       });
     });
 
     describe('Error Handling', () => {
       it('should handle database errors', async () => {
-        mocks.poolQuery.mockRejectedValueOnce(new Error('Database error'));
-
-        const request = createGetRequest(
-          'http://localhost:3000/api/tracking/locations?driver_id=driver-123'
+        mockRawQuery.mockRejectedValueOnce(new Error('Database error'));
+        const response = await GET(
+          createGetRequest('http://localhost:3000/api/tracking/locations?driver_id=driver-123'),
         );
-
-        const response = await GET(request);
         await expectErrorResponse(response, 500, /Failed to fetch location history/i);
       });
     });

--- a/src/__tests__/api/tracking/locations.test.ts
+++ b/src/__tests__/api/tracking/locations.test.ts
@@ -27,7 +27,11 @@ jest.mock('@/lib/db/raw', () => {
 // Route gained withAuth in the security-hardening pass — mock it (default ADMIN).
 jest.mock('@/lib/auth-middleware', () => ({ withAuth: jest.fn() }));
 
+// Rate limiter — default to "allowed" (null) in beforeEach.
+jest.mock('@/lib/security/rate-limit', () => ({ enforceRateLimit: jest.fn() }));
+
 import { withAuth } from '@/lib/auth-middleware';
+import { enforceRateLimit } from '@/lib/security/rate-limit';
 import { withRawTx, rawQuery } from '@/lib/db/raw';
 import { GET, POST } from '@/app/api/tracking/locations/route';
 import {
@@ -40,6 +44,7 @@ import {
 const mockWithAuth = withAuth as jest.Mock;
 const mockWithRawTx = withRawTx as jest.Mock;
 const mockRawQuery = rawQuery as jest.Mock;
+const mockEnforceRateLimit = enforceRateLimit as jest.Mock;
 
 // Fake interactive-transaction client.
 const mockTxQuery = jest.fn();
@@ -61,6 +66,7 @@ describe('/api/tracking/locations API', () => {
       success: true,
       context: { user: { id: 'admin-1', type: 'ADMIN' } },
     });
+    mockEnforceRateLimit.mockResolvedValue(null);
     mockWithRawTx.mockImplementation((fn: any) =>
       fn({ $queryRawUnsafe: mockTxQuery, $executeRawUnsafe: mockTxExec }),
     );

--- a/src/app/api/tracking/drivers/route.ts
+++ b/src/app/api/tracking/drivers/route.ts
@@ -1,13 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withAuth } from '@/lib/auth-middleware';
-// import { Pool } from 'pg';
-const Pool = require('pg').Pool;
-
-// Database connection for tracking system
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
-});
+import { rawQuery } from '@/lib/db/raw';
 
 interface Driver {
   id: string;
@@ -37,6 +30,15 @@ interface Driver {
 interface DriverLocation {
   latitude: number;
   longitude: number;
+}
+
+/** True when a raw-query error is a Postgres unique-violation (SQLSTATE 23505). */
+function isUniqueViolation(error: any): boolean {
+  return (
+    error?.code === '23505' ||
+    error?.meta?.code === '23505' ||
+    String(error?.message ?? '').includes('23505')
+  );
 }
 
 // GET - List drivers (admins) / own record (drivers)
@@ -78,7 +80,7 @@ export async function GET(request: NextRequest) {
       FROM drivers
       WHERE deleted_at IS NULL
     `;
-    
+
     const params: (string | number | boolean)[] = [];
     let paramCounter = 1;
 
@@ -104,9 +106,9 @@ export async function GET(request: NextRequest) {
     query += ` ORDER BY created_at DESC LIMIT $${paramCounter} OFFSET $${paramCounter + 1}`;
     params.push(limit, offset);
 
-    const result = await pool.query(query, params);
-    
-    const drivers = result.rows.map((row: any) => ({
+    const rows = await rawQuery<any>(query, params);
+
+    const drivers = rows.map((row: any) => ({
       ...row,
       last_known_location: row.location_geojson ? JSON.parse(row.location_geojson) : null,
     }));
@@ -124,8 +126,8 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     console.error('Error fetching drivers:', error);
     return NextResponse.json(
-      { 
-        success: false, 
+      {
+        success: false,
         error: 'Failed to fetch drivers',
         details: error instanceof Error ? error.message : 'Unknown error'
       },
@@ -163,7 +165,8 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const query = `
+    const rows = await rawQuery<any>(
+      `
       INSERT INTO drivers (
         user_id,
         profile_id,
@@ -183,40 +186,40 @@ export async function POST(request: NextRequest) {
         is_on_duty,
         created_at,
         updated_at
-    `;
-
-    const result = await pool.query(query, [
-      user_id || null,
-      profile_id || null,
-      employee_id || null,
-      vehicle_number || null,
-      phone_number || null,
-    ]);
+      `,
+      [
+        user_id || null,
+        profile_id || null,
+        employee_id || null,
+        vehicle_number || null,
+        phone_number || null,
+      ],
+    );
 
     return NextResponse.json({
       success: true,
-      data: result.rows[0]
+      data: rows[0]
     }, { status: 201 });
 
   } catch (error: any) {
     console.error('Error creating driver:', error);
-    
+
     // Handle unique constraint violation
-    if (error.code === '23505') {
+    if (isUniqueViolation(error)) {
       return NextResponse.json(
-        { 
-          success: false, 
-          error: 'Driver with this employee_id already exists' 
+        {
+          success: false,
+          error: 'Driver with this employee_id already exists'
         },
         { status: 409 }
       );
     }
 
     return NextResponse.json(
-      { 
-        success: false, 
+      {
+        success: false,
         error: 'Failed to create driver',
-        details: error.message
+        details: error instanceof Error ? error.message : 'Unknown error'
       },
       { status: 500 }
     );
@@ -244,11 +247,11 @@ export async function PUT(request: NextRequest) {
 
     // A DRIVER may only update their own record.
     if (auth.context.user.type === 'DRIVER') {
-      const owns = await pool.query(
+      const owns = await rawQuery<{ id: string }>(
         'SELECT id FROM drivers WHERE id = $1 AND user_id = $2',
-        [driver_id, auth.context.user.id]
+        [driver_id, auth.context.user.id],
       );
-      if (owns.rows.length === 0) {
+      if (owns.length === 0) {
         return NextResponse.json(
           { success: false, error: 'Access denied' },
           { status: 403 }
@@ -280,7 +283,7 @@ export async function PUT(request: NextRequest) {
       paramCounter++;
     }
 
-    query += ` WHERE id = $${paramCounter} RETURNING 
+    query += ` WHERE id = $${paramCounter} RETURNING
       id,
       employee_id,
       is_active,
@@ -290,9 +293,9 @@ export async function PUT(request: NextRequest) {
     `;
     params.push(driver_id);
 
-    const result = await pool.query(query, params);
+    const rows = await rawQuery<any>(query, params);
 
-    if (result.rows.length === 0) {
+    if (rows.length === 0) {
       return NextResponse.json(
         { success: false, error: 'Driver not found' },
         { status: 404 }
@@ -300,9 +303,9 @@ export async function PUT(request: NextRequest) {
     }
 
     const driver = {
-      ...result.rows[0],
-      last_known_location: result.rows[0].location_geojson ? 
-        JSON.parse(result.rows[0].location_geojson) : null,
+      ...rows[0],
+      last_known_location: rows[0].location_geojson ?
+        JSON.parse(rows[0].location_geojson) : null,
     };
 
     return NextResponse.json({
@@ -313,8 +316,8 @@ export async function PUT(request: NextRequest) {
   } catch (error) {
     console.error('Error updating driver:', error);
     return NextResponse.json(
-      { 
-        success: false, 
+      {
+        success: false,
         error: 'Failed to update driver',
         details: error instanceof Error ? error.message : 'Unknown error'
       },
@@ -343,10 +346,12 @@ export async function DELETE(request: NextRequest) {
       );
     }
 
-    const query = 'DELETE FROM drivers WHERE id = $1 RETURNING id';
-    const result = await pool.query(query, [driverId]);
+    const rows = await rawQuery<{ id: string }>(
+      'DELETE FROM drivers WHERE id = $1 RETURNING id',
+      [driverId],
+    );
 
-    if (result.rows.length === 0) {
+    if (rows.length === 0) {
       return NextResponse.json(
         { success: false, error: 'Driver not found' },
         { status: 404 }
@@ -361,12 +366,12 @@ export async function DELETE(request: NextRequest) {
   } catch (error) {
     console.error('Error deleting driver:', error);
     return NextResponse.json(
-      { 
-        success: false, 
+      {
+        success: false,
         error: 'Failed to delete driver',
         details: error instanceof Error ? error.message : 'Unknown error'
       },
       { status: 500 }
     );
   }
-} 
+}

--- a/src/app/api/tracking/locations/__tests__/route.test.ts
+++ b/src/app/api/tracking/locations/__tests__/route.test.ts
@@ -8,12 +8,14 @@
  * - GET: Fetching location history
  * - Input validation (coordinates, driver_id)
  * - Coordinate range validation
- * - Driver existence checks
+ * - Driver existence + ownership checks
  * - Pagination and filtering
  * - Error handling
+ *
+ * The route uses the shared pooled-Prisma raw helpers (`@/lib/db/raw`) rather than
+ * its own `pg.Pool`; these tests mock those helpers.
  */
 
-import { NextRequest } from "next/server";
 import {
   createPostRequest,
   createRequestWithParams,
@@ -23,40 +25,43 @@ import {
   expectServerError,
 } from "@/__tests__/helpers/api-test-helpers";
 
-// Mock pg Pool - define mocks inside the factory and export them
-jest.mock("pg", () => {
-  // Create mock client
-  const mockClient = {
-    query: jest.fn(),
-    release: jest.fn(),
-  };
-
-  // Create mock pool instance
-  const mockPoolInstance = {
-    connect: jest.fn().mockResolvedValue(mockClient),
-    query: jest.fn(),
-  };
-
-  // Expose mocks for test configuration
+// Mock the raw DB helpers. DbHttpError is defined in the mock so the route's
+// `throw new DbHttpError` and `instanceof DbHttpError` resolve to the same class.
+jest.mock("@/lib/db/raw", () => {
+  class DbHttpError extends Error {
+    status: number;
+    body: any;
+    constructor(status: number, body: any) {
+      super("db-http-error");
+      this.name = "DbHttpError";
+      this.status = status;
+      this.body = body;
+    }
+  }
   return {
-    Pool: jest.fn().mockImplementation(() => mockPoolInstance),
-    __mockClient: mockClient,
-    __mockPoolInstance: mockPoolInstance,
+    __esModule: true,
+    DbHttpError,
+    TRACKING_STATEMENT_TIMEOUT_MS: 8000,
+    withRawTx: jest.fn(),
+    rawQuery: jest.fn(),
+    rawExec: jest.fn(),
   };
 });
 
 // Mock auth middleware (the route gained withAuth in the security-hardening pass)
 jest.mock("@/lib/auth-middleware", () => ({ withAuth: jest.fn() }));
-import { withAuth } from "@/lib/auth-middleware";
-const mockWithAuth = withAuth as jest.Mock;
 
-// Import route handlers after mocking
+import { withAuth } from "@/lib/auth-middleware";
+import { withRawTx, rawQuery } from "@/lib/db/raw";
 import { POST, GET } from "../route";
 
-// Get references to the mocks for test configuration
-const pg = require("pg");
-const mockClient = pg.__mockClient;
-const mockPoolInstance = pg.__mockPoolInstance;
+const mockWithAuth = withAuth as jest.Mock;
+const mockWithRawTx = withRawTx as jest.Mock;
+const mockRawQuery = rawQuery as jest.Mock;
+
+// Fake interactive-transaction client driven by these two jest fns.
+const mockTxQuery = jest.fn();
+const mockTxExec = jest.fn();
 
 describe("/api/tracking/locations", () => {
   const mockDriverId = "driver-123";
@@ -101,179 +106,136 @@ describe("/api/tracking/locations", () => {
       context: { user: { id: "admin-1", type: "ADMIN" } },
     });
 
-    // Reset connect to return our mock client
-    mockPoolInstance.connect.mockResolvedValue(mockClient);
+    // withRawTx invokes its callback with our fake tx client.
+    mockWithRawTx.mockImplementation((fn: any) =>
+      fn({ $queryRawUnsafe: mockTxQuery, $executeRawUnsafe: mockTxExec }),
+    );
 
-    // Default client query implementation: driver exists and is active
-    mockClient.query.mockImplementation((sql: string) => {
+    // Default tx reads: driver exists + insert returns the record.
+    mockTxQuery.mockImplementation((sql: string) => {
       if (sql.includes("SELECT id FROM drivers")) {
-        return Promise.resolve({ rows: [{ id: mockDriverId }] });
+        return Promise.resolve([{ id: mockDriverId }]);
       }
       if (sql.includes("INSERT INTO driver_locations")) {
-        return Promise.resolve({ rows: [mockLocationRecord] });
+        return Promise.resolve([mockLocationRecord]);
       }
-      if (sql.includes("UPDATE drivers")) {
-        return Promise.resolve({ rows: [] });
-      }
-      if (
-        sql.includes("BEGIN") ||
-        sql.includes("COMMIT") ||
-        sql.includes("ROLLBACK")
-      ) {
-        return Promise.resolve({ rows: [] });
-      }
-      return Promise.resolve({ rows: [] });
+      return Promise.resolve([]);
     });
+    mockTxExec.mockResolvedValue(1);
 
-    // Default pool query for GET requests
-    mockPoolInstance.query.mockResolvedValue({ rows: [] });
+    // Default standalone read (GET history / ownership) returns empty.
+    mockRawQuery.mockResolvedValue([]);
   });
 
   describe("POST /api/tracking/locations", () => {
     describe("Input validation", () => {
       it("should return 400 when driver_id is missing", async () => {
         const { driver_id, ...dataWithoutDriverId } = mockLocationData;
-
-        const request = createPostRequest(
-          "http://localhost:3000/api/tracking/locations",
-          dataWithoutDriverId
+        const response = await POST(
+          createPostRequest("http://localhost:3000/api/tracking/locations", dataWithoutDriverId),
         );
-
-        const response = await POST(request);
         await expectValidationError(response, /driver_id/);
       });
 
       it("should return 400 when latitude is missing", async () => {
         const { latitude, ...dataWithoutLat } = mockLocationData;
-
-        const request = createPostRequest(
-          "http://localhost:3000/api/tracking/locations",
-          dataWithoutLat
+        const response = await POST(
+          createPostRequest("http://localhost:3000/api/tracking/locations", dataWithoutLat),
         );
-
-        const response = await POST(request);
         await expectValidationError(response, /latitude|longitude/);
       });
 
       it("should return 400 when longitude is missing", async () => {
         const { longitude, ...dataWithoutLng } = mockLocationData;
-
-        const request = createPostRequest(
-          "http://localhost:3000/api/tracking/locations",
-          dataWithoutLng
+        const response = await POST(
+          createPostRequest("http://localhost:3000/api/tracking/locations", dataWithoutLng),
         );
-
-        const response = await POST(request);
         await expectValidationError(response, /latitude|longitude/);
       });
 
       it("should return 400 when latitude is not a number", async () => {
-        const request = createPostRequest(
-          "http://localhost:3000/api/tracking/locations",
-          {
+        const response = await POST(
+          createPostRequest("http://localhost:3000/api/tracking/locations", {
             ...mockLocationData,
             latitude: "invalid",
-          }
+          }),
         );
-
-        const response = await POST(request);
         await expectValidationError(response);
       });
 
       it("should return 400 when longitude is not a number", async () => {
-        const request = createPostRequest(
-          "http://localhost:3000/api/tracking/locations",
-          {
+        const response = await POST(
+          createPostRequest("http://localhost:3000/api/tracking/locations", {
             ...mockLocationData,
             longitude: "invalid",
-          }
+          }),
         );
-
-        const response = await POST(request);
         await expectValidationError(response);
       });
     });
 
     describe("Coordinate range validation", () => {
       it("should return 400 when latitude is below -90", async () => {
-        const request = createPostRequest(
-          "http://localhost:3000/api/tracking/locations",
-          {
+        const response = await POST(
+          createPostRequest("http://localhost:3000/api/tracking/locations", {
             ...mockLocationData,
             latitude: -91,
-          }
+          }),
         );
-
-        const response = await POST(request);
         await expectValidationError(response, /Invalid coordinates/);
       });
 
       it("should return 400 when latitude is above 90", async () => {
-        const request = createPostRequest(
-          "http://localhost:3000/api/tracking/locations",
-          {
+        const response = await POST(
+          createPostRequest("http://localhost:3000/api/tracking/locations", {
             ...mockLocationData,
             latitude: 91,
-          }
+          }),
         );
-
-        const response = await POST(request);
         await expectValidationError(response, /Invalid coordinates/);
       });
 
       it("should return 400 when longitude is below -180", async () => {
-        const request = createPostRequest(
-          "http://localhost:3000/api/tracking/locations",
-          {
+        const response = await POST(
+          createPostRequest("http://localhost:3000/api/tracking/locations", {
             ...mockLocationData,
             longitude: -181,
-          }
+          }),
         );
-
-        const response = await POST(request);
         await expectValidationError(response, /Invalid coordinates/);
       });
 
       it("should return 400 when longitude is above 180", async () => {
-        const request = createPostRequest(
-          "http://localhost:3000/api/tracking/locations",
-          {
+        const response = await POST(
+          createPostRequest("http://localhost:3000/api/tracking/locations", {
             ...mockLocationData,
             longitude: 181,
-          }
+          }),
         );
-
-        const response = await POST(request);
         await expectValidationError(response, /Invalid coordinates/);
       });
 
       it("should accept valid edge case coordinates (-90, -180)", async () => {
-        const request = createPostRequest(
-          "http://localhost:3000/api/tracking/locations",
-          {
+        const response = await POST(
+          createPostRequest("http://localhost:3000/api/tracking/locations", {
             ...mockLocationData,
             latitude: -90,
             longitude: -180,
-          }
+          }),
         );
-
-        const response = await POST(request);
         const data = await response.json();
         expect(response.status).toBe(201);
         expect(data.success).toBe(true);
       });
 
       it("should accept valid edge case coordinates (90, 180)", async () => {
-        const request = createPostRequest(
-          "http://localhost:3000/api/tracking/locations",
-          {
+        const response = await POST(
+          createPostRequest("http://localhost:3000/api/tracking/locations", {
             ...mockLocationData,
             latitude: 90,
             longitude: 180,
-          }
+          }),
         );
-
-        const response = await POST(request);
         const data = await response.json();
         expect(response.status).toBe(201);
         expect(data.success).toBe(true);
@@ -282,52 +244,36 @@ describe("/api/tracking/locations", () => {
 
     describe("Driver validation", () => {
       it("should return 404 when driver does not exist", async () => {
-        mockClient.query.mockImplementation((sql: string) => {
-          if (sql.includes("SELECT id FROM drivers")) {
-            return Promise.resolve({ rows: [] });
-          }
-          return Promise.resolve({ rows: [] });
+        mockTxQuery.mockImplementation((sql: string) => {
+          if (sql.includes("SELECT id FROM drivers")) return Promise.resolve([]);
+          return Promise.resolve([]);
         });
-
-        const request = createPostRequest(
-          "http://localhost:3000/api/tracking/locations",
-          {
+        const response = await POST(
+          createPostRequest("http://localhost:3000/api/tracking/locations", {
             ...mockLocationData,
             driver_id: "non-existent-driver",
-          }
+          }),
         );
-
-        const response = await POST(request);
         await expectNotFound(response);
       });
 
       it("should return 404 when driver is inactive", async () => {
-        mockClient.query.mockImplementation((sql: string) => {
-          if (sql.includes("SELECT id FROM drivers")) {
-            // Query includes "is_active = true", so inactive driver returns empty
-            return Promise.resolve({ rows: [] });
-          }
-          return Promise.resolve({ rows: [] });
+        mockTxQuery.mockImplementation((sql: string) => {
+          if (sql.includes("SELECT id FROM drivers")) return Promise.resolve([]);
+          return Promise.resolve([]);
         });
-
-        const request = createPostRequest(
-          "http://localhost:3000/api/tracking/locations",
-          mockLocationData
+        const response = await POST(
+          createPostRequest("http://localhost:3000/api/tracking/locations", mockLocationData),
         );
-
-        const response = await POST(request);
         await expectNotFound(response);
       });
     });
 
     describe("Successful location recording", () => {
       it("should create location record and return 201", async () => {
-        const request = createPostRequest(
-          "http://localhost:3000/api/tracking/locations",
-          mockLocationData
+        const response = await POST(
+          createPostRequest("http://localhost:3000/api/tracking/locations", mockLocationData),
         );
-
-        const response = await POST(request);
         const data = await response.json();
 
         expect(response.status).toBe(201);
@@ -337,12 +283,9 @@ describe("/api/tracking/locations", () => {
       });
 
       it("should include all optional fields in the response", async () => {
-        const request = createPostRequest(
-          "http://localhost:3000/api/tracking/locations",
-          mockLocationData
+        const response = await POST(
+          createPostRequest("http://localhost:3000/api/tracking/locations", mockLocationData),
         );
-
-        const response = await POST(request);
         const data = await response.json();
 
         expect(data.data.accuracy).toBe(10);
@@ -360,131 +303,78 @@ describe("/api/tracking/locations", () => {
           longitude: -122.4194,
         };
 
-        mockClient.query.mockImplementation((sql: string) => {
-          if (sql.includes("SELECT id FROM drivers")) {
-            return Promise.resolve({ rows: [{ id: mockDriverId }] });
-          }
+        mockTxQuery.mockImplementation((sql: string) => {
+          if (sql.includes("SELECT id FROM drivers")) return Promise.resolve([{ id: mockDriverId }]);
           if (sql.includes("INSERT INTO driver_locations")) {
-            return Promise.resolve({
-              rows: [
-                {
-                  ...mockLocationRecord,
-                  accuracy: null,
-                  speed: null,
-                  heading: null,
-                },
-              ],
-            });
+            return Promise.resolve([{ ...mockLocationRecord, accuracy: null, speed: null, heading: null }]);
           }
-          return Promise.resolve({ rows: [] });
+          return Promise.resolve([]);
         });
 
-        const request = createPostRequest(
-          "http://localhost:3000/api/tracking/locations",
-          minimalData
+        const response = await POST(
+          createPostRequest("http://localhost:3000/api/tracking/locations", minimalData),
         );
-
-        const response = await POST(request);
         expect(response.status).toBe(201);
       });
     });
 
     describe("Error handling", () => {
       it("should return 500 when database insert fails", async () => {
-        mockClient.query.mockImplementation((sql: string) => {
-          if (sql.includes("SELECT id FROM drivers")) {
-            return Promise.resolve({ rows: [{ id: mockDriverId }] });
-          }
-          if (sql.includes("INSERT INTO driver_locations")) {
-            return Promise.reject(new Error("Database insert failed"));
-          }
-          return Promise.resolve({ rows: [] });
+        mockTxQuery.mockImplementation((sql: string) => {
+          if (sql.includes("SELECT id FROM drivers")) return Promise.resolve([{ id: mockDriverId }]);
+          if (sql.includes("INSERT INTO driver_locations")) return Promise.reject(new Error("Database insert failed"));
+          return Promise.resolve([]);
         });
-
-        const request = createPostRequest(
-          "http://localhost:3000/api/tracking/locations",
-          mockLocationData
+        const response = await POST(
+          createPostRequest("http://localhost:3000/api/tracking/locations", mockLocationData),
         );
-
-        const response = await POST(request);
         await expectServerError(response);
       });
 
-      it("should rollback transaction on error", async () => {
-        let rollbackCalled = false;
-        mockClient.query.mockImplementation((sql: string) => {
-          if (sql.includes("ROLLBACK")) {
-            rollbackCalled = true;
-            return Promise.resolve({ rows: [] });
-          }
-          if (sql.includes("SELECT id FROM drivers")) {
-            return Promise.resolve({ rows: [{ id: mockDriverId }] });
-          }
-          if (sql.includes("INSERT INTO driver_locations")) {
-            return Promise.reject(new Error("Insert failed"));
-          }
-          return Promise.resolve({ rows: [] });
+      it("does not apply the denormalized update when the insert fails (atomic)", async () => {
+        mockTxQuery.mockImplementation((sql: string) => {
+          if (sql.includes("SELECT id FROM drivers")) return Promise.resolve([{ id: mockDriverId }]);
+          if (sql.includes("INSERT INTO driver_locations")) return Promise.reject(new Error("Insert failed"));
+          return Promise.resolve([]);
         });
 
-        const request = createPostRequest(
-          "http://localhost:3000/api/tracking/locations",
-          mockLocationData
+        const response = await POST(
+          createPostRequest("http://localhost:3000/api/tracking/locations", mockLocationData),
         );
 
-        await POST(request);
-
-        expect(rollbackCalled).toBe(true);
+        expect(response.status).toBe(500);
+        // The UPDATE drivers statement must not run once the insert throws — the
+        // transaction rolls back (Prisma), keeping the write atomic.
+        expect(mockTxExec).not.toHaveBeenCalled();
       });
     });
   });
 
   describe("GET /api/tracking/locations", () => {
     const mockLocationHistory = [
-      {
-        ...mockLocationRecord,
-        id: "location-1",
-        recorded_at: new Date("2025-01-15T10:00:00Z").toISOString(),
-      },
-      {
-        ...mockLocationRecord,
-        id: "location-2",
-        recorded_at: new Date("2025-01-15T10:05:00Z").toISOString(),
-      },
-      {
-        ...mockLocationRecord,
-        id: "location-3",
-        recorded_at: new Date("2025-01-15T10:10:00Z").toISOString(),
-      },
+      { ...mockLocationRecord, id: "location-1", recorded_at: new Date("2025-01-15T10:00:00Z").toISOString() },
+      { ...mockLocationRecord, id: "location-2", recorded_at: new Date("2025-01-15T10:05:00Z").toISOString() },
+      { ...mockLocationRecord, id: "location-3", recorded_at: new Date("2025-01-15T10:10:00Z").toISOString() },
     ];
 
     beforeEach(() => {
-      mockPoolInstance.query.mockResolvedValue({ rows: mockLocationHistory });
+      mockRawQuery.mockResolvedValue(mockLocationHistory);
     });
 
     describe("Input validation", () => {
       it("should return 400 when driver_id is missing", async () => {
-        const request = createRequestWithParams(
-          "http://localhost:3000/api/tracking/locations",
-          {
-            hours: "24",
-          }
+        const response = await GET(
+          createRequestWithParams("http://localhost:3000/api/tracking/locations", { hours: "24" }),
         );
-
-        const response = await GET(request);
         await expectValidationError(response, /driver_id/);
       });
     });
 
     describe("Successful retrieval", () => {
       it("should return location history for driver", async () => {
-        const request = createRequestWithParams(
-          "http://localhost:3000/api/tracking/locations",
-          {
-            driver_id: mockDriverId,
-          }
+        const response = await GET(
+          createRequestWithParams("http://localhost:3000/api/tracking/locations", { driver_id: mockDriverId }),
         );
-
-        const response = await GET(request);
         const data = await expectSuccessResponse(response, 200);
 
         expect(data.success).toBe(true);
@@ -494,76 +384,48 @@ describe("/api/tracking/locations", () => {
       });
 
       it("should use default hours (24) when not specified", async () => {
-        const request = createRequestWithParams(
-          "http://localhost:3000/api/tracking/locations",
-          {
-            driver_id: mockDriverId,
-          }
+        const response = await GET(
+          createRequestWithParams("http://localhost:3000/api/tracking/locations", { driver_id: mockDriverId }),
         );
-
-        const response = await GET(request);
         const data = await expectSuccessResponse(response, 200);
-
         expect(data.metadata.hours_requested).toBe(24);
       });
 
       it("should respect custom hours parameter", async () => {
-        const request = createRequestWithParams(
-          "http://localhost:3000/api/tracking/locations",
-          {
+        const response = await GET(
+          createRequestWithParams("http://localhost:3000/api/tracking/locations", {
             driver_id: mockDriverId,
             hours: "48",
-          }
+          }),
         );
-
-        const response = await GET(request);
         const data = await expectSuccessResponse(response, 200);
-
         expect(data.metadata.hours_requested).toBe(48);
       });
 
       it("should use default limit (100) when not specified", async () => {
-        const request = createRequestWithParams(
-          "http://localhost:3000/api/tracking/locations",
-          {
-            driver_id: mockDriverId,
-          }
+        const response = await GET(
+          createRequestWithParams("http://localhost:3000/api/tracking/locations", { driver_id: mockDriverId }),
         );
-
-        const response = await GET(request);
         const data = await expectSuccessResponse(response, 200);
-
         expect(data.metadata.total_points).toBe(3);
       });
 
       it("should respect custom limit parameter", async () => {
-        mockPoolInstance.query.mockResolvedValue({
-          rows: [mockLocationHistory[0]],
-        });
-
-        const request = createRequestWithParams(
-          "http://localhost:3000/api/tracking/locations",
-          {
+        mockRawQuery.mockResolvedValue([mockLocationHistory[0]]);
+        const response = await GET(
+          createRequestWithParams("http://localhost:3000/api/tracking/locations", {
             driver_id: mockDriverId,
             limit: "1",
-          }
+          }),
         );
-
-        const response = await GET(request);
         const data = await expectSuccessResponse(response, 200);
-
         expect(data.data).toHaveLength(1);
       });
 
       it("should transform location_geojson to location object", async () => {
-        const request = createRequestWithParams(
-          "http://localhost:3000/api/tracking/locations",
-          {
-            driver_id: mockDriverId,
-          }
+        const response = await GET(
+          createRequestWithParams("http://localhost:3000/api/tracking/locations", { driver_id: mockDriverId }),
         );
-
-        const response = await GET(request);
         const data = await expectSuccessResponse(response, 200);
 
         expect(data.data[0].location).toBeDefined();
@@ -572,18 +434,11 @@ describe("/api/tracking/locations", () => {
       });
 
       it("should return empty array when no locations found", async () => {
-        mockPoolInstance.query.mockResolvedValue({ rows: [] });
-
-        const request = createRequestWithParams(
-          "http://localhost:3000/api/tracking/locations",
-          {
-            driver_id: mockDriverId,
-          }
+        mockRawQuery.mockResolvedValue([]);
+        const response = await GET(
+          createRequestWithParams("http://localhost:3000/api/tracking/locations", { driver_id: mockDriverId }),
         );
-
-        const response = await GET(request);
         const data = await expectSuccessResponse(response, 200);
-
         expect(data.data).toHaveLength(0);
         expect(data.metadata.total_points).toBe(0);
       });
@@ -591,36 +446,19 @@ describe("/api/tracking/locations", () => {
 
     describe("Error handling", () => {
       it("should return 500 when database query fails", async () => {
-        mockPoolInstance.query.mockRejectedValue(
-          new Error("Database query failed")
+        mockRawQuery.mockRejectedValue(new Error("Database query failed"));
+        const response = await GET(
+          createRequestWithParams("http://localhost:3000/api/tracking/locations", { driver_id: mockDriverId }),
         );
-
-        const request = createRequestWithParams(
-          "http://localhost:3000/api/tracking/locations",
-          {
-            driver_id: mockDriverId,
-          }
-        );
-
-        const response = await GET(request);
         await expectServerError(response);
       });
 
       it("should include error details in response", async () => {
-        mockPoolInstance.query.mockRejectedValue(
-          new Error("Specific database error")
+        mockRawQuery.mockRejectedValue(new Error("Specific database error"));
+        const response = await GET(
+          createRequestWithParams("http://localhost:3000/api/tracking/locations", { driver_id: mockDriverId }),
         );
-
-        const request = createRequestWithParams(
-          "http://localhost:3000/api/tracking/locations",
-          {
-            driver_id: mockDriverId,
-          }
-        );
-
-        const response = await GET(request);
         const data = await response.json();
-
         expect(data.details).toBeDefined();
       });
     });
@@ -628,26 +466,19 @@ describe("/api/tracking/locations", () => {
 
   describe("Security (auth + ownership)", () => {
     it("POST: returns 401 when unauthenticated", async () => {
-      mockWithAuth.mockResolvedValue({
-        success: false,
-        response: { status: 401 },
-        context: {},
-      });
+      mockWithAuth.mockResolvedValue({ success: false, response: { status: 401 }, context: {} });
       const response = await POST(
         createPostRequest("http://localhost:3000/api/tracking/locations", mockLocationData),
       );
       expect(response.status).toBe(401);
-      expect(mockPoolInstance.connect).not.toHaveBeenCalled();
+      expect(mockWithRawTx).not.toHaveBeenCalled();
     });
 
     it("POST: denies a driver writing a foreign driver_id (403)", async () => {
-      mockWithAuth.mockResolvedValue({
-        success: true,
-        context: { user: { id: "attacker", type: "DRIVER" } },
-      });
-      mockClient.query.mockImplementation((sql: string) => {
-        if (sql.includes("SELECT id FROM drivers")) return Promise.resolve({ rows: [] });
-        return Promise.resolve({ rows: [] });
+      mockWithAuth.mockResolvedValue({ success: true, context: { user: { id: "attacker", type: "DRIVER" } } });
+      mockTxQuery.mockImplementation((sql: string) => {
+        if (sql.includes("SELECT id FROM drivers")) return Promise.resolve([]);
+        return Promise.resolve([]);
       });
       const response = await POST(
         createPostRequest("http://localhost:3000/api/tracking/locations", mockLocationData),
@@ -658,44 +489,31 @@ describe("/api/tracking/locations", () => {
     });
 
     it("POST: allows the owning driver and scopes the check to their auth id (201)", async () => {
-      mockWithAuth.mockResolvedValue({
-        success: true,
-        context: { user: { id: "user-owner", type: "DRIVER" } },
-      });
+      mockWithAuth.mockResolvedValue({ success: true, context: { user: { id: "user-owner", type: "DRIVER" } } });
       const response = await POST(
         createPostRequest("http://localhost:3000/api/tracking/locations", mockLocationData),
       );
       expect(response.status).toBe(201);
-      const ownershipCall = mockClient.query.mock.calls.find(
-        ([sql]: [string]) => typeof sql === "string" && sql.includes("AND user_id"),
+      const ownershipCall = mockTxQuery.mock.calls.find(
+        ([sql]: any[]) => typeof sql === "string" && sql.includes("AND user_id"),
       );
-      expect(ownershipCall?.[1]).toEqual([mockDriverId, "user-owner"]);
+      // tx.$queryRawUnsafe(sql, driver_id, userId) → args after the sql.
+      expect(ownershipCall?.slice(1)).toEqual([mockDriverId, "user-owner"]);
     });
 
     it("GET: returns 401 when unauthenticated", async () => {
-      mockWithAuth.mockResolvedValue({
-        success: false,
-        response: { status: 401 },
-        context: {},
-      });
+      mockWithAuth.mockResolvedValue({ success: false, response: { status: 401 }, context: {} });
       const response = await GET(
-        createRequestWithParams("http://localhost:3000/api/tracking/locations", {
-          driver_id: mockDriverId,
-        }),
+        createRequestWithParams("http://localhost:3000/api/tracking/locations", { driver_id: mockDriverId }),
       );
       expect(response.status).toBe(401);
     });
 
     it("GET: denies a driver reading a foreign driver's history (403)", async () => {
-      mockWithAuth.mockResolvedValue({
-        success: true,
-        context: { user: { id: "attacker", type: "DRIVER" } },
-      });
-      mockPoolInstance.query.mockResolvedValue({ rows: [] }); // ownership lookup → not owned
+      mockWithAuth.mockResolvedValue({ success: true, context: { user: { id: "attacker", type: "DRIVER" } } });
+      mockRawQuery.mockResolvedValue([]); // ownership lookup → not owned
       const response = await GET(
-        createRequestWithParams("http://localhost:3000/api/tracking/locations", {
-          driver_id: "driver-victim",
-        }),
+        createRequestWithParams("http://localhost:3000/api/tracking/locations", { driver_id: "driver-victim" }),
       );
       expect(response.status).toBe(403);
     });

--- a/src/app/api/tracking/locations/__tests__/route.test.ts
+++ b/src/app/api/tracking/locations/__tests__/route.test.ts
@@ -51,13 +51,18 @@ jest.mock("@/lib/db/raw", () => {
 // Mock auth middleware (the route gained withAuth in the security-hardening pass)
 jest.mock("@/lib/auth-middleware", () => ({ withAuth: jest.fn() }));
 
+// Rate limiter — default to "allowed" (null); the abuse-protection test overrides.
+jest.mock("@/lib/security/rate-limit", () => ({ enforceRateLimit: jest.fn() }));
+
 import { withAuth } from "@/lib/auth-middleware";
 import { withRawTx, rawQuery } from "@/lib/db/raw";
+import { enforceRateLimit } from "@/lib/security/rate-limit";
 import { POST, GET } from "../route";
 
 const mockWithAuth = withAuth as jest.Mock;
 const mockWithRawTx = withRawTx as jest.Mock;
 const mockRawQuery = rawQuery as jest.Mock;
+const mockEnforceRateLimit = enforceRateLimit as jest.Mock;
 
 // Fake interactive-transaction client driven by these two jest fns.
 const mockTxQuery = jest.fn();
@@ -105,6 +110,9 @@ describe("/api/tracking/locations", () => {
       success: true,
       context: { user: { id: "admin-1", type: "ADMIN" } },
     });
+
+    // Default: rate limiter allows the request.
+    mockEnforceRateLimit.mockResolvedValue(null);
 
     // withRawTx invokes its callback with our fake tx client.
     mockWithRawTx.mockImplementation((fn: any) =>
@@ -471,6 +479,19 @@ describe("/api/tracking/locations", () => {
         createPostRequest("http://localhost:3000/api/tracking/locations", mockLocationData),
       );
       expect(response.status).toBe(401);
+      expect(mockWithRawTx).not.toHaveBeenCalled();
+    });
+
+    it("POST: returns the limiter's 429 and skips the DB when rate-limited", async () => {
+      mockEnforceRateLimit.mockResolvedValue(
+        new Response(JSON.stringify({ status: "ERROR" }), { status: 429 }),
+      );
+      const response = await POST(
+        createPostRequest("http://localhost:3000/api/tracking/locations", mockLocationData),
+      );
+      expect(response.status).toBe(429);
+      // Keyed by the authenticated user id, not the body driver_id.
+      expect(mockEnforceRateLimit).toHaveBeenCalledWith("admin-1", "tracking-location-write");
       expect(mockWithRawTx).not.toHaveBeenCalled();
     });
 

--- a/src/app/api/tracking/locations/route.ts
+++ b/src/app/api/tracking/locations/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withAuth } from '@/lib/auth-middleware';
 import { rawQuery, withRawTx, DbHttpError } from '@/lib/db/raw';
+import { enforceRateLimit } from '@/lib/security/rate-limit';
 
 interface LocationUpdate {
   driver_id: string;
@@ -23,6 +24,13 @@ export async function POST(request: NextRequest) {
     requireAuth: true,
   });
   if (!auth.success) return auth.response;
+
+  // Abuse protection: cap location writes per authenticated user (keyed by the
+  // auth id, not the body driver_id, so it can't be bypassed). Multi-instance
+  // safe via Upstash; falls open if the limiter backend is unavailable. Normal
+  // drivers write ~12/min (client throttled to 1/5s) — well under the cap.
+  const limited = await enforceRateLimit(auth.context.user.id, 'tracking-location-write');
+  if (limited) return limited;
 
   try {
     const body = await request.json();

--- a/src/app/api/tracking/locations/route.ts
+++ b/src/app/api/tracking/locations/route.ts
@@ -1,13 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withAuth } from '@/lib/auth-middleware';
-// import { Pool } from 'pg';
-const Pool = require('pg').Pool;
-
-// Database connection for tracking system
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
-});
+import { rawQuery, withRawTx, DbHttpError } from '@/lib/db/raw';
 
 interface LocationUpdate {
   driver_id: string;
@@ -31,11 +24,7 @@ export async function POST(request: NextRequest) {
   });
   if (!auth.success) return auth.response;
 
-  const client = await pool.connect();
-
   try {
-    await client.query('BEGIN');
-
     const body = await request.json();
     const {
       driver_id,
@@ -53,9 +42,9 @@ export async function POST(request: NextRequest) {
     // Validate required fields
     if (!driver_id || typeof latitude !== 'number' || typeof longitude !== 'number') {
       return NextResponse.json(
-        { 
-          success: false, 
-          error: 'Missing required fields: driver_id, latitude, longitude' 
+        {
+          success: false,
+          error: 'Missing required fields: driver_id, latitude, longitude'
         },
         { status: 400 }
       );
@@ -69,90 +58,92 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Check if driver exists. A DRIVER may only write their OWN location:
-    // verify the target driver row belongs to the authenticated user
-    // (drivers.user_id === auth user id). Admins may write for any driver.
     const isDriver = auth.context.user.type === 'DRIVER';
-    const driverCheck = isDriver
-      ? await client.query(
-          'SELECT id FROM drivers WHERE id = $1 AND user_id = $2 AND is_active = true',
-          [driver_id, auth.context.user.id]
-        )
-      : await client.query(
-          'SELECT id FROM drivers WHERE id = $1 AND is_active = true',
-          [driver_id]
-        );
 
-    if (driverCheck.rows.length === 0) {
-      await client.query('ROLLBACK');
-      return NextResponse.json(
-        {
+    // One transaction: ownership/existence check + insert + denormalized update.
+    // A DRIVER may only write their OWN location (drivers.user_id === auth user
+    // id); admins may write for any driver. Coordinates are bound as numeric
+    // params via ST_MakePoint (never string-interpolated).
+    const locationRow = await withRawTx(async (tx) => {
+      const driverCheck = isDriver
+        ? await tx.$queryRawUnsafe<{ id: string }[]>(
+            'SELECT id FROM drivers WHERE id = $1 AND user_id = $2 AND is_active = true',
+            driver_id,
+            auth.context.user.id,
+          )
+        : await tx.$queryRawUnsafe<{ id: string }[]>(
+            'SELECT id FROM drivers WHERE id = $1 AND is_active = true',
+            driver_id,
+          );
+
+      if (driverCheck.length === 0) {
+        throw new DbHttpError(isDriver ? 403 : 404, {
           success: false,
-          error: isDriver
-            ? 'Access denied'
-            : 'Driver not found or inactive',
-        },
-        { status: isDriver ? 403 : 404 }
-      );
-    }
+          error: isDriver ? 'Access denied' : 'Driver not found or inactive',
+        });
+      }
 
-    // Insert location record
-    const locationQuery = `
-      INSERT INTO driver_locations (
+      const inserted = await tx.$queryRawUnsafe<any[]>(
+        `
+        INSERT INTO driver_locations (
+          driver_id,
+          location,
+          accuracy,
+          speed,
+          heading,
+          altitude,
+          battery_level,
+          is_moving,
+          activity_type,
+          recorded_at
+        )
+        VALUES ($1, ST_SetSRID(ST_MakePoint($2, $3), 4326)::geography, $4, $5, $6, $7, $8, $9, $10, NOW())
+        RETURNING
+          id,
+          ST_AsGeoJSON(location) as location_geojson,
+          accuracy,
+          speed,
+          heading,
+          altitude,
+          battery_level,
+          is_moving,
+          activity_type,
+          recorded_at,
+          created_at
+        `,
         driver_id,
-        location,
-        accuracy,
-        speed,
-        heading,
-        altitude,
-        battery_level,
-        is_moving,
-        activity_type,
-        recorded_at
-      )
-      VALUES ($1, ST_SetSRID(ST_MakePoint($2, $3), 4326)::geography, $4, $5, $6, $7, $8, $9, $10, NOW())
-      RETURNING
-        id,
-        ST_AsGeoJSON(location) as location_geojson,
-        accuracy,
-        speed,
-        heading,
-        altitude,
-        battery_level,
-        is_moving,
-        activity_type,
-        recorded_at,
-        created_at
-    `;
+        longitude,
+        latitude,
+        accuracy ?? null,
+        speed ?? null,
+        heading ?? null,
+        altitude ?? null,
+        battery_level ?? null,
+        is_moving ?? null,
+        activity_type ?? null,
+      );
 
-    const locationResult = await client.query(locationQuery, [
-      driver_id,
-      longitude,
-      latitude,
-      accuracy,
-      speed,
-      heading,
-      altitude,
-      battery_level,
-      is_moving,
-      activity_type
-    ]);
+      // Update driver's last known location
+      await tx.$executeRawUnsafe(
+        `
+        UPDATE drivers
+        SET
+          last_known_location = ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography,
+          last_location_update = NOW(),
+          updated_at = NOW()
+        WHERE id = $3
+        `,
+        longitude,
+        latitude,
+        driver_id,
+      );
 
-    // Update driver's last known location
-    await client.query(`
-      UPDATE drivers
-      SET
-        last_known_location = ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography,
-        last_location_update = NOW(),
-        updated_at = NOW()
-      WHERE id = $3
-    `, [longitude, latitude, driver_id]);
-
-    await client.query('COMMIT');
+      return inserted[0];
+    });
 
     const locationData = {
-      ...locationResult.rows[0],
-      location: JSON.parse(locationResult.rows[0].location_geojson)
+      ...locationRow,
+      location: JSON.parse(locationRow.location_geojson)
     };
 
     return NextResponse.json({
@@ -161,18 +152,18 @@ export async function POST(request: NextRequest) {
     }, { status: 201 });
 
   } catch (error) {
-    await client.query('ROLLBACK');
+    if (error instanceof DbHttpError) {
+      return NextResponse.json(error.body, { status: error.status });
+    }
     console.error('Error recording location:', error);
     return NextResponse.json(
-      { 
-        success: false, 
+      {
+        success: false,
         error: 'Failed to record location',
         details: error instanceof Error ? error.message : 'Unknown error'
       },
       { status: 500 }
     );
-  } finally {
-    client.release();
   }
 }
 
@@ -201,11 +192,11 @@ export async function GET(request: NextRequest) {
 
     // A DRIVER may only read their own location history.
     if (auth.context.user.type === 'DRIVER') {
-      const owns = await pool.query(
+      const owns = await rawQuery<{ id: string }>(
         'SELECT id FROM drivers WHERE id = $1 AND user_id = $2',
-        [driver_id, auth.context.user.id]
+        [driver_id, auth.context.user.id],
       );
-      if (owns.rows.length === 0) {
+      if (owns.length === 0) {
         return NextResponse.json(
           { success: false, error: 'Access denied' },
           { status: 403 }
@@ -213,8 +204,9 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    const query = `
-      SELECT 
+    const rows = await rawQuery<any>(
+      `
+      SELECT
         id,
         ST_AsGeoJSON(location) as location_geojson,
         accuracy,
@@ -227,16 +219,16 @@ export async function GET(request: NextRequest) {
         recorded_at,
         created_at
       FROM driver_locations
-      WHERE 
-        driver_id = $1 
+      WHERE
+        driver_id = $1
         AND recorded_at >= NOW() - INTERVAL '${hours} hours'
       ORDER BY recorded_at DESC
       LIMIT $2
-    `;
+      `,
+      [driver_id, limit],
+    );
 
-    const result = await pool.query(query, [driver_id, limit]);
-
-    const locations = result.rows.map((row: any) => ({
+    const locations = rows.map((row: any) => ({
       ...row,
       location: JSON.parse(row.location_geojson)
     }));
@@ -254,12 +246,12 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     console.error('Error fetching location history:', error);
     return NextResponse.json(
-      { 
-        success: false, 
+      {
+        success: false,
         error: 'Failed to fetch location history',
         details: error instanceof Error ? error.message : 'Unknown error'
       },
       { status: 500 }
     );
   }
-} 
+}

--- a/src/app/api/tracking/test/route.ts
+++ b/src/app/api/tracking/test/route.ts
@@ -1,14 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withAuth } from '@/lib/auth-middleware';
 import { devOnlyGuard } from '@/lib/auth/dev-only-guard';
-// import { Pool } from 'pg';
-const Pool = require('pg').Pool;
-
-// Database connection for tracking system
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
-});
+import { rawQuery, rawExec } from '@/lib/db/raw';
 
 // GET - Test tracking system connectivity and data
 export async function GET(request: NextRequest) {
@@ -28,14 +21,14 @@ export async function GET(request: NextRequest) {
 
   try {
     const tests = [];
-    
+
     // Test 1: Database connectivity
     try {
-      const dbTest = await pool.query('SELECT NOW() as current_time, version() as db_version');
+      const dbTest = await rawQuery<any>('SELECT NOW() as current_time, version() as db_version');
       tests.push({
         name: 'Database Connectivity',
         status: 'PASS',
-        data: dbTest.rows[0]
+        data: dbTest[0]
       });
     } catch (error) {
       tests.push({
@@ -47,11 +40,11 @@ export async function GET(request: NextRequest) {
 
     // Test 2: PostGIS Extension
     try {
-      const postgisTest = await pool.query('SELECT PostGIS_Version() as postgis_version');
+      const postgisTest = await rawQuery<any>('SELECT PostGIS_Version() as postgis_version');
       tests.push({
         name: 'PostGIS Extension',
         status: 'PASS',
-        data: postgisTest.rows[0]
+        data: postgisTest[0]
       });
     } catch (error) {
       tests.push({
@@ -63,18 +56,18 @@ export async function GET(request: NextRequest) {
 
     // Test 3: Tables exist
     try {
-      const tablesTest = await pool.query(`
-        SELECT table_name 
-        FROM information_schema.tables 
-        WHERE table_schema = 'public' 
+      const tablesTest = await rawQuery<any>(`
+        SELECT table_name
+        FROM information_schema.tables
+        WHERE table_schema = 'public'
         AND table_name IN ('drivers', 'driver_locations', 'deliveries', 'tracking_events', 'geofences')
         ORDER BY table_name
       `);
-      
+
       const expectedTables = ['deliveries', 'driver_locations', 'drivers', 'geofences', 'tracking_events'];
-      const foundTables = tablesTest.rows.map((row: any) => row.table_name);
+      const foundTables = tablesTest.map((row: any) => row.table_name);
       const missingTables = expectedTables.filter(table => !foundTables.includes(table));
-      
+
       tests.push({
         name: 'Required Tables',
         status: missingTables.length === 0 ? 'PASS' : 'FAIL',
@@ -92,21 +85,21 @@ export async function GET(request: NextRequest) {
       });
     }
 
-    // Test 4: Sample data counts
+    // Test 4: Sample data counts (cast to int so the result is a JS number, not BigInt)
     try {
-      const countsTest = await pool.query(`
-        SELECT 
-          (SELECT COUNT(*) FROM drivers) as drivers_count,
-          (SELECT COUNT(*) FROM deliveries) as deliveries_count,
-          (SELECT COUNT(*) FROM driver_locations) as locations_count,
-          (SELECT COUNT(*) FROM tracking_events) as events_count,
-          (SELECT COUNT(*) FROM geofences) as geofences_count
+      const countsTest = await rawQuery<any>(`
+        SELECT
+          (SELECT COUNT(*)::int FROM drivers) as drivers_count,
+          (SELECT COUNT(*)::int FROM deliveries) as deliveries_count,
+          (SELECT COUNT(*)::int FROM driver_locations) as locations_count,
+          (SELECT COUNT(*)::int FROM tracking_events) as events_count,
+          (SELECT COUNT(*)::int FROM geofences) as geofences_count
       `);
-      
+
       tests.push({
         name: 'Sample Data',
         status: 'PASS',
-        data: countsTest.rows[0]
+        data: countsTest[0]
       });
     } catch (error) {
       tests.push({
@@ -118,20 +111,20 @@ export async function GET(request: NextRequest) {
 
     // Test 5: Geographic queries
     try {
-      const geoTest = await pool.query(`
-        SELECT 
+      const geoTest = await rawQuery<any>(`
+        SELECT
           employee_id,
           ST_AsText(last_known_location) as location_text,
           ST_AsGeoJSON(last_known_location) as location_geojson
-        FROM drivers 
+        FROM drivers
         WHERE last_known_location IS NOT NULL
         LIMIT 1
       `);
-      
+
       tests.push({
         name: 'Geographic Queries',
         status: 'PASS',
-        data: geoTest.rows[0] || { message: 'No location data found' }
+        data: geoTest[0] || { message: 'No location data found' }
       });
     } catch (error) {
       tests.push({
@@ -143,25 +136,25 @@ export async function GET(request: NextRequest) {
 
     // Test 6: Recent activity
     try {
-      const activityTest = await pool.query(`
-        SELECT 
+      const activityTest = await rawQuery<any>(`
+        SELECT
           d.employee_id,
           d.is_on_duty,
           d.last_location_update,
-          COUNT(dl.id) as recent_location_updates
+          COUNT(dl.id)::int as recent_location_updates
         FROM drivers d
-        LEFT JOIN driver_locations dl ON d.id = dl.driver_id 
+        LEFT JOIN driver_locations dl ON d.id = dl.driver_id
           AND dl.recorded_at >= NOW() - INTERVAL '1 hour'
         WHERE d.is_active = true
         GROUP BY d.id, d.employee_id, d.is_on_duty, d.last_location_update
         ORDER BY d.last_location_update DESC NULLS LAST
         LIMIT 3
       `);
-      
+
       tests.push({
         name: 'Recent Activity',
         status: 'PASS',
-        data: activityTest.rows
+        data: activityTest
       });
     } catch (error) {
       tests.push({
@@ -194,8 +187,8 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     console.error('Error running tracking system tests:', error);
     return NextResponse.json(
-      { 
-        success: false, 
+      {
+        success: false,
         error: 'Failed to run tracking system tests',
         details: error instanceof Error ? error.message : 'Unknown error'
       },
@@ -229,33 +222,35 @@ export async function POST(request: NextRequest) {
     if (test_type === 'basic' || test_type === 'all') {
       // Test location insert performance
       const startTime = Date.now();
-      
+
       try {
         // Get a test driver
-        const driverResult = await pool.query('SELECT id FROM drivers LIMIT 1');
-        if (driverResult.rows.length === 0) {
+        const driverResult = await rawQuery<{ id: string }>('SELECT id FROM drivers LIMIT 1');
+        const driverId = driverResult[0]?.id;
+        if (!driverId) {
           throw new Error('No test drivers available');
         }
-        
-        const driverId = driverResult.rows[0].id;
-        
-        // Insert 10 test locations
+
+        // Insert 10 test locations (coordinates bound as numeric params)
         const insertPromises = [];
         for (let i = 0; i < 10; i++) {
           const lat = 30.2672 + (Math.random() - 0.5) * 0.01;
           const lng = -97.7431 + (Math.random() - 0.5) * 0.01;
-          
+
           insertPromises.push(
-            pool.query(`
+            rawExec(
+              `
               INSERT INTO driver_locations (driver_id, location, accuracy, speed, is_moving, recorded_at)
-              VALUES ($1, ST_GeogFromText($2), $3, $4, $5, NOW())
-            `, [driverId, `POINT(${lng} ${lat})`, 5.0, 25.5, true])
+              VALUES ($1, ST_SetSRID(ST_MakePoint($2, $3), 4326)::geography, $4, $5, $6, NOW())
+              `,
+              [driverId, lng, lat, 5.0, 25.5, true],
+            )
           );
         }
-        
+
         await Promise.all(insertPromises);
         const endTime = Date.now();
-        
+
         performanceTests.push({
           name: 'Location Insert Performance',
           status: 'PASS',
@@ -275,21 +270,21 @@ export async function POST(request: NextRequest) {
     if (test_type === 'spatial' || test_type === 'all') {
       // Test spatial queries
       const startTime = Date.now();
-      
+
       try {
-        await pool.query(`
-          SELECT 
+        await rawQuery<any>(`
+          SELECT
             d.employee_id,
             ST_Distance(d.last_known_location, ST_GeogFromText('POINT(-97.7431 30.2672)')) as distance_meters
           FROM drivers d
-          WHERE 
+          WHERE
             d.last_known_location IS NOT NULL
             AND ST_DWithin(d.last_known_location, ST_GeogFromText('POINT(-97.7431 30.2672)'), 10000)
           ORDER BY distance_meters
         `);
-        
+
         const endTime = Date.now();
-        
+
         performanceTests.push({
           name: 'Spatial Query Performance',
           status: 'PASS',
@@ -320,12 +315,12 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error('Error running performance tests:', error);
     return NextResponse.json(
-      { 
-        success: false, 
+      {
+        success: false,
         error: 'Failed to run performance tests',
         details: error instanceof Error ? error.message : 'Unknown error'
       },
       { status: 500 }
     );
   }
-} 
+}

--- a/src/lib/db/raw.ts
+++ b/src/lib/db/raw.ts
@@ -1,0 +1,73 @@
+import type { Prisma } from "@prisma/client";
+import { prisma } from "@/utils/prismaDB";
+
+/**
+ * Raw-SQL helpers on the shared, pgbouncer-aware pooled Prisma client.
+ *
+ * Why this exists: the driver-tracking API routes used to each create their own
+ * unbounded `new (require('pg').Pool)({ connectionString: DATABASE_URL })` at
+ * module scope. In Vercel serverless that spins up a separate, uncapped pool per
+ * route/instance, all competing with Prisma for the ~20-slot Supabase pooler.
+ * Under 20-30 concurrent drivers (each POSTing location every few seconds) those
+ * pools exhaust the pooler and unrelated routes (e.g. the history Server
+ * Component) start returning 500s. Routing every tracking query through the one
+ * tuned singleton fixes that.
+ *
+ * Every call is wrapped in a transaction that first sets a hard Postgres
+ * `statement_timeout`, so a slow query is killed by the database (releasing its
+ * pooled connection) instead of hanging up to the socket timeout and starving
+ * concurrent drivers. `SET LOCAL` is scoped to the transaction, which is safe
+ * under pgbouncer transaction-mode pooling.
+ *
+ * Placeholders use Postgres `$1, $2, …` exactly like the previous `pg` calls, so
+ * call sites only change `pool.query(sql, [a, b]).rows` → `rawQuery(sql, [a, b])`.
+ */
+
+/** Default per-statement timeout (ms) for tracking DB work. */
+export const TRACKING_STATEMENT_TIMEOUT_MS = 8000;
+
+/** An error carrying an HTTP status + JSON body, thrown from inside a tx so the
+ *  route can translate it into the right response (e.g. 403/404) after rollback. */
+export class DbHttpError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly body: Record<string, unknown>,
+  ) {
+    super(typeof body.error === "string" ? body.error : "db-http-error");
+    this.name = "DbHttpError";
+  }
+}
+
+/** Run `fn` in one transaction with a hard `statement_timeout`. */
+export async function withRawTx<T>(
+  fn: (tx: Prisma.TransactionClient) => Promise<T>,
+  timeoutMs: number = TRACKING_STATEMENT_TIMEOUT_MS,
+): Promise<T> {
+  const ms = Math.max(1000, Math.trunc(timeoutMs));
+  return prisma.$transaction(
+    async (tx) => {
+      await tx.$executeRawUnsafe(`SET LOCAL statement_timeout = ${ms}`);
+      return fn(tx);
+    },
+    { timeout: ms + 2000, maxWait: 4000 },
+  );
+}
+
+/** Parameterized read returning rows (statement-timeout bounded). */
+export function rawQuery<T = Record<string, unknown>>(
+  sql: string,
+  params: unknown[] = [],
+  timeoutMs?: number,
+): Promise<T[]> {
+  return withRawTx((tx) => tx.$queryRawUnsafe<T[]>(sql, ...params), timeoutMs);
+}
+
+/** Parameterized write with no result set (statement-timeout bounded). Returns
+ *  the affected row count. */
+export function rawExec(
+  sql: string,
+  params: unknown[] = [],
+  timeoutMs?: number,
+): Promise<number> {
+  return withRawTx((tx) => tx.$executeRawUnsafe(sql, ...params), timeoutMs);
+}


### PR DESCRIPTION
## What & why (Production readiness, part 1 of 3)

First of three PRs hardening the driver app for **20-30 concurrent drivers** (plan from the `/driver/history` 500 investigation).

`/api/tracking/{locations,drivers,test}` each created their own **unbounded `new (require('pg').Pool)()`** at module scope. In Vercel serverless that's a separate, uncapped pool per route/instance, all competing with Prisma for the ~20-slot Supabase pgbouncer pool. Under concurrent drivers (each POSTing location every few seconds) the pooler exhausts — which is what made the history Server Component intermittently **500**.

## Change

- New `src/lib/db/raw.ts`: `rawQuery` / `rawExec` / `withRawTx` over the tuned `@/lib/db/prisma-pooled` singleton. Every call runs in a transaction that sets a hard Postgres `statement_timeout` (default 8s), so a slow query is killed and its pooled connection released instead of hanging.
- All three tracking routes converted off `pg.Pool`. **No more competing connection pools.**
- The location write stays **atomic** (ownership check + insert + denormalized update in one transaction).
- **Abuse protection:** the location POST is now rate-limited per authenticated user via the existing Upstash-backed `enforceRateLimit` (multi-instance safe, falls open on backend error, keyed by auth id so it can't be bypassed via the body).

## Security preserved (#433)

Parameterized `ST_MakePoint` geometry, lat/lng range checks, `withAuth` gating, and driver self-scoping are kept verbatim, with their test assertions retained.

## Tests

Route suites updated to mock the raw helpers instead of `pg`. **251 tracking tests pass** (10 suites); typecheck + lint + token guardrail green.

## Notes

- BigInt gotcha handled: `COUNT(*)` cast to `::int` in the diagnostic route.
- The dev-only test route's perf-insert geometry was also parameterized (`ST_MakePoint`).

Part 2 = driver `error.tsx` + history `try/catch` (#436). Part 3 = count/list consistency (#437).

🤖 Generated with [Claude Code](https://claude.com/claude-code)