### PR TITLE
fix: driver route resilience — error boundary + graceful history fallback

### DIFF
--- a/src/app/(site)/(users)/driver/error.tsx
+++ b/src/app/(site)/(users)/driver/error.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect } from "react";
+import { AlertTriangle } from "lucide-react";
+import { DriverScreen, StateBlock, DriverButton } from "@/components/Driver/ui";
+
+/**
+ * Segment-level error boundary for the driver app.
+ *
+ * Without this, any thrown Server Component (e.g. the history page's DB lookup
+ * failing under connection-pool pressure) bubbles to the global 500 page — a
+ * jarring full-app error for a driver mid-shift. This keeps the driver chrome
+ * (theme, bottom nav, shift pill from the layout) and offers a one-tap retry.
+ */
+export default function DriverError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Driver route error:", error);
+  }, [error]);
+
+  return (
+    <DriverScreen title="Something went wrong">
+      <StateBlock
+        icon={AlertTriangle}
+        title="This screen hit a snag"
+        body="It's usually temporary. Give it another try in a moment."
+        action={
+          <DriverButton variant="brand" onClick={reset}>
+            Try again
+          </DriverButton>
+        }
+      />
+    </DriverScreen>
+  );
+}

--- a/src/app/(site)/(users)/driver/history/HistoryUnavailable.tsx
+++ b/src/app/(site)/(users)/driver/history/HistoryUnavailable.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { RefreshCcw, TriangleAlert } from "lucide-react";
+import { DriverScreen, StateBlock, DriverButton, Spinner } from "@/components/Driver/ui";
+
+/**
+ * Graceful fallback rendered by the history page when its server-side driver
+ * lookup fails (e.g. the DB is briefly unreachable / pool-starved). Keeps the
+ * driver chrome and lets the driver retry without a hard 500. `router.refresh()`
+ * re-runs the Server Component, so a transient DB hiccup recovers on tap.
+ */
+export default function HistoryUnavailable() {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <DriverScreen title="Your history" subtitle="View and export your deliveries">
+      <StateBlock
+        icon={TriangleAlert}
+        title="History is temporarily unavailable"
+        body="We couldn't load your deliveries just now. This is usually brief — try again in a moment."
+        action={
+          <DriverButton
+            variant="brand"
+            onClick={() => startTransition(() => router.refresh())}
+            disabled={isPending}
+          >
+            {isPending ? <Spinner size={16} /> : <RefreshCcw className="h-4 w-4" />}
+            Try again
+          </DriverButton>
+        }
+      />
+    </DriverScreen>
+  );
+}

--- a/src/app/(site)/(users)/driver/history/page.tsx
+++ b/src/app/(site)/(users)/driver/history/page.tsx
@@ -7,8 +7,9 @@
 
 import { redirect } from "next/navigation";
 import { createClient } from "@/utils/supabase/server";
-import { prisma } from "@/utils/prismaDB";
+import { prisma, withDatabaseRetry } from "@/utils/prismaDB";
 import HistoryClient from "./HistoryClient";
+import HistoryUnavailable from "./HistoryUnavailable";
 
 export default async function DriverHistoryPage() {
   // Check authentication
@@ -21,23 +22,36 @@ export default async function DriverHistoryPage() {
     redirect("/sign-in");
   }
 
-  // Find driver record for this user
-  const driver = await prisma.driver.findFirst({
-    where: {
-      profile: {
-        id: user.id,
-      },
-      deletedAt: null,
-    },
-    select: {
-      id: true,
-      profile: {
-        select: {
-          name: true,
-        },
-      },
-    },
-  });
+  // Find driver record for this user. This server-side DB call is what made the
+  // page 500 under connection-pool pressure — retry transient failures, then
+  // degrade gracefully (a retryable fallback) instead of throwing a hard 500.
+  let driver: { id: string; profile: { name: string | null } | null } | null;
+  try {
+    driver = await withDatabaseRetry(
+      () =>
+        prisma.driver.findFirst({
+          where: {
+            profile: {
+              id: user.id,
+            },
+            deletedAt: null,
+          },
+          select: {
+            id: true,
+            profile: {
+              select: {
+                name: true,
+              },
+            },
+          },
+        }),
+      2,
+      "driver-history-lookup",
+    );
+  } catch (error) {
+    console.error("Driver history lookup failed:", error);
+    return <HistoryUnavailable />;
+  }
 
   if (!driver) {
     // User is not a driver, redirect to home


### PR DESCRIPTION
## What & why (Production readiness, part 2 of 3)

Second of three PRs hardening the driver app for 20-30 concurrent drivers.

The driver segment had **no `error.tsx`**, so any thrown Server Component — notably the history page's server-side driver lookup failing under DB/connection-pool pressure — bubbled to the **global 500 page**, a full-app error for a driver mid-shift.

## Change

- **`driver/error.tsx`** — segment error boundary that keeps the driver chrome (theme, bottom nav, shift pill) and offers a one-tap **retry** via `reset()`. Catch-all for any driver-route render error.
- **`history/page.tsx`** — wrap the `prisma.driver.findFirst` lookup in `withDatabaseRetry` (retries transient connection errors) inside a `try/catch`; on failure render a retryable **`HistoryUnavailable`** fallback (`router.refresh()` re-runs the Server Component) instead of throwing a hard 500.

## Relationship to #435

#435 (pooling fix) removes most of the pressure that caused the history 500; this PR makes the page **degrade gracefully** when the DB still hiccups. Independent — either can merge first.

## Verification

Typecheck + lint green. Manual: load `/driver/history` (renders), then induce a DB failure (e.g. brief network blip / statement-timeout) → confirm the retryable "History is temporarily unavailable" fallback renders instead of a 500, and "Try again" recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)