### PR TITLE
fix: single-source the driver home deliveries count and list

### DIFF
--- a/src/app/(site)/(users)/driver/__tests__/page.test.tsx
+++ b/src/app/(site)/(users)/driver/__tests__/page.test.tsx
@@ -111,15 +111,39 @@ describe('DriverPage (redesigned home)', () => {
       mockTrackingState = {
         isShiftActive: true,
         currentShift: { startTime: '2024-06-15T13:30:00' },
-        activeDeliveries: [{ id: 'd1' }, { id: 'd2' }],
+        activeDeliveries: [],
       };
+      // The "N active" count now derives from /api/driver-deliveries — the same
+      // single source the deliveries list uses — not the tracking context.
+      global.fetch = jest.fn().mockImplementation((url: string) => {
+        if (url.includes('/api/profile')) {
+          return Promise.resolve(createMockApiResponse(mockProfileResponse));
+        }
+        if (url.includes('/api/tracking/drivers')) {
+          return Promise.resolve(createMockApiResponse(mockDriversResponse));
+        }
+        if (url.includes('/api/driver-deliveries')) {
+          return Promise.resolve(
+            createMockApiResponse({
+              deliveries: [
+                { id: 'd1', completeDateTime: null },
+                { id: 'd2', completeDateTime: null },
+              ],
+            }),
+          );
+        }
+        return Promise.resolve(createMockApiResponse({}));
+      });
+
       renderDriverHome();
 
       await waitFor(() => {
         expect(screen.getByText('On shift')).toBeInTheDocument();
       });
       expect(screen.getByText('Active shift')).toBeInTheDocument();
-      expect(screen.getByText('2 active')).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText('2 active')).toBeInTheDocument();
+      });
     });
   });
 

--- a/src/app/(site)/(users)/driver/page.tsx
+++ b/src/app/(site)/(users)/driver/page.tsx
@@ -22,11 +22,22 @@ import {
 import { DriverProfileSheet } from "@/components/Driver/ui/DriverProfileSheet";
 import { DriverStatsPanel } from "@/components/Driver/DriverStatsPanel";
 import { DriverDeliveryList } from "@/components/Driver/DriverDeliveryList";
+import { useDriverDeliveriesFeed } from "@/hooks/driver/useDriverDeliveriesFeed";
 
 export default function DriverHomePage() {
   const { logout } = useUser();
   const supabase = createClient();
-  const { isShiftActive, currentShift, activeDeliveries } = useDriverTracking();
+  const { isShiftActive, currentShift } = useDriverTracking();
+
+  // Single source for the deliveries list AND the "N active" count below, so
+  // they can never disagree (the prior bug). Polls + refreshes on focus.
+  const {
+    deliveries,
+    loading: deliveriesLoading,
+    error: deliveriesError,
+    refresh: refreshDeliveries,
+    activeCount,
+  } = useDriverDeliveriesFeed();
 
   const [mounted, setMounted] = useState(false);
   const [now, setNow] = useState(new Date());
@@ -81,7 +92,6 @@ export default function DriverHomePage() {
   const shiftSeconds = currentShift?.startTime
     ? Math.floor((now.getTime() - new Date(currentShift.startTime).getTime()) / 1000)
     : 0;
-  const activeCount = activeDeliveries?.length ?? 0;
 
   const handleSignOut = async () => {
     try {
@@ -188,7 +198,12 @@ export default function DriverHomePage() {
 
         {driverId ? <DriverStatsPanel driverId={driverId} /> : null}
 
-        <DriverDeliveryList />
+        <DriverDeliveryList
+          deliveries={deliveries}
+          loading={deliveriesLoading}
+          error={deliveriesError}
+          onRetry={refreshDeliveries}
+        />
       </div>
     </DriverScreen>
   );

--- a/src/components/Driver/DriverDeliveryList.tsx
+++ b/src/components/Driver/DriverDeliveryList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Inbox, TriangleAlert } from "lucide-react";
 import { encodeOrderNumber } from "@/utils/order/urlEncoding";
@@ -12,25 +12,7 @@ import {
   StateBlock,
   formatTime,
 } from "@/components/Driver/ui";
-
-/** Minimal shape we consume from /api/driver-deliveries (full shape lives in
- *  DriverDeliveries.tsx). Kept local + permissive to tolerate API drift. */
-interface ApiDelivery {
-  id: string;
-  orderNumber: string;
-  delivery_type: "catering" | "on_demand";
-  status: string;
-  driverStatus?: string | null;
-  pickupDateTime: string;
-  completeDateTime?: string | null;
-  order_total: string | number;
-  client_attention?: string | null;
-  address?: { street1?: string | null; city?: string | null } | null;
-  delivery_address?: { street1?: string | null; city?: string | null } | null;
-  headcount?: number | null;
-  itemDelivered?: string | null;
-  user?: { name?: string | null; email?: string | null } | null;
-}
+import type { ApiDelivery } from "@/hooks/driver/useDriverDeliveriesFeed";
 
 type Tab = "today" | "upcoming" | "completed";
 
@@ -67,48 +49,30 @@ function metaFor(d: ApiDelivery): string | undefined {
   return undefined;
 }
 
-/**
- * Redesigned driver deliveries list (Home). Reuses the existing
- * /api/driver-deliveries endpoint + Today/Upcoming/Completed categorization,
- * rendering DeliveryCards that open the Delivery Detail view. Status
- * advancement now lives on Detail / Live Tracking (the "one dominant action").
- */
-export function DriverDeliveryList() {
-  const router = useRouter();
-  const [deliveries, setDeliveries] = useState<ApiDelivery[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [tab, setTab] = useState<Tab>("today");
+interface DriverDeliveryListProps {
+  deliveries: ApiDelivery[];
+  loading: boolean;
+  error: string | null;
+  /** Re-fetch the shared feed (used by the error-state retry). */
+  onRetry: () => void;
+}
 
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const res = await fetch("/api/driver-deliveries?page=1&limit=999");
-        if (!res.ok) throw new Error("Failed to fetch deliveries");
-        const data = await res.json();
-        const list: ApiDelivery[] =
-          data && typeof data === "object" && "deliveries" in data
-            ? Array.isArray(data.deliveries)
-              ? data.deliveries
-              : []
-            : Array.isArray(data)
-              ? data
-              : [];
-        if (!cancelled) setDeliveries(list);
-      } catch (e) {
-        if (!cancelled)
-          setError(e instanceof Error ? e.message : "An error occurred");
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+/**
+ * Redesigned driver deliveries list (Home). Renders the shared delivery feed
+ * (from `useDriverDeliveriesFeed`, lifted to the Home page) into Today/Upcoming/
+ * Completed tabs as DeliveryCards that open the Delivery Detail view. Because the
+ * data is passed in from the same feed that drives the Home "N active" count,
+ * the count and the list are always consistent. Status advancement lives on
+ * Detail / Live Tracking (the "one dominant action").
+ */
+export function DriverDeliveryList({
+  deliveries,
+  loading,
+  error,
+  onRetry,
+}: DriverDeliveryListProps) {
+  const router = useRouter();
+  const [tab, setTab] = useState<Tab>("today");
 
   const filtered = useMemo(() => {
     const today = new Date();
@@ -146,7 +110,7 @@ export function DriverDeliveryList() {
           title="Couldn't load deliveries"
           body={error}
           action={
-            <DriverButton variant="outline" onClick={() => router.refresh()}>
+            <DriverButton variant="outline" onClick={onRetry}>
               Retry
             </DriverButton>
           }

--- a/src/hooks/driver/useDriverDeliveriesFeed.ts
+++ b/src/hooks/driver/useDriverDeliveriesFeed.ts
@@ -1,0 +1,98 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/** Minimal shape consumed from /api/driver-deliveries. Kept permissive to
+ *  tolerate API drift. */
+export interface ApiDelivery {
+  id: string;
+  orderNumber: string;
+  delivery_type: "catering" | "on_demand";
+  status: string;
+  driverStatus?: string | null;
+  pickupDateTime: string;
+  completeDateTime?: string | null;
+  order_total: string | number;
+  client_attention?: string | null;
+  address?: { street1?: string | null; city?: string | null } | null;
+  delivery_address?: { street1?: string | null; city?: string | null } | null;
+  headcount?: number | null;
+  itemDelivered?: string | null;
+  user?: { name?: string | null; email?: string | null } | null;
+}
+
+export interface DriverDeliveriesFeed {
+  deliveries: ApiDelivery[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+  /** Deliveries the driver still has to do (not completed). This is the count
+   *  the Home "N active" card shows — derived from the SAME list data, so the
+   *  count and the list can never disagree. */
+  activeCount: number;
+}
+
+function parseDeliveries(data: unknown): ApiDelivery[] {
+  if (data && typeof data === "object" && "deliveries" in data) {
+    const d = (data as { deliveries: unknown }).deliveries;
+    return Array.isArray(d) ? (d as ApiDelivery[]) : [];
+  }
+  return Array.isArray(data) ? (data as ApiDelivery[]) : [];
+}
+
+/**
+ * Single source of truth for the driver's delivery list on Home.
+ *
+ * Both the "My deliveries — N active" card and the DriverDeliveryList read from
+ * this one fetch, so the count and the rendered list are always consistent. It
+ * also polls (60s) and refreshes on tab focus, fixing the prior bug where the
+ * list fetched once on mount and went stale (showing an empty list while the
+ * count, from a different polling source, claimed deliveries existed).
+ */
+export function useDriverDeliveriesFeed(): DriverDeliveriesFeed {
+  const [deliveries, setDeliveries] = useState<ApiDelivery[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const inFlight = useRef(false);
+
+  const load = useCallback(async () => {
+    if (inFlight.current) return;
+    inFlight.current = true;
+    setError(null);
+    try {
+      const res = await fetch("/api/driver-deliveries?page=1&limit=999");
+      if (!res.ok) throw new Error("Failed to fetch deliveries");
+      const data = await res.json();
+      setDeliveries(parseDeliveries(data));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "An error occurred");
+    } finally {
+      setLoading(false);
+      inFlight.current = false;
+    }
+  }, []);
+
+  // Initial load.
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // Poll every 60s.
+  useEffect(() => {
+    const id = setInterval(() => void load(), 60_000);
+    return () => clearInterval(id);
+  }, [load]);
+
+  // Refresh when the tab regains focus (a driver coming back to the app).
+  useEffect(() => {
+    const onVisible = () => {
+      if (!document.hidden) void load();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [load]);
+
+  const activeCount = deliveries.filter((d) => !d.completeDateTime).length;
+
+  return { deliveries, loading, error, refresh: load, activeCount };
+}


### PR DESCRIPTION
## What & why (Production readiness, part 3 of 3)

Fixes the QA-reported inconsistency where the Home **"My deliveries — N active"** card showed a count (e.g. "2 active") while every list tab rendered **empty**.

**Root cause:** two different backends. The count read `useDriverTracking().activeDeliveries` (one source, polling); the `DriverDeliveryList` fetched `/api/driver-deliveries` (a different source) **once on mount and never refreshed**. They could disagree, and the list went stale as soon as assignments changed.

## Change

- New **`useDriverDeliveriesFeed`** — one fetch of `/api/driver-deliveries` that **polls (60s) and refreshes on tab focus**.
- The Home page derives the **"N active" count** from this feed **and** passes the same data into `DriverDeliveryList`. Count and list now come from one source — they can't disagree, and the list self-refreshes.
- `DriverDeliveryList` is now presentational (data via props).

## Tests

Updated the home-page test so the active count is driven by `/api/driver-deliveries` (the new single source). **10 home-page tests pass**; typecheck + lint green.

## Note on the location rate-limit

The plan paired this with rate-limiting the location POST. That endpoint lives in the route **#435 rewrote**, so the rate-limit is added on **that** branch to avoid a merge conflict — keeping each PR's files non-overlapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)