### PR TITLE
chore: sync development into main (2026-06-12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Driver "Access denied" on own deliveries**: ownership checks now accept either auth-link column (`profile_id` or legacy `user_id`) via the new `src/lib/auth/driver-ownership.ts` module — drivers whose row only carries `profile_id` (most of them) no longer get 403s on every tracking write
+- Driver tracking portal surfaces failed delivery status updates with an error toast instead of silently doing nothing; the proof-of-delivery sheet stays open on failure so the capture can be retried
+- Error banners in the driver portal no longer mask each other (all active location/shift/delivery errors render, keyed by source)
+- Backfill migration syncs the `drivers.user_id` / `profile_id` auth-link columns both ways (guarded by FK existence checks, idempotent)
+- Stale orders PATCH test assertions left behind by the earlier IDOR-hardening pass
+
+### Security
+- Driver tracking server actions (`delivery-actions.ts`, `driver-actions.ts`) now authenticate the caller and enforce owner-or-admin on every read/write; `createDelivery` / `assignDeliveryToDriver` are admin-only
+- `updateDeliveryStatus` validates the status value server-side (enum) and only increments the shift `delivery_count` on a genuine transition into COMPLETED (no replay inflation)
+- `updateDriverLocation` checks ownership before recording the rate limit, so a non-owner can no longer burn a victim driver's ping budget
+- Delivery ownership lookups filter soft-deleted rows; `GET /api/tracking/drivers` driver-scoping matches both auth-link columns
+
 ## [2.1.0] - 2026-05-13
 
 Periodic dev → main sync ([PR #402](https://github.com/ReadySet1/ready-set/pull/402)). 89 commits / ~25 PRs since the previous release window. First versioned release after baseline rebase — anchors retroactively to merge commit `c3803ac9`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,8 @@ pnpm studio                 # Open Prisma Studio
 
 **Stack**: Next.js 15 (App Router), PostgreSQL, Prisma 6, Supabase Auth, TanStack Query, Shadcn UI
 
+Full architecture deep-dive (domain models, data flows, authz, realtime): [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+
 ### Directory Structure
 
 ```
@@ -78,6 +80,7 @@ src/
 - `src/lib/auth/token-refresh-service.ts` - Automatic background refresh
 - `src/utils/supabase/client.ts` - Browser client (singleton)
 - `src/utils/supabase/server.ts` - Server-side client (SSR-safe)
+- `src/lib/auth/driver-ownership.ts` - Driver ↔ auth-user linkage. The `drivers` table has two auth-link columns (`profile_id` canonical, `user_id` legacy); ownership checks must accept either. **All driver-ownership decisions belong in this module** — never inline `user_id = $n` / `profile_id = $n` checks in routes or actions.
 
 **Database**: PostgreSQL with Prisma
 - Schema: `prisma/schema.prisma`
@@ -106,6 +109,7 @@ API Route → Server Action → Service Layer → Utils → Prisma
 - Routes: `/admin/*`, `/driver/*`, `/client/*`, `/helpdesk/*`
 - Config: `src/middleware/routeProtection.ts`
 - **Middleware does NOT run for `/api/*`** — each API route must handle its own auth via `withAuth({ allowedRoles })` from `src/lib/auth-middleware.ts`.
+- **Server actions are plain POST endpoints** — nothing upstream authenticates them. Actions that touch driver data must resolve the caller themselves via `getActionCaller()` / `callerMayActOnDriver()` from `src/lib/auth/driver-ownership.ts` (admin-only for `createDelivery` / `assignDeliveryToDriver`, owner-or-admin for the rest).
 
 **Debug / test routes**: if you add a route under `src/app/api/debug/`, `src/app/api/test-*`, `src/app/api/test/`, or any page that exists only for engineering (e.g. SSR-error pages), it MUST be gated by `devOnlyGuard()` from `src/lib/auth/dev-only-guard.ts` (returns 404 in production) AND by `withAuth({ allowedRoles: ['SUPER_ADMIN'], requireAuth: true })`. See `docs/architecture/REMEDIATION_PLAN.md` → Appendix A for the gating pattern.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -163,6 +163,8 @@ mobile app  →  POST /api/tracking/locations
 
 Source: `src/app/api/tracking/locations/route.ts`. The simulator at `/admin/tracking/test-driver` posts to the same endpoint.
 
+**Driver ownership / authz:** the `drivers` table carries two auth-link columns in one id space — `profile_id` (canonical, FK to `profiles.id`) and `user_id` (legacy, NULL on most rows). Every ownership check must accept either column; checking `user_id` alone 403s most real drivers. `src/lib/auth/driver-ownership.ts` is the single home for these checks (`driverOwnershipCondition()` for raw-SQL embedding, `userOwnsDriver()`, `getDriverForUser()`, `callerMayActOnDriver()`) — never inline `user_id = $n` in a route. Tracking **server actions** (`src/app/actions/tracking/*`) authenticate their own caller via `getActionCaller()`: `createDelivery` / `assignDeliveryToDriver` are admin-only; all other reads/writes are owner-or-admin. A guarded, idempotent migration (`prisma/migrations/20260611000000_backfill_driver_user_id`) syncs the two columns both ways until `user_id` can be dropped.
+
 **State machine:** order/driver state transitions live in `src/lib/state-machine/`:
 
 - `driver-state.ts` — valid `DriverStatus` transitions.

--- a/prisma/migrations/20260611000000_backfill_driver_user_id/migration.sql
+++ b/prisma/migrations/20260611000000_backfill_driver_user_id/migration.sql
@@ -1,0 +1,25 @@
+-- drivers carries two auth-user link columns in the same id space
+-- (profiles.id === auth.users.id):
+--   profile_id — canonical: unique, FK -> profiles(id)
+--   user_id    — legacy:    FK -> auth.users(id), NULL on most rows
+-- Ownership checks accept either column (src/lib/auth/driver-ownership.ts);
+-- this backfill brings existing rows in sync so the legacy column stops
+-- diverging. Both fills are guarded by their FK targets (a profile can exist
+-- without an auth.users row, e.g. seeded test drivers). Idempotent.
+
+-- Forward fill: the common case — rows created with only profile_id.
+UPDATE drivers d
+SET user_id = d.profile_id
+WHERE d.user_id IS NULL
+  AND d.profile_id IS NOT NULL
+  AND EXISTS (SELECT 1 FROM auth.users u WHERE u.id = d.profile_id);
+
+-- Reverse fill: rows created with only user_id. Guarded so we only adopt a
+-- user_id that actually references a profile and doesn't collide with the
+-- unique constraint on profile_id.
+UPDATE drivers d
+SET profile_id = d.user_id
+WHERE d.profile_id IS NULL
+  AND d.user_id IS NOT NULL
+  AND EXISTS (SELECT 1 FROM profiles p WHERE p.id = d.user_id)
+  AND NOT EXISTS (SELECT 1 FROM drivers d2 WHERE d2.profile_id = d.user_id);

--- a/src/__tests__/actions/tracking/driver-actions.test.ts
+++ b/src/__tests__/actions/tracking/driver-actions.test.ts
@@ -22,6 +22,15 @@ jest.mock('next/cache', () => ({
   revalidatePath: jest.fn(),
 }));
 
+// Mock the ownership/auth helper — these unit tests target the actions' own
+// logic. beforeEach re-primes the caller as the owning driver (resetAllMocks
+// wipes implementations); the AuthZ block overrides per-test.
+jest.mock('@/lib/auth/driver-ownership', () => ({
+  callerMayActOnDriver: jest.fn(),
+  getActionCaller: jest.fn(),
+  userOwnsDriver: jest.fn(),
+}));
+
 // Mock rate limiter
 jest.mock('@/lib/rate-limiting/location-rate-limiter', () => ({
   locationRateLimiter: {
@@ -73,8 +82,14 @@ jest.mock('@/services/tracking/mileage', () => ({
 import { prisma } from '@/utils/prismaDB';
 import { locationRateLimiter } from '@/lib/rate-limiting/location-rate-limiter';
 import { revalidatePath } from 'next/cache';
+import {
+  callerMayActOnDriver,
+  getActionCaller,
+} from '@/lib/auth/driver-ownership';
 
 const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+const mockCallerMayActOnDriver = callerMayActOnDriver as jest.Mock;
+const mockGetActionCaller = getActionCaller as jest.Mock;
 
 describe('Driver Tracking Actions', () => {
   const validDriverId = '550e8400-e29b-41d4-a716-446655440000';
@@ -99,6 +114,9 @@ describe('Driver Tracking Actions', () => {
     jest.resetAllMocks();
     // Default rate limiter to allow requests
     (locationRateLimiter.checkAndRecordLimit as jest.Mock).mockReturnValue({ allowed: true });
+    // Default caller: the owning driver (authorized)
+    mockCallerMayActOnDriver.mockResolvedValue(true);
+    mockGetActionCaller.mockResolvedValue({ userId: 'driver-user-1', isPrivileged: false });
   });
 
   describe('startDriverShift', () => {
@@ -629,6 +647,59 @@ describe('Driver Tracking Actions', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('Failed to start shift');
+    });
+  });
+
+  describe('AuthZ (IDOR guards)', () => {
+    beforeEach(() => {
+      // A caller who does NOT own the target driver and is not an admin.
+      mockCallerMayActOnDriver.mockResolvedValue(false);
+      mockGetActionCaller.mockResolvedValue({ userId: 'attacker', isPrivileged: false });
+    });
+
+    it('denies starting a shift for a foreign driver', async () => {
+      const result = await startDriverShift(validDriverId, mockLocationUpdate);
+      expect(result).toEqual({ success: false, error: 'Access denied' });
+      expect(mockPrisma.$executeRawUnsafe).not.toHaveBeenCalled();
+    });
+
+    it('denies ending a foreign driver shift', async () => {
+      (mockPrisma.$queryRawUnsafe as jest.Mock).mockResolvedValueOnce([
+        { driver_id: 'driver-victim', status: 'active' },
+      ]);
+      const result = await endDriverShift(validShiftId, mockLocationUpdate);
+      expect(result).toEqual({ success: false, error: 'Access denied' });
+      expect(mockPrisma.$executeRawUnsafe).not.toHaveBeenCalled();
+    });
+
+    it('denies pausing a foreign driver shift', async () => {
+      (mockPrisma.$queryRawUnsafe as jest.Mock).mockResolvedValueOnce([
+        { id: validShiftId, driver_id: 'driver-victim' },
+      ]);
+      const result = await startShiftBreak(validShiftId);
+      expect(result).toEqual({ success: false, error: 'Access denied' });
+      expect(mockPrisma.$executeRawUnsafe).not.toHaveBeenCalled();
+    });
+
+    it('denies resuming a foreign driver break', async () => {
+      (mockPrisma.$queryRawUnsafe as jest.Mock).mockResolvedValueOnce([
+        { id: validBreakId, status: 'paused', driver_id: 'driver-victim' },
+      ]);
+      const result = await endShiftBreak(validBreakId);
+      expect(result).toEqual({ success: false, error: 'Access denied' });
+      expect(mockPrisma.$executeRawUnsafe).not.toHaveBeenCalled();
+    });
+
+    it('denies writing a foreign driver location', async () => {
+      const result = await updateDriverLocation(validDriverId, mockLocationUpdate);
+      expect(result).toEqual({ success: false, error: 'Access denied' });
+      expect(mockPrisma.$executeRawUnsafe).not.toHaveBeenCalled();
+    });
+
+    it('scopes shift reads to the owning driver', async () => {
+      expect(await getActiveShift(validDriverId)).toBeNull();
+      expect(await getDriverShiftHistory(validDriverId)).toEqual([]);
+      expect(mockPrisma.$queryRawUnsafe).not.toHaveBeenCalled();
     });
   });
 

--- a/src/__tests__/api/orders/edit-order.test.ts
+++ b/src/__tests__/api/orders/edit-order.test.ts
@@ -14,6 +14,20 @@ import {
 // Mock dependencies BEFORE imports
 jest.mock('@/utils/supabase/server', () => ({
   createClient: jest.fn(),
+  // Used by the fire-and-forget realtime broadcast on driver-status updates
+  createAdminClient: jest.fn(async () => {
+    const channel = {
+      subscribe: (cb: (status: string) => void) => {
+        cb('SUBSCRIBED');
+        return channel;
+      },
+      send: async () => 'ok',
+    };
+    return {
+      channel: () => channel,
+      removeChannel: async () => undefined,
+    };
+  }),
 }));
 
 jest.mock('@/utils/prismaDB', () => ({
@@ -29,6 +43,13 @@ jest.mock('@/utils/prismaDB', () => ({
     address: {
       create: jest.fn(),
       update: jest.fn(),
+    },
+    delivery: {
+      findFirst: jest.fn(),
+      upsert: jest.fn(),
+    },
+    driver: {
+      findFirst: jest.fn(),
     },
   },
 }));
@@ -644,9 +665,8 @@ describe('/api/orders/[order_number] PATCH API - Edit Order', () => {
     });
   });
 
-  describe('📊 Status-Only Updates (Legacy Behavior)', () => {
-    it('should allow status updates without role check (driver updates)', async () => {
-      // Drivers can update status but not other fields
+  describe('📊 Driver Status Updates (IDOR protection)', () => {
+    const setupAuthenticatedDriver = () => {
       mockCreateClient.mockResolvedValue({
         auth: {
           getUser: jest.fn().mockResolvedValue({
@@ -665,14 +685,34 @@ describe('/api/orders/[order_number] PATCH API - Edit Order', () => {
           }),
         }),
       });
+    };
 
+    it('should allow the assigned driver to update driverStatus without admin role', async () => {
+      setupAuthenticatedDriver();
+
+      // The caller's auth user id matches the dispatch driver's profile id
       const mockOrder = createMockCateringOrder({
         orderNumber: 'CAT001',
         status: 'ASSIGNED',
         driverStatus: 'ASSIGNED',
+        dispatches: [
+          {
+            id: 'dispatch-1',
+            driver: {
+              id: 'driver-id',
+              name: 'Test Driver',
+              email: 'driver@example.com',
+              contactNumber: '555-0100',
+            },
+          },
+        ],
       });
       mockCateringFindFirst.mockResolvedValue(mockOrder);
-      mockCateringUpdate.mockResolvedValue({ ...mockOrder, driverStatus: 'EN_ROUTE_TO_VENDOR' });
+      mockCateringUpdate.mockResolvedValue({
+        ...mockOrder,
+        driverStatus: 'EN_ROUTE_TO_VENDOR',
+        status: 'IN_PROGRESS',
+      });
 
       const request = createPatchRequest(
         'http://localhost:3000/api/orders/CAT001',
@@ -682,6 +722,31 @@ describe('/api/orders/[order_number] PATCH API - Edit Order', () => {
       const response = await PATCH(request, createMockParams('CAT001'));
 
       expect(response.status).toBe(200);
+    });
+
+    it('should return 403 when a driver is not assigned to the order', async () => {
+      setupAuthenticatedDriver();
+
+      // No dispatches — the caller is not the assigned driver, so the
+      // IDOR guard added in the driver-tracking hardening must reject this.
+      const mockOrder = createMockCateringOrder({
+        orderNumber: 'CAT001',
+        status: 'ASSIGNED',
+        driverStatus: 'ASSIGNED',
+      });
+      mockCateringFindFirst.mockResolvedValue(mockOrder);
+
+      const request = createPatchRequest(
+        'http://localhost:3000/api/orders/CAT001',
+        { driverStatus: 'EN_ROUTE_TO_VENDOR' }
+      );
+
+      const response = await PATCH(request, createMockParams('CAT001'));
+      const data = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(data.message).toBe('You are not assigned to this delivery');
+      expect(mockCateringUpdate).not.toHaveBeenCalled();
     });
   });
 

--- a/src/__tests__/api/orders/order-by-number.test.ts
+++ b/src/__tests__/api/orders/order-by-number.test.ts
@@ -22,11 +22,36 @@ jest.mock('@/utils/prismaDB', () => ({
       findFirst: jest.fn(),
       update: jest.fn(),
     },
+    delivery: {
+      findFirst: jest.fn(),
+      upsert: jest.fn(),
+    },
+    driver: {
+      findFirst: jest.fn(),
+    },
   },
 }));
 
 jest.mock('@/utils/supabase/server', () => ({
   createClient: jest.fn(),
+  // Used by the fire-and-forget realtime broadcast on driver-status updates
+  createAdminClient: jest.fn(async () => {
+    const channel = {
+      subscribe: (cb: (status: string) => void) => {
+        cb('SUBSCRIBED');
+        return channel;
+      },
+      send: async () => 'ok',
+    };
+    return {
+      channel: () => channel,
+      removeChannel: async () => undefined,
+    };
+  }),
+}));
+
+jest.mock('@/services/notifications/delivery-status', () => ({
+  sendDispatchStatusNotification: jest.fn().mockResolvedValue(undefined),
 }));
 
 describe('/api/orders/[order_number] - Get and Update Order', () => {
@@ -34,6 +59,22 @@ describe('/api/orders/[order_number] - Get and Update Order', () => {
     auth: {
       getUser: jest.fn(),
     },
+    from: jest.fn(),
+  };
+
+  // Configures the `profiles` lookup the PATCH route performs for
+  // driver-status updates and full field edits.
+  const mockProfileType = (type: string) => {
+    mockSupabaseClient.from.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: { type },
+            error: null,
+          }),
+        }),
+      }),
+    });
   };
 
   beforeEach(() => {
@@ -288,6 +329,9 @@ describe('/api/orders/[order_number] - Get and Update Order', () => {
         mockSupabaseClient.auth.getUser.mockResolvedValue({
           data: { user: { id: 'user-123' } },
         });
+        // Driver-status updates require the caller to be the assigned driver
+        // (dispatch driver profile id === auth user id) unless privileged.
+        mockProfileType('DRIVER');
 
         // No catering order found
         (prisma.cateringRequest.findFirst as jest.Mock).mockResolvedValue(null);
@@ -300,7 +344,17 @@ describe('/api/orders/[order_number] - Get and Update Order', () => {
           user: { name: 'Jane Smith', email: 'jane@example.com' },
           pickupAddress: {},
           deliveryAddress: { state: 'TX' },
-          dispatches: [],
+          dispatches: [
+            {
+              id: 'dispatch-1',
+              driver: {
+                id: 'user-123',
+                name: 'Jane Driver',
+                email: 'driver@example.com',
+                contactNumber: '555-0100',
+              },
+            },
+          ],
           fileUploads: [],
           createdAt: new Date(),
           updatedAt: new Date(),
@@ -331,6 +385,8 @@ describe('/api/orders/[order_number] - Get and Update Order', () => {
         mockSupabaseClient.auth.getUser.mockResolvedValue({
           data: { user: { id: 'user-123' } },
         });
+        // Caller is the driver assigned to this order via Dispatch
+        mockProfileType('DRIVER');
 
         const mockExistingOrder = {
           id: 'order-1',
@@ -340,7 +396,17 @@ describe('/api/orders/[order_number] - Get and Update Order', () => {
           user: { name: 'John Doe', email: 'john@example.com' },
           pickupAddress: {},
           deliveryAddress: { state: 'CA' },
-          dispatches: [],
+          dispatches: [
+            {
+              id: 'dispatch-1',
+              driver: {
+                id: 'user-123',
+                name: 'John Driver',
+                email: 'driver@example.com',
+                contactNumber: '555-0100',
+              },
+            },
+          ],
           fileUploads: [],
           createdAt: new Date(),
           updatedAt: new Date(),

--- a/src/__tests__/api/tracking/delivery-status-transitions.test.ts
+++ b/src/__tests__/api/tracking/delivery-status-transitions.test.ts
@@ -50,19 +50,23 @@ describe('Delivery Status Transitions', () => {
     });
   };
 
-  // Helper to mock delivery lookup
+  // Helper to mock delivery lookup. The route now verifies ownership with a
+  // separate drivers query (profile_id OR user_id linkage), so answer both.
   const mockDeliveryLookup = (
     status: string,
     driverId: string = 'driver-1',
-    userId: string = 'driver-user-1'
+    _userId: string = 'driver-user-1'
   ) => {
-    (prisma.$queryRawUnsafe as jest.Mock).mockResolvedValueOnce([
-      {
-        driver_id: driverId,
-        status,
-        user_id: userId,
-      },
-    ]);
+    (prisma.$queryRawUnsafe as jest.Mock).mockImplementation((sql: string) => {
+      if (sql.includes('FROM deliveries')) {
+        return Promise.resolve([{ driver_id: driverId, status }]);
+      }
+      if (sql.includes('FROM drivers')) {
+        // Ownership lookup: the calling driver owns this delivery.
+        return Promise.resolve([{ id: driverId }]);
+      }
+      return Promise.resolve([]);
+    });
   };
 
   describe('Status Transition State Machine', () => {
@@ -422,7 +426,13 @@ describe('Delivery Status Transitions', () => {
 
       it('should deny driver updating another driver delivery', async () => {
         setupDriverAuth('driver-user-2');
-        mockDeliveryLookup('ASSIGNED', 'driver-1', 'driver-user-1');
+        (prisma.$queryRawUnsafe as jest.Mock).mockImplementation((sql: string) => {
+          if (sql.includes('FROM deliveries')) {
+            return Promise.resolve([{ driver_id: 'driver-1', status: 'ASSIGNED' }]);
+          }
+          // Ownership lookup: driver-1 is not linked to driver-user-2.
+          return Promise.resolve([]);
+        });
 
         const request = createPutRequest(
           'http://localhost:3000/api/tracking/deliveries/delivery-1',

--- a/src/__tests__/api/tracking/drivers.test.ts
+++ b/src/__tests__/api/tracking/drivers.test.ts
@@ -141,6 +141,30 @@ describe('/api/tracking/drivers', () => {
       expect(data.pagination.limit).toBe(1);
     });
 
+    it('scopes a DRIVER caller to their own row via both auth-link columns', async () => {
+      mockWithAuth.mockResolvedValue({
+        success: true,
+        context: { user: { id: 'driver-user-9', type: 'DRIVER' } },
+      });
+      mockRawQuery.mockResolvedValue([]);
+
+      const request = new NextRequest('http://localhost:3000/api/tracking/drivers');
+      const response = await GET(request);
+      expect(response.status).toBe(200);
+
+      const selectCall = mockRawQuery.mock.calls.find(
+        ([sql]: [string]) => typeof sql === 'string' && sql.includes('FROM drivers')
+      );
+      expect(selectCall).toBeDefined();
+      // Ownership must check BOTH auth-link columns (profile_id is canonical,
+      // user_id is the legacy duplicate — see src/lib/auth/driver-ownership.ts).
+      // A user_id-only condition returns nothing for most real drivers.
+      expect(selectCall?.[0]).toContain('profile_id = $1');
+      expect(selectCall?.[0]).toContain('user_id = $1');
+      // The auth user id is bound to that placeholder.
+      expect(selectCall?.[1]?.[0]).toBe('driver-user-9');
+    });
+
     it('falls back to the default limit for an invalid limit parameter', async () => {
       mockRawQuery.mockResolvedValue([]);
       const request = new NextRequest('http://localhost:3000/api/tracking/drivers?limit=invalid');
@@ -189,7 +213,7 @@ describe('/api/tracking/drivers', () => {
     });
 
     it('stores user_id in sync with profile_id when only profile_id is given', async () => {
-      mockQuery.mockResolvedValue({ rows: [{ id: 'driver-9' }] });
+      mockRawQuery.mockResolvedValue([{ id: 'driver-9' }]);
 
       const request = new NextRequest('http://localhost:3000/api/tracking/drivers', {
         method: 'POST',
@@ -199,7 +223,7 @@ describe('/api/tracking/drivers', () => {
       const response = await POST(request);
       expect(response.status).toBe(201);
 
-      const insertCall = mockQuery.mock.calls.find(
+      const insertCall = mockRawQuery.mock.calls.find(
         ([sql]: [string]) => typeof sql === 'string' && sql.includes('INSERT INTO drivers')
       );
       // user_id ($1) and profile_id ($2) must never diverge at creation.
@@ -207,7 +231,7 @@ describe('/api/tracking/drivers', () => {
     });
 
     it('stores profile_id in sync with user_id when only user_id is given', async () => {
-      mockQuery.mockResolvedValue({ rows: [{ id: 'driver-9' }] });
+      mockRawQuery.mockResolvedValue([{ id: 'driver-9' }]);
 
       const request = new NextRequest('http://localhost:3000/api/tracking/drivers', {
         method: 'POST',
@@ -217,7 +241,7 @@ describe('/api/tracking/drivers', () => {
       const response = await POST(request);
       expect(response.status).toBe(201);
 
-      const insertCall = mockQuery.mock.calls.find(
+      const insertCall = mockRawQuery.mock.calls.find(
         ([sql]: [string]) => typeof sql === 'string' && sql.includes('INSERT INTO drivers')
       );
       expect(insertCall?.[1]?.slice(0, 2)).toEqual(['user-9', 'user-9']);

--- a/src/__tests__/api/tracking/drivers.test.ts
+++ b/src/__tests__/api/tracking/drivers.test.ts
@@ -235,6 +235,41 @@ describe('/api/tracking/drivers', () => {
       expect(data.data.employee_id).toBe('EMP003');
     });
 
+    it('stores user_id in sync with profile_id when only profile_id is given', async () => {
+      mockQuery.mockResolvedValue({ rows: [{ id: 'driver-9' }] });
+
+      const request = new NextRequest('http://localhost:3000/api/tracking/drivers', {
+        method: 'POST',
+        body: JSON.stringify({ profile_id: 'profile-9' }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(201);
+
+      const insertCall = mockQuery.mock.calls.find(
+        ([sql]: [string]) => typeof sql === 'string' && sql.includes('INSERT INTO drivers')
+      );
+      // user_id ($1) and profile_id ($2) must never diverge at creation.
+      expect(insertCall?.[1]?.slice(0, 2)).toEqual(['profile-9', 'profile-9']);
+    });
+
+    it('stores profile_id in sync with user_id when only user_id is given', async () => {
+      mockQuery.mockResolvedValue({ rows: [{ id: 'driver-9' }] });
+
+      const request = new NextRequest('http://localhost:3000/api/tracking/drivers', {
+        method: 'POST',
+        body: JSON.stringify({ user_id: 'user-9' }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(201);
+
+      const insertCall = mockQuery.mock.calls.find(
+        ([sql]: [string]) => typeof sql === 'string' && sql.includes('INSERT INTO drivers')
+      );
+      expect(insertCall?.[1]?.slice(0, 2)).toEqual(['user-9', 'user-9']);
+    });
+
     it('returns 400 when no identifier is provided', async () => {
       const invalidDriver = {
         vehicle_number: 'V003',

--- a/src/__tests__/api/tracking/shifts.test.ts
+++ b/src/__tests__/api/tracking/shifts.test.ts
@@ -178,9 +178,14 @@ describe('/api/tracking/shifts API', () => {
           },
         ];
 
-        (prisma.$queryRawUnsafe as jest.Mock)
-          .mockResolvedValueOnce(mockShifts)
-          .mockResolvedValueOnce([]);
+        (prisma.$queryRawUnsafe as jest.Mock).mockImplementation((sql: string) => {
+          if (sql.includes('FROM shift_breaks')) return Promise.resolve([]);
+          if (sql.includes('FROM driver_shifts')) return Promise.resolve(mockShifts);
+          // Driver row resolution (profile_id OR user_id linkage)
+          return Promise.resolve([
+            { id: 'driver-1', is_active: true, current_shift_id: 'shift-1' },
+          ]);
+        });
 
         const request = createGetRequest(
           'http://localhost:3000/api/tracking/shifts'
@@ -190,9 +195,10 @@ describe('/api/tracking/shifts API', () => {
         const data = await expectSuccessResponse(response, 200);
 
         expect(data.data[0].driverInfo).toBeUndefined(); // Drivers shouldn't see driverInfo
+        // Scoped to the resolved driver id, not a user_id subquery
         expect(prisma.$queryRawUnsafe).toHaveBeenCalledWith(
-          expect.stringContaining('ds.driver_id = (SELECT id FROM drivers WHERE user_id = $'),
-          'driver-user-123',
+          expect.stringContaining('ds.driver_id = $'),
+          'driver-1',
           50,
           0
         );
@@ -347,7 +353,7 @@ describe('/api/tracking/shifts API', () => {
         });
 
         (prisma.$queryRawUnsafe as jest.Mock)
-          .mockResolvedValueOnce([{ id: 'driver-1', current_shift_id: null }]) // Get driver
+          .mockResolvedValueOnce([{ id: 'driver-1', is_active: true, current_shift_id: null }]) // Get driver
           .mockResolvedValueOnce([{ id: 'shift-new-1' }]); // Create shift
 
         (prisma.$executeRawUnsafe as jest.Mock).mockResolvedValue(1);
@@ -381,7 +387,7 @@ describe('/api/tracking/shifts API', () => {
         });
 
         (prisma.$queryRawUnsafe as jest.Mock)
-          .mockResolvedValueOnce([{ id: 'driver-1', current_shift_id: null }])
+          .mockResolvedValueOnce([{ id: 'driver-1', is_active: true, current_shift_id: null }])
           .mockResolvedValueOnce([{ id: 'shift-new-2' }]);
 
         (prisma.$executeRawUnsafe as jest.Mock).mockResolvedValue(1);
@@ -480,7 +486,7 @@ describe('/api/tracking/shifts API', () => {
         });
 
         (prisma.$queryRawUnsafe as jest.Mock).mockResolvedValueOnce([
-          { id: 'driver-1', current_shift_id: 'existing-shift' },
+          { id: 'driver-1', is_active: true, current_shift_id: 'existing-shift' },
         ]);
 
         const request = createPostRequest(
@@ -623,9 +629,12 @@ describe('/api/tracking/shifts API', () => {
           vehicle_number: null,
         };
 
-        (prisma.$queryRawUnsafe as jest.Mock)
-          .mockResolvedValueOnce([mockShift])
-          .mockResolvedValueOnce([]);
+        (prisma.$queryRawUnsafe as jest.Mock).mockImplementation((sql: string) => {
+          if (sql.includes('FROM shift_breaks')) return Promise.resolve([]);
+          if (sql.includes('FROM driver_shifts')) return Promise.resolve([mockShift]);
+          // Ownership lookup: driver-1 belongs to driver-user-123
+          return Promise.resolve([{ id: 'driver-1' }]);
+        });
 
         const request = createGetRequest(
           'http://localhost:3000/api/tracking/shifts/shift-1'
@@ -673,13 +682,13 @@ describe('/api/tracking/shifts API', () => {
           },
         });
 
-        (prisma.$queryRawUnsafe as jest.Mock).mockResolvedValueOnce([
-          {
-            driver_id: 'driver-1',
-            status: 'active',
-            user_id: 'driver-user-123',
-          },
-        ]);
+        (prisma.$queryRawUnsafe as jest.Mock).mockImplementation((sql: string) => {
+          if (sql.includes('FROM driver_shifts')) {
+            return Promise.resolve([{ driver_id: 'driver-1', status: 'active' }]);
+          }
+          // Ownership lookup: driver-1 belongs to driver-user-123
+          return Promise.resolve([{ id: 'driver-1' }]);
+        });
 
         (prisma.$executeRawUnsafe as jest.Mock).mockResolvedValue(1);
 
@@ -710,13 +719,12 @@ describe('/api/tracking/shifts API', () => {
           },
         });
 
-        (prisma.$queryRawUnsafe as jest.Mock).mockResolvedValueOnce([
-          {
-            driver_id: 'driver-1',
-            status: 'paused',
-            user_id: 'driver-user-123',
-          },
-        ]);
+        (prisma.$queryRawUnsafe as jest.Mock).mockImplementation((sql: string) => {
+          if (sql.includes('FROM driver_shifts')) {
+            return Promise.resolve([{ driver_id: 'driver-1', status: 'paused' }]);
+          }
+          return Promise.resolve([{ id: 'driver-1' }]);
+        });
 
         (prisma.$executeRawUnsafe as jest.Mock).mockResolvedValue(1);
 
@@ -741,13 +749,12 @@ describe('/api/tracking/shifts API', () => {
           },
         });
 
-        (prisma.$queryRawUnsafe as jest.Mock).mockResolvedValueOnce([
-          {
-            driver_id: 'driver-1',
-            status: 'completed',
-            user_id: 'driver-user-123',
-          },
-        ]);
+        (prisma.$queryRawUnsafe as jest.Mock).mockImplementation((sql: string) => {
+          if (sql.includes('FROM driver_shifts')) {
+            return Promise.resolve([{ driver_id: 'driver-1', status: 'completed' }]);
+          }
+          return Promise.resolve([{ id: 'driver-1' }]);
+        });
 
         const request = createPutRequest(
           'http://localhost:3000/api/tracking/shifts/shift-1',
@@ -808,13 +815,13 @@ describe('/api/tracking/shifts API', () => {
           },
         });
 
-        (prisma.$queryRawUnsafe as jest.Mock).mockResolvedValueOnce([
-          {
-            driver_id: 'driver-1',
-            status: 'active',
-            user_id: 'different-driver-user', // Different user
-          },
-        ]);
+        (prisma.$queryRawUnsafe as jest.Mock).mockImplementation((sql: string) => {
+          if (sql.includes('FROM driver_shifts')) {
+            return Promise.resolve([{ driver_id: 'driver-1', status: 'active' }]);
+          }
+          // Ownership lookup: driver-1 is NOT linked to driver-user-123
+          return Promise.resolve([]);
+        });
 
         const request = createPutRequest(
           'http://localhost:3000/api/tracking/shifts/shift-1',

--- a/src/__tests__/api/tracking/shifts.test.ts
+++ b/src/__tests__/api/tracking/shifts.test.ts
@@ -649,6 +649,54 @@ describe('/api/tracking/shifts API', () => {
       });
     });
 
+    describe('Authorization Tests', () => {
+      it('should return 404 (not 403) when a driver fetches another drivers shift', async () => {
+        // Anti-oracle behavior: a non-owned shift must be indistinguishable
+        // from a non-existent one, so the route can't be used to probe ids.
+        (withAuth as jest.Mock).mockResolvedValue({
+          success: true,
+          context: {
+            user: { id: 'driver-user-123', type: 'DRIVER' },
+          },
+        });
+
+        const mockShift = {
+          id: 'shift-1',
+          driver_id: 'driver-other',
+          start_time: new Date(),
+          end_time: null,
+          start_location_geojson: JSON.stringify({
+            coordinates: [-97.7431, 30.2672],
+          }),
+          end_location_geojson: null,
+          total_distance_km: 0,
+          delivery_count: 0,
+          status: 'active',
+          metadata: {},
+          created_at: new Date(),
+          updated_at: new Date(),
+          employee_id: null,
+          vehicle_number: null,
+        };
+
+        (prisma.$queryRawUnsafe as jest.Mock).mockImplementation((sql: string) => {
+          if (sql.includes('FROM shift_breaks')) return Promise.resolve([]);
+          if (sql.includes('FROM driver_shifts')) return Promise.resolve([mockShift]);
+          // Ownership lookup: driver-other is NOT linked to driver-user-123
+          return Promise.resolve([]);
+        });
+
+        const request = createGetRequest(
+          'http://localhost:3000/api/tracking/shifts/shift-1'
+        );
+
+        const response = await GET_SHIFT(request, {
+          params: Promise.resolve({ id: 'shift-1' }),
+        });
+        await expectErrorResponse(response, 404, /shift not found/i);
+      });
+    });
+
     describe('Not Found', () => {
       it('should return 404 for non-existent shift', async () => {
         (withAuth as jest.Mock).mockResolvedValue({

--- a/src/__tests__/api/tracking/tracking-deliveries-id.test.ts
+++ b/src/__tests__/api/tracking/tracking-deliveries-id.test.ts
@@ -456,13 +456,13 @@ describe('/api/tracking/deliveries/[id] API', () => {
           },
         });
 
-        (prisma.$queryRawUnsafe as jest.Mock).mockResolvedValue([
-          {
-            driver_id: 'driver-1',
-            status: 'ASSIGNED',
-            user_id: 'driver-user-1',
-          },
-        ]);
+        (prisma.$queryRawUnsafe as jest.Mock).mockImplementation((sql: string) => {
+          if (sql.includes('FROM deliveries')) {
+            return Promise.resolve([{ driver_id: 'driver-1', status: 'ASSIGNED' }]);
+          }
+          // Ownership lookup: driver-1 is not linked to driver-user-2.
+          return Promise.resolve([]);
+        });
 
         const request = createPutRequest(
           'http://localhost:3000/api/tracking/deliveries/delivery-1',

--- a/src/app/actions/tracking/__tests__/delivery-actions.security.test.ts
+++ b/src/app/actions/tracking/__tests__/delivery-actions.security.test.ts
@@ -85,6 +85,29 @@ describe("updateDeliveryStatus security", () => {
     expect(mockPrisma.$executeRawUnsafe).toHaveBeenCalled();
   });
 
+  it("checks ownership against profile_id as well as user_id", async () => {
+    // Most drivers rows only have profile_id set (user_id is a legacy,
+    // usually-NULL column). The ownership query must accept either link —
+    // a user_id-only check 403s every real driver. Regression for the
+    // "Access denied on own delivery" bug.
+    mockAuth({ id: "user-owner" });
+    mockGetUserRole.mockResolvedValue("DRIVER");
+    mockPrisma.$queryRawUnsafe.mockImplementation((sql: string) => {
+      if (sql.includes("FROM deliveries")) return Promise.resolve([{ driver_id: "driver-1" }]);
+      if (sql.includes("FROM drivers")) return Promise.resolve([{ id: "driver-1" }]);
+      return Promise.resolve([]);
+    });
+
+    await updateDeliveryStatus(VALID_ID, DriverStatus.PICKED_UP);
+
+    const ownershipSql = mockPrisma.$queryRawUnsafe.mock.calls
+      .map(([sql]) => sql as string)
+      .find((sql) => sql.includes("FROM drivers"));
+    expect(ownershipSql).toBeDefined();
+    expect(ownershipSql).toContain("profile_id");
+    expect(ownershipSql).toContain("user_id");
+  });
+
   it("lets an admin advance any delivery without an ownership row", async () => {
     mockAuth({ id: "user-admin" });
     mockGetUserRole.mockResolvedValue("ADMIN");

--- a/src/app/actions/tracking/__tests__/delivery-actions.security.test.ts
+++ b/src/app/actions/tracking/__tests__/delivery-actions.security.test.ts
@@ -115,6 +115,51 @@ describe("updateDeliveryStatus security", () => {
     expect(ownershipSql).toContain("user_id");
   });
 
+  it("rejects a status value outside the DriverStatus enum before touching the DB", async () => {
+    // The DriverStatus type is compile-time only; a server action is a public
+    // POST endpoint, so arbitrary strings must be rejected server-side.
+    const res = await updateDeliveryStatus(VALID_ID, "TOTALLY_BOGUS" as DriverStatus);
+    expect(res).toEqual({ success: false, error: "Invalid status" });
+    expect(mockCreateClient).not.toHaveBeenCalled();
+    expect(mockPrisma.$executeRawUnsafe).not.toHaveBeenCalled();
+  });
+
+  it("does not re-increment the shift delivery_count when the delivery is already COMPLETED", async () => {
+    mockAuth({ id: "user-owner" });
+    mockGetUserRole.mockResolvedValue("DRIVER");
+    mockPrisma.$queryRawUnsafe.mockImplementation((sql: string) => {
+      if (sql.includes("FROM deliveries"))
+        return Promise.resolve([{ driver_id: "driver-1", status: DriverStatus.COMPLETED }]);
+      if (sql.includes("FROM drivers")) return Promise.resolve([{ id: "driver-1" }]);
+      return Promise.resolve([]);
+    });
+
+    const res = await updateDeliveryStatus(VALID_ID, DriverStatus.COMPLETED);
+    expect(res).toEqual({ success: true });
+    const countBump = mockPrisma.$executeRawUnsafe.mock.calls.find(([sql]) =>
+      (sql as string).includes("delivery_count"),
+    );
+    expect(countBump).toBeUndefined();
+  });
+
+  it("increments the shift delivery_count on a genuine transition into COMPLETED", async () => {
+    mockAuth({ id: "user-owner" });
+    mockGetUserRole.mockResolvedValue("DRIVER");
+    mockPrisma.$queryRawUnsafe.mockImplementation((sql: string) => {
+      if (sql.includes("FROM deliveries"))
+        return Promise.resolve([{ driver_id: "driver-1", status: DriverStatus.ARRIVED_AT_DROPOFF }]);
+      if (sql.includes("FROM drivers")) return Promise.resolve([{ id: "driver-1" }]);
+      return Promise.resolve([]);
+    });
+
+    const res = await updateDeliveryStatus(VALID_ID, DriverStatus.COMPLETED);
+    expect(res).toEqual({ success: true });
+    const countBump = mockPrisma.$executeRawUnsafe.mock.calls.find(([sql]) =>
+      (sql as string).includes("delivery_count"),
+    );
+    expect(countBump).toBeDefined();
+  });
+
   it("lets an admin advance any delivery without an ownership row", async () => {
     mockAuth({ id: "user-admin" });
     mockGetUserRole.mockResolvedValue("ADMIN");

--- a/src/app/actions/tracking/__tests__/delivery-actions.security.test.ts
+++ b/src/app/actions/tracking/__tests__/delivery-actions.security.test.ts
@@ -7,7 +7,13 @@
  *  - the deliveryId must be a valid UUID before it reaches raw SQL
  */
 
-import { updateDeliveryStatus } from "../delivery-actions";
+import {
+  updateDeliveryStatus,
+  assignDeliveryToDriver,
+  createDelivery,
+  getDriverActiveDeliveries,
+  uploadProofOfDelivery,
+} from "../delivery-actions";
 import { prisma } from "@/utils/prismaDB";
 import { createClient } from "@/utils/supabase/server";
 import { getUserRole } from "@/lib/auth";
@@ -118,6 +124,56 @@ describe("updateDeliveryStatus security", () => {
 
     const res = await updateDeliveryStatus(VALID_ID, DriverStatus.PICKED_UP);
     expect(res).toEqual({ success: true });
+  });
+
+  it("restricts delivery assignment to admins", async () => {
+    mockAuth({ id: "user-driver" });
+    mockGetUserRole.mockResolvedValue("DRIVER");
+
+    const res = await assignDeliveryToDriver(VALID_ID, VALID_ID);
+    expect(res).toEqual({ success: false, error: "Access denied" });
+    expect(mockPrisma.$executeRawUnsafe).not.toHaveBeenCalled();
+  });
+
+  it("restricts delivery creation to admins", async () => {
+    mockAuth({ id: "user-driver" });
+    mockGetUserRole.mockResolvedValue("DRIVER");
+
+    const res = await createDelivery(
+      VALID_ID,
+      { lat: 1, lng: 1 },
+      { lat: 2, lng: 2 },
+    );
+    expect(res).toEqual({ success: false, error: "Access denied" });
+  });
+
+  it("returns no deliveries to a driver reading a foreign driver id", async () => {
+    mockAuth({ id: "user-attacker" });
+    mockGetUserRole.mockResolvedValue("DRIVER");
+    mockPrisma.$queryRawUnsafe.mockResolvedValue([]); // ownership lookup → not owned
+
+    const res = await getDriverActiveDeliveries(VALID_ID);
+    expect(res).toEqual([]);
+    // Only the ownership lookup ran — never the deliveries query.
+    const deliveriesQueried = mockPrisma.$queryRawUnsafe.mock.calls.some(
+      ([sql]) => typeof sql === "string" && sql.includes("FROM deliveries"),
+    );
+    expect(deliveriesQueried).toBe(false);
+  });
+
+  it("denies POD upload on a foreign delivery", async () => {
+    mockAuth({ id: "user-attacker" });
+    mockGetUserRole.mockResolvedValue("DRIVER");
+    mockPrisma.$queryRawUnsafe.mockImplementation((sql: string) => {
+      if (sql.includes("FROM deliveries")) {
+        return Promise.resolve([{ driver_id: "driver-victim" }]);
+      }
+      return Promise.resolve([]); // not owned
+    });
+
+    const res = await uploadProofOfDelivery(VALID_ID, new Blob(["x"]));
+    expect(res).toEqual({ success: false, error: "Access denied" });
+    expect(mockPrisma.$executeRawUnsafe).not.toHaveBeenCalled();
   });
 
   it("does not write a location when coordinates are out of range", async () => {

--- a/src/app/actions/tracking/__tests__/delivery-actions.security.test.ts
+++ b/src/app/actions/tracking/__tests__/delivery-actions.security.test.ts
@@ -12,6 +12,7 @@ import {
   assignDeliveryToDriver,
   createDelivery,
   getDriverActiveDeliveries,
+  getDriverDeliveryHistory,
   uploadProofOfDelivery,
 } from "../delivery-actions";
 import { prisma } from "@/utils/prismaDB";
@@ -159,6 +160,63 @@ describe("updateDeliveryStatus security", () => {
       ([sql]) => typeof sql === "string" && sql.includes("FROM deliveries"),
     );
     expect(deliveriesQueried).toBe(false);
+  });
+
+  it("rejects an invalid driverId for delivery history before touching the DB", async () => {
+    const res = await getDriverDeliveryHistory("not-a-uuid");
+    expect(res).toEqual([]);
+    expect(mockCreateClient).not.toHaveBeenCalled();
+    expect(mockPrisma.$queryRawUnsafe).not.toHaveBeenCalled();
+  });
+
+  it("returns no delivery history to a driver reading a foreign driver id", async () => {
+    mockAuth({ id: "user-attacker" });
+    mockGetUserRole.mockResolvedValue("DRIVER");
+    mockPrisma.$queryRawUnsafe.mockResolvedValue([]); // ownership lookup → not owned
+
+    const res = await getDriverDeliveryHistory(VALID_ID);
+    expect(res).toEqual([]);
+    // Only the ownership lookup ran — never the deliveries history query.
+    const deliveriesQueried = mockPrisma.$queryRawUnsafe.mock.calls.some(
+      ([sql]) => typeof sql === "string" && sql.includes("FROM deliveries"),
+    );
+    expect(deliveriesQueried).toBe(false);
+  });
+
+  it("returns delivery history rows to the owning driver", async () => {
+    mockAuth({ id: "user-owner" });
+    mockGetUserRole.mockResolvedValue("DRIVER");
+    mockPrisma.$queryRawUnsafe.mockImplementation((sql: string) => {
+      if (sql.includes("FROM deliveries")) {
+        return Promise.resolve([
+          {
+            id: "delivery-1",
+            driver_id: VALID_ID,
+            status: "COMPLETED",
+            pickup_location_geojson: null,
+            delivery_location_geojson: null,
+            estimated_delivery_time: null,
+            delivered_at: null,
+            delivery_photo_url: null,
+            delivery_notes: null,
+            assigned_at: new Date(),
+            arrived_at_vendor_at: null,
+            picked_up_at: null,
+            en_route_at: null,
+            arrived_at_client_at: null,
+            created_at: new Date(),
+            updated_at: new Date(),
+          },
+        ]);
+      }
+      if (sql.includes("FROM drivers")) return Promise.resolve([{ id: VALID_ID }]); // owned
+      return Promise.resolve([]);
+    });
+
+    const res = await getDriverDeliveryHistory(VALID_ID);
+    expect(res).toHaveLength(1);
+    expect(res[0]?.id).toBe("delivery-1");
+    expect(res[0]?.driverId).toBe(VALID_ID);
   });
 
   it("denies POD upload on a foreign delivery", async () => {

--- a/src/app/actions/tracking/delivery-actions.ts
+++ b/src/app/actions/tracking/delivery-actions.ts
@@ -8,6 +8,7 @@ import { DriverStatus } from '@/types/user';
 import { getTimestampUpdatesForStatus } from '@/lib/delivery-status-transitions';
 import { createClient } from '@/utils/supabase/server';
 import { getUserRole } from '@/lib/auth';
+import { userOwnsDriver } from '@/lib/auth/driver-ownership';
 
 /**
  * Update delivery status with location and optional proof of delivery
@@ -52,13 +53,11 @@ export async function updateDeliveryStatus(
     const deliveryRecord = delivery[0];
 
     // AuthZ: a non-admin caller may only mutate a delivery assigned to their
-    // own driver record (drivers.user_id === auth user id). Prevents one driver
-    // from advancing another driver's delivery (IDOR).
+    // own driver record. Prevents one driver from advancing another driver's
+    // delivery (IDOR).
     if (!isPrivileged) {
-      const owns = await prisma.$queryRawUnsafe<{ id: string }[]>(`
-        SELECT id FROM drivers WHERE id = $1::uuid AND user_id = $2::uuid
-      `, deliveryRecord?.driver_id, user.id);
-      if (owns.length === 0) {
+      const owns = await userOwnsDriver(deliveryRecord?.driver_id, user.id);
+      if (!owns) {
         return { success: false, error: 'Access denied' };
       }
     }

--- a/src/app/actions/tracking/delivery-actions.ts
+++ b/src/app/actions/tracking/delivery-actions.ts
@@ -6,9 +6,11 @@ import { revalidatePath } from 'next/cache';
 import type { LocationUpdate, DeliveryTracking } from '@/types/tracking';
 import { DriverStatus } from '@/types/user';
 import { getTimestampUpdatesForStatus } from '@/lib/delivery-status-transitions';
-import { createClient } from '@/utils/supabase/server';
-import { getUserRole } from '@/lib/auth';
-import { userOwnsDriver } from '@/lib/auth/driver-ownership';
+import {
+  callerMayActOnDriver,
+  getActionCaller,
+  userOwnsDriver,
+} from '@/lib/auth/driver-ownership';
 
 /**
  * Update delivery status with location and optional proof of delivery
@@ -27,15 +29,10 @@ export async function updateDeliveryStatus(
     }
 
     // AuthN: the caller must be signed in.
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (!user) {
+    const caller = await getActionCaller();
+    if (!caller) {
       return { success: false, error: 'Authentication required' };
     }
-    const role = (await getUserRole(user.id))?.toUpperCase();
-    const isPrivileged = role === 'ADMIN' || role === 'SUPER_ADMIN';
 
     // Get current delivery info
     const delivery = await prisma.$queryRawUnsafe<{
@@ -55,8 +52,8 @@ export async function updateDeliveryStatus(
     // AuthZ: a non-admin caller may only mutate a delivery assigned to their
     // own driver record. Prevents one driver from advancing another driver's
     // delivery (IDOR).
-    if (!isPrivileged) {
-      const owns = await userOwnsDriver(deliveryRecord?.driver_id, user.id);
+    if (!caller.isPrivileged) {
+      const owns = await userOwnsDriver(deliveryRecord?.driver_id, caller.userId);
       if (!owns) {
         return { success: false, error: 'Access denied' };
       }
@@ -168,6 +165,13 @@ export async function assignDeliveryToDriver(
     if (!z.string().uuid().safeParse(driverId).success) {
       return { success: false, error: 'Invalid driverId' };
     }
+
+    // AuthZ: assignment is a dispatch operation — admins only.
+    const caller = await getActionCaller();
+    if (!caller?.isPrivileged) {
+      return { success: false, error: 'Access denied' };
+    }
+
     // Verify driver exists and is active
     const driver = await prisma.$queryRawUnsafe<{ id: string; is_active: boolean }[]>(`
       SELECT id, is_active 
@@ -222,6 +226,13 @@ export async function createDelivery(
     if (!z.string().uuid().safeParse(driverId).success) {
       return { success: false, error: 'Invalid driverId' };
     }
+
+    // AuthZ: creating deliveries is a dispatch operation — admins only.
+    const caller = await getActionCaller();
+    if (!caller?.isPrivileged) {
+      return { success: false, error: 'Access denied' };
+    }
+
     // Insert delivery record
     const result = await prisma.$queryRawUnsafe<{ id: string }[]>(`
       INSERT INTO deliveries (
@@ -277,6 +288,12 @@ export async function getDriverActiveDeliveries(driverId: string): Promise<Deliv
     if (!z.string().uuid().safeParse(driverId).success) {
       return [];
     }
+
+    // AuthZ: a driver may only read their own deliveries (admins any).
+    if (!(await callerMayActOnDriver(driverId))) {
+      return [];
+    }
+
     const result = await prisma.$queryRawUnsafe<any[]>(`
       SELECT
         d.id,
@@ -353,6 +370,17 @@ export async function uploadProofOfDelivery(
       return { success: false, error: 'Invalid deliveryId' };
     }
 
+    // AuthZ: only the delivery's driver (or an admin) may attach a POD.
+    const podDelivery = await prisma.$queryRawUnsafe<{ driver_id: string | null }[]>(`
+      SELECT driver_id FROM deliveries WHERE id = $1::uuid
+    `, deliveryId);
+    if (podDelivery.length === 0) {
+      return { success: false, error: 'Delivery not found' };
+    }
+    if (!(await callerMayActOnDriver(podDelivery[0]?.driver_id))) {
+      return { success: false, error: 'Access denied' };
+    }
+
     // Import upload function
     const { uploadPODImage } = await import('@/utils/supabase/storage');
 
@@ -401,6 +429,15 @@ export async function getDriverDeliveryHistory(
   limit: number = 20
 ): Promise<DeliveryTracking[]> {
   try {
+    if (!z.string().uuid().safeParse(driverId).success) {
+      return [];
+    }
+
+    // AuthZ: a driver may only read their own delivery history (admins any).
+    if (!(await callerMayActOnDriver(driverId))) {
+      return [];
+    }
+
     const result = await prisma.$queryRawUnsafe<any[]>(`
       SELECT
         d.id,

--- a/src/app/actions/tracking/delivery-actions.ts
+++ b/src/app/actions/tracking/delivery-actions.ts
@@ -28,6 +28,13 @@ export async function updateDeliveryStatus(
       return { success: false, error: 'Invalid deliveryId' };
     }
 
+    // Server actions are public POST endpoints — the DriverStatus type is
+    // compile-time only, so reject anything outside the enum before it is
+    // written to the (unconstrained varchar) status column.
+    if (!z.nativeEnum(DriverStatus).safeParse(status).success) {
+      return { success: false, error: 'Invalid status' };
+    }
+
     // AuthN: the caller must be signed in.
     const caller = await getActionCaller();
     if (!caller) {
@@ -37,8 +44,9 @@ export async function updateDeliveryStatus(
     // Get current delivery info
     const delivery = await prisma.$queryRawUnsafe<{
       driver_id: string;
+      status: string;
     }[]>(`
-      SELECT driver_id
+      SELECT driver_id, status
       FROM deliveries
       WHERE id = $1::uuid
       AND deleted_at IS NULL
@@ -121,8 +129,14 @@ export async function updateDeliveryStatus(
       );
     }
 
-    // Update delivery count in current shift if delivery is completed
-    if (status === DriverStatus.COMPLETED && deliveryRecord?.driver_id) {
+    // Update delivery count in current shift if delivery is completed.
+    // Only on an actual transition into COMPLETED — re-sending COMPLETED
+    // (retry, replay) must not inflate the shift's delivery_count.
+    if (
+      status === DriverStatus.COMPLETED &&
+      deliveryRecord?.driver_id &&
+      deliveryRecord.status !== DriverStatus.COMPLETED
+    ) {
       await prisma.$executeRawUnsafe(`
         UPDATE driver_shifts 
         SET 

--- a/src/app/actions/tracking/delivery-actions.ts
+++ b/src/app/actions/tracking/delivery-actions.ts
@@ -41,6 +41,7 @@ export async function updateDeliveryStatus(
       SELECT driver_id
       FROM deliveries
       WHERE id = $1::uuid
+      AND deleted_at IS NULL
     `, deliveryId);
 
     if (delivery.length === 0) {
@@ -372,7 +373,7 @@ export async function uploadProofOfDelivery(
 
     // AuthZ: only the delivery's driver (or an admin) may attach a POD.
     const podDelivery = await prisma.$queryRawUnsafe<{ driver_id: string | null }[]>(`
-      SELECT driver_id FROM deliveries WHERE id = $1::uuid
+      SELECT driver_id FROM deliveries WHERE id = $1::uuid AND deleted_at IS NULL
     `, deliveryId);
     if (podDelivery.length === 0) {
       return { success: false, error: 'Delivery not found' };

--- a/src/app/actions/tracking/driver-actions.ts
+++ b/src/app/actions/tracking/driver-actions.ts
@@ -20,6 +20,7 @@ import {
   calculateShiftMileageWithBreakdown,
   calculateShiftMileageWithValidation,
 } from '@/services/tracking/mileage';
+import { callerMayActOnDriver } from '@/lib/auth/driver-ownership';
 
 /**
  * Start a new driver shift
@@ -31,6 +32,15 @@ export async function startDriverShift(
   metadata: Record<string, any> = {}
 ): Promise<{ success: boolean; shiftId?: string; error?: string }> {
   try {
+    if (!z.string().uuid().safeParse(driverId).success) {
+      return { success: false, error: 'Invalid driverId' };
+    }
+
+    // AuthZ: only the driver themself (or an admin) may start their shift.
+    if (!(await callerMayActOnDriver(driverId))) {
+      return { success: false, error: 'Access denied' };
+    }
+
     // Use raw SQL for PostGIS operations since Prisma doesn't support geography types well
     const result = await prisma.$executeRawUnsafe(`
       INSERT INTO driver_shifts (
@@ -129,6 +139,11 @@ export async function endDriverShift(
     }
 
     const shift = shiftInfo[0];
+
+    // AuthZ: only the shift's driver (or an admin) may end it.
+    if (!(await callerMayActOnDriver(shift?.driver_id))) {
+      return { success: false, error: 'Access denied' };
+    }
 
     // Always record the end location in the database first so that the
     // mileage calculation window has a proper closing point.
@@ -242,13 +257,18 @@ export async function startShiftBreak(
 ): Promise<{ success: boolean; breakId?: string; error?: string }> {
   try {
     // Verify shift exists and is active
-    const shiftExists = await prisma.$queryRawUnsafe<{ id: string }[]>(`
-      SELECT id FROM driver_shifts
+    const shiftExists = await prisma.$queryRawUnsafe<{ id: string; driver_id: string }[]>(`
+      SELECT id, driver_id FROM driver_shifts
       WHERE id = $1::uuid AND status = 'active' AND deleted_at IS NULL
     `, shiftId);
 
     if (shiftExists.length === 0) {
       return { success: false, error: 'Active shift not found' };
+    }
+
+    // AuthZ: only the shift's driver (or an admin) may pause it.
+    if (!(await callerMayActOnDriver(shiftExists[0]?.driver_id))) {
+      return { success: false, error: 'Access denied' };
     }
 
     // Update shift with break start time and set status to paused
@@ -294,14 +314,20 @@ export async function endShiftBreak(
     const shiftInfo = await prisma.$queryRawUnsafe<{
       id: string;
       status: string;
+      driver_id: string;
     }[]>(`
-      SELECT id, status
+      SELECT id, status, driver_id
       FROM driver_shifts
       WHERE id = $1::uuid AND status = 'paused' AND deleted_at IS NULL
     `, breakId);
 
     if (shiftInfo.length === 0) {
       return { success: false, error: 'Paused shift not found (no active break)' };
+    }
+
+    // AuthZ: only the shift's driver (or an admin) may resume it.
+    if (!(await callerMayActOnDriver(shiftInfo[0]?.driver_id))) {
+      return { success: false, error: 'Access denied' };
     }
 
     // End the break and resume shift
@@ -339,6 +365,12 @@ export async function getActiveShift(driverId: string): Promise<DriverShift | nu
       console.error('getActiveShift called with invalid driverId', { driverId });
       return null;
     }
+
+    // AuthZ: a driver may only read their own shift (admins any).
+    if (!(await callerMayActOnDriver(driverId))) {
+      return null;
+    }
+
     const result = await prisma.$queryRawUnsafe<any[]>(`
       SELECT
         ds.id,
@@ -443,6 +475,13 @@ export async function updateDriverLocation(
         success: false,
         error: rateLimit.message
       };
+    }
+
+    // AuthZ: a driver may only write their own location (admins any).
+    // Checked after the rate limiter so unauthenticated spam can't multiply
+    // DB lookups beyond the per-driver ping budget.
+    if (!(await callerMayActOnDriver(driverId))) {
+      return { success: false, error: 'Access denied' };
     }
 
     // Insert location record
@@ -566,6 +605,12 @@ export async function getDriverShiftHistory(
     if (!uuid.success) {
       return [];
     }
+
+    // AuthZ: a driver may only read their own shift history (admins any).
+    if (!(await callerMayActOnDriver(driverId))) {
+      return [];
+    }
+
     const result = await prisma.$queryRawUnsafe<any[]>(`
       SELECT
         ds.id,

--- a/src/app/actions/tracking/driver-actions.ts
+++ b/src/app/actions/tracking/driver-actions.ts
@@ -465,6 +465,14 @@ export async function updateDriverLocation(
       return { success: false, error: 'Invalid driverId' };
     }
 
+    // AuthZ: a driver may only write their own location (admins any).
+    // Checked BEFORE the rate limiter — the limiter is keyed by the target
+    // driverId, so recording denied attempts would let any authenticated
+    // caller burn a victim driver's ping budget and freeze their GPS stream.
+    if (!(await callerMayActOnDriver(driverId))) {
+      return { success: false, error: 'Access denied' };
+    }
+
     // Check rate limit atomically (1 update per 5 seconds per driver)
     // SECURITY FIX: Using checkAndRecordLimit() to prevent race conditions
     // This atomically checks AND records, preventing concurrent requests from bypassing the limit
@@ -475,13 +483,6 @@ export async function updateDriverLocation(
         success: false,
         error: rateLimit.message
       };
-    }
-
-    // AuthZ: a driver may only write their own location (admins any).
-    // Checked after the rate limiter so unauthenticated spam can't multiply
-    // DB lookups beyond the per-driver ping budget.
-    if (!(await callerMayActOnDriver(driverId))) {
-      return { success: false, error: 'Access denied' };
     }
 
     // Insert location record

--- a/src/app/api/drivers/[driverId]/stats/route.ts
+++ b/src/app/api/drivers/[driverId]/stats/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 import { withAuth } from '@/lib/auth-middleware';
 import { prisma } from '@/utils/prismaDB';
+import { getDriverForUser } from '@/lib/auth/driver-ownership';
 import {
   getDriverStats,
   type StatsPeriod,
@@ -105,14 +106,10 @@ export async function GET(
     }
 
     // Authorization check: Drivers can only view their own stats
-    // Check both user_id and profile_id to handle cases where user_id hasn't been backfilled
     if (authContext.user.type === 'DRIVER') {
-      const ownDriver = await prisma.$queryRawUnsafe<{ id: string }[]>(
-        `SELECT id FROM drivers WHERE (user_id = $1::uuid OR profile_id = $1::uuid) AND deleted_at IS NULL`,
-        authContext.user.id
-      );
+      const ownDriver = await getDriverForUser(authContext.user.id);
 
-      if (ownDriver.length === 0 || ownDriver[0]?.id !== driverId) {
+      if (!ownDriver || ownDriver.id !== driverId) {
         return NextResponse.json(
           { success: false, error: 'Access denied: Can only view your own stats' },
           { status: 403 }

--- a/src/app/api/tracking/deliveries/[id]/pod/route.ts
+++ b/src/app/api/tracking/deliveries/[id]/pod/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { withAuth } from '@/lib/auth-middleware';
 import { prisma } from '@/utils/prismaDB';
 import { uploadPODImage, deletePODImage } from '@/utils/supabase/storage';
+import { userOwnsDriver } from '@/lib/auth/driver-ownership';
 import * as Sentry from '@sentry/nextjs';
 
 /**
@@ -32,9 +33,8 @@ export async function POST(
 
     // Verify delivery exists and user has permission
     const verifyQuery = `
-      SELECT d.id, d.proof_of_delivery, dr.user_id
+      SELECT d.id, d.proof_of_delivery, d.driver_id
       FROM deliveries d
-      LEFT JOIN drivers dr ON d.driver_id = dr.id
       WHERE d.id = $1
     `;
 
@@ -42,7 +42,7 @@ export async function POST(
       {
         id: string;
         proof_of_delivery: string | null;
-        user_id: string | null;
+        driver_id: string | null;
       }[]
     >(verifyQuery, deliveryId);
 
@@ -56,14 +56,14 @@ export async function POST(
     const delivery = verifyResult[0]!;
 
     // If user is DRIVER, verify they own this delivery
-    if (
-      authResult.context.user.type === 'DRIVER' &&
-      delivery.user_id !== authResult.context.user.id
-    ) {
-      return NextResponse.json(
-        { success: false, error: 'Access denied' },
-        { status: 403 }
-      );
+    if (authResult.context.user.type === 'DRIVER') {
+      const owns = await userOwnsDriver(delivery.driver_id, authResult.context.user.id);
+      if (!owns) {
+        return NextResponse.json(
+          { success: false, error: 'Access denied' },
+          { status: 403 }
+        );
+      }
     }
 
     // Parse form data
@@ -174,9 +174,8 @@ export async function GET(
         d.id,
         d.proof_of_delivery,
         d.metadata,
-        dr.user_id
+        d.driver_id
       FROM deliveries d
-      LEFT JOIN drivers dr ON d.driver_id = dr.id
       WHERE d.id = $1
     `;
 
@@ -185,7 +184,7 @@ export async function GET(
         id: string;
         proof_of_delivery: string | null;
         metadata: Record<string, unknown> | null;
-        user_id: string | null;
+        driver_id: string | null;
       }[]
     >(query, deliveryId);
 
@@ -199,14 +198,14 @@ export async function GET(
     const delivery = result[0]!;
 
     // If user is DRIVER, verify they own this delivery
-    if (
-      authResult.context.user.type === 'DRIVER' &&
-      delivery.user_id !== authResult.context.user.id
-    ) {
-      return NextResponse.json(
-        { success: false, error: 'Access denied' },
-        { status: 403 }
-      );
+    if (authResult.context.user.type === 'DRIVER') {
+      const owns = await userOwnsDriver(delivery.driver_id, authResult.context.user.id);
+      if (!owns) {
+        return NextResponse.json(
+          { success: false, error: 'Access denied' },
+          { status: 403 }
+        );
+      }
     }
 
     if (!delivery.proof_of_delivery) {

--- a/src/app/api/tracking/deliveries/[id]/route.ts
+++ b/src/app/api/tracking/deliveries/[id]/route.ts
@@ -3,6 +3,7 @@ import { withAuth } from '@/lib/auth-middleware';
 import { prisma } from '@/utils/prismaDB';
 import { DriverStatus } from '@/types/user';
 import { getTimestampUpdatesForStatus } from '@/lib/delivery-status-transitions';
+import { userOwnsDriver } from '@/lib/auth/driver-ownership';
 
 // GET - Get specific delivery details
 export async function GET(
@@ -43,20 +44,13 @@ export async function GET(
         d.created_at,
         d.updated_at,
         dr.employee_id,
-        dr.vehicle_number,
-        dr.user_id
+        dr.vehicle_number
       FROM deliveries d
       LEFT JOIN drivers dr ON d.driver_id = dr.id
       WHERE d.id = $1
     `;
 
     const params_array = [id];
-
-    // If user is DRIVER, verify they own this delivery
-    if (authResult.context.user.type === 'DRIVER') {
-      query += ` AND dr.user_id = $2`;
-      params_array.push(authResult.context.user.id);
-    }
 
     const result = await prisma.$queryRawUnsafe<any[]>(query, ...params_array);
 
@@ -68,6 +62,18 @@ export async function GET(
     }
 
     const delivery = result[0];
+
+    // If user is DRIVER, verify they own this delivery. Report non-owned
+    // deliveries as 404 (not 403) so the route is not an existence oracle.
+    if (authResult.context.user.type === 'DRIVER') {
+      const owns = await userOwnsDriver(delivery.driver_id, authResult.context.user.id);
+      if (!owns) {
+        return NextResponse.json(
+          { success: false, error: 'Delivery not found' },
+          { status: 404 }
+        );
+      }
+    }
 
     const deliveryData = {
       id: delivery.id,
@@ -139,16 +145,14 @@ export async function PUT(
 
     // Verify delivery exists and user has permission
     let verifyQuery = `
-      SELECT d.driver_id, d.status, dr.user_id
+      SELECT d.driver_id, d.status
       FROM deliveries d
-      LEFT JOIN drivers dr ON d.driver_id = dr.id
       WHERE d.id = $1
     `;
 
     const verifyResult = await prisma.$queryRawUnsafe<{
       driver_id: string;
       status: string;
-      user_id?: string;
     }[]>(verifyQuery, id);
 
     if (verifyResult.length === 0) {
@@ -161,11 +165,14 @@ export async function PUT(
     const delivery = verifyResult[0];
 
     // If user is DRIVER, verify they own this delivery
-    if (authResult.context.user.type === 'DRIVER' && delivery?.user_id !== authResult.context.user.id) {
-      return NextResponse.json(
-        { success: false, error: 'Access denied' },
-        { status: 403 }
-      );
+    if (authResult.context.user.type === 'DRIVER') {
+      const owns = await userOwnsDriver(delivery?.driver_id, authResult.context.user.id);
+      if (!owns) {
+        return NextResponse.json(
+          { success: false, error: 'Access denied' },
+          { status: 403 }
+        );
+      }
     }
 
     // Validate status transition

--- a/src/app/api/tracking/drivers/route.ts
+++ b/src/app/api/tracking/drivers/route.ts
@@ -85,9 +85,10 @@ export async function GET(request: NextRequest) {
     const params: (string | number | boolean)[] = [];
     let paramCounter = 1;
 
-    // Drivers are scoped to their own record (drivers.user_id === auth user id).
+    // Drivers are scoped to their own record (linked via profile_id or the
+    // legacy user_id column — see src/lib/auth/driver-ownership.ts).
     if (auth.context.user.type === 'DRIVER') {
-      query += ` AND user_id = $${paramCounter}`;
+      query += ` AND ${driverOwnershipCondition(paramCounter)}`;
       params.push(auth.context.user.id);
       paramCounter++;
     }

--- a/src/app/api/tracking/drivers/route.ts
+++ b/src/app/api/tracking/drivers/route.ts
@@ -164,6 +164,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // profile_id and user_id both link a drivers row to the auth user and
+    // share one id space (profiles.id === auth.users.id). profile_id is
+    // canonical; user_id is the legacy duplicate (FK -> auth.users). Accept
+    // either on input but store them in sync so ownership checks
+    // (src/lib/auth/driver-ownership.ts) never see a divergent pair. The
+    // user_id subselect nulls itself out when no auth.users row exists
+    // (e.g. seeded profiles), since its FK would reject the insert.
+    const authLinkId = profile_id || user_id || null;
+
     const query = `
       INSERT INTO drivers (
         user_id,
@@ -172,7 +181,7 @@ export async function POST(request: NextRequest) {
         vehicle_number,
         phone_number
       )
-      VALUES ($1, $2, $3, $4, $5)
+      VALUES ((SELECT id FROM auth.users WHERE id = $1::uuid), $2, $3, $4, $5)
       RETURNING
         id,
         user_id,
@@ -187,8 +196,8 @@ export async function POST(request: NextRequest) {
     `;
 
     const result = await pool.query(query, [
-      user_id || null,
-      profile_id || null,
+      authLinkId, // user_id (guarded by the auth.users subselect)
+      authLinkId, // profile_id
       employee_id || null,
       vehicle_number || null,
       phone_number || null,

--- a/src/app/api/tracking/drivers/route.ts
+++ b/src/app/api/tracking/drivers/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withAuth } from '@/lib/auth-middleware';
+import { driverOwnershipCondition } from '@/lib/auth/driver-ownership';
 // import { Pool } from 'pg';
 const Pool = require('pg').Pool;
 
@@ -245,7 +246,7 @@ export async function PUT(request: NextRequest) {
     // A DRIVER may only update their own record.
     if (auth.context.user.type === 'DRIVER') {
       const owns = await pool.query(
-        'SELECT id FROM drivers WHERE id = $1 AND user_id = $2',
+        `SELECT id FROM drivers WHERE id = $1 AND ${driverOwnershipCondition(2)}`,
         [driver_id, auth.context.user.id]
       );
       if (owns.rows.length === 0) {

--- a/src/app/api/tracking/drivers/route.ts
+++ b/src/app/api/tracking/drivers/route.ts
@@ -220,7 +220,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         {
           success: false,
-          error: 'Driver with this employee_id already exists'
+          error: 'Driver with this employee_id or profile already exists'
         },
         { status: 409 }
       );

--- a/src/app/api/tracking/locations/__tests__/route.test.ts
+++ b/src/app/api/tracking/locations/__tests__/route.test.ts
@@ -667,8 +667,14 @@ describe("/api/tracking/locations", () => {
       );
       expect(response.status).toBe(201);
       const ownershipCall = mockClient.query.mock.calls.find(
-        ([sql]: [string]) => typeof sql === "string" && sql.includes("AND user_id"),
+        ([sql]: [string]) =>
+          typeof sql === "string" &&
+          sql.includes("SELECT id FROM drivers") &&
+          sql.includes("user_id"),
       );
+      // Ownership must match either linkage column (profile_id is canonical;
+      // user_id is the legacy duplicate), scoped to the caller's auth id.
+      expect(ownershipCall?.[0]).toContain("profile_id");
       expect(ownershipCall?.[1]).toEqual([mockDriverId, "user-owner"]);
     });
 

--- a/src/app/api/tracking/locations/route.ts
+++ b/src/app/api/tracking/locations/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withAuth } from '@/lib/auth-middleware';
+import { driverOwnershipCondition } from '@/lib/auth/driver-ownership';
 // import { Pool } from 'pg';
 const Pool = require('pg').Pool;
 
@@ -70,12 +71,12 @@ export async function POST(request: NextRequest) {
     }
 
     // Check if driver exists. A DRIVER may only write their OWN location:
-    // verify the target driver row belongs to the authenticated user
-    // (drivers.user_id === auth user id). Admins may write for any driver.
+    // verify the target driver row belongs to the authenticated user.
+    // Admins may write for any driver.
     const isDriver = auth.context.user.type === 'DRIVER';
     const driverCheck = isDriver
       ? await client.query(
-          'SELECT id FROM drivers WHERE id = $1 AND user_id = $2 AND is_active = true',
+          `SELECT id FROM drivers WHERE id = $1 AND ${driverOwnershipCondition(2)} AND is_active = true`,
           [driver_id, auth.context.user.id]
         )
       : await client.query(
@@ -202,7 +203,7 @@ export async function GET(request: NextRequest) {
     // A DRIVER may only read their own location history.
     if (auth.context.user.type === 'DRIVER') {
       const owns = await pool.query(
-        'SELECT id FROM drivers WHERE id = $1 AND user_id = $2',
+        `SELECT id FROM drivers WHERE id = $1 AND ${driverOwnershipCondition(2)}`,
         [driver_id, auth.context.user.id]
       );
       if (owns.rows.length === 0) {

--- a/src/app/api/tracking/shifts/[id]/route.ts
+++ b/src/app/api/tracking/shifts/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withAuth } from '@/lib/auth-middleware';
 import { prisma } from '@/utils/prismaDB';
+import { userOwnsDriver } from '@/lib/auth/driver-ownership';
 
 // GET - Get specific shift details
 export async function GET(
@@ -42,12 +43,6 @@ export async function GET(
 
     const params_array = [id];
 
-    // If user is DRIVER, verify they own this shift
-    if (authResult.context.user.type === 'DRIVER') {
-      query += ` AND ds.driver_id = (SELECT id FROM drivers WHERE user_id = $2)`;
-      params_array.push(authResult.context.user.id);
-    }
-
     const result = await prisma.$queryRawUnsafe<any[]>(query, ...params_array);
 
     if (result.length === 0) {
@@ -58,6 +53,18 @@ export async function GET(
     }
 
     const shift = result[0];
+
+    // If user is DRIVER, verify they own this shift. Report non-owned shifts
+    // as 404 (not 403) so the route is not an existence oracle.
+    if (authResult.context.user.type === 'DRIVER') {
+      const owns = await userOwnsDriver(shift.driver_id, authResult.context.user.id);
+      if (!owns) {
+        return NextResponse.json(
+          { success: false, error: 'Shift not found' },
+          { status: 404 }
+        );
+      }
+    }
 
     // Get breaks for this shift
     const breaks = await prisma.$queryRawUnsafe<any[]>(`
@@ -146,16 +153,14 @@ export async function PUT(
 
     // Verify shift exists and user has permission
     let verifyQuery = `
-      SELECT ds.driver_id, ds.status, d.user_id
+      SELECT ds.driver_id, ds.status
       FROM driver_shifts ds
-      LEFT JOIN drivers d ON ds.driver_id = d.id
       WHERE ds.id = $1
     `;
 
     const verifyResult = await prisma.$queryRawUnsafe<{
       driver_id: string;
       status: string;
-      user_id?: string;
     }[]>(verifyQuery, id);
 
     if (verifyResult.length === 0) {
@@ -168,11 +173,14 @@ export async function PUT(
     const shift = verifyResult[0];
 
     // If user is DRIVER, verify they own this shift
-    if (authResult.context.user.type === 'DRIVER' && shift?.user_id !== authResult.context.user.id) {
-      return NextResponse.json(
-        { success: false, error: 'Access denied' },
-        { status: 403 }
-      );
+    if (authResult.context.user.type === 'DRIVER') {
+      const owns = await userOwnsDriver(shift?.driver_id, authResult.context.user.id);
+      if (!owns) {
+        return NextResponse.json(
+          { success: false, error: 'Access denied' },
+          { status: 403 }
+        );
+      }
     }
 
     switch (action) {
@@ -186,36 +194,57 @@ export async function PUT(
 
         // End shift: record end location and mark as completed. Detailed mileage
         // calculation is now handled by the mileage service and driver actions.
-        await prisma.$executeRawUnsafe(`
-          UPDATE driver_shifts 
-          SET 
-            end_time = NOW(),
-            end_location = ${location ? 'ST_GeogFromText($2)' : 'NULL'},
-            status = 'completed',
-            metadata = metadata || $4::jsonb,
-            updated_at = NOW()
-          WHERE id = $1::uuid
-        `,
-          id,
-          location ? `POINT(${location.coordinates.lng} ${location.coordinates.lat})` : null,
-          JSON.stringify(metadata)
-        );
+        // Postgres rejects statements whose bind parameters don't line up with
+        // the placeholders, so the with/without-location variants are split.
+        if (location) {
+          const endPoint = `POINT(${location.coordinates.lng} ${location.coordinates.lat})`;
+          await prisma.$executeRawUnsafe(`
+            UPDATE driver_shifts
+            SET
+              end_time = NOW(),
+              end_location = ST_GeogFromText($2),
+              status = 'completed',
+              metadata = COALESCE(metadata, '{}'::jsonb) || $3::jsonb,
+              updated_at = NOW()
+            WHERE id = $1::uuid
+          `, id, endPoint, JSON.stringify(metadata));
 
-        // Update driver status
-        await prisma.$executeRawUnsafe(`
-          UPDATE drivers 
-          SET 
-            is_on_duty = false,
-            current_shift_id = NULL,
-            shift_start_time = NULL,
-            ${location ? 'last_known_location = ST_GeogFromText($2),' : ''}
-            last_location_update = NOW(),
-            updated_at = NOW()
-          WHERE id = $1::uuid
-        `,
-          shift.driver_id,
-          location ? `POINT(${location.coordinates.lng} ${location.coordinates.lat})` : null
-        );
+          // Update driver status
+          await prisma.$executeRawUnsafe(`
+            UPDATE drivers
+            SET
+              is_on_duty = false,
+              current_shift_id = NULL,
+              shift_start_time = NULL,
+              last_known_location = ST_GeogFromText($2),
+              last_location_update = NOW(),
+              updated_at = NOW()
+            WHERE id = $1::uuid
+          `, shift?.driver_id, endPoint);
+        } else {
+          await prisma.$executeRawUnsafe(`
+            UPDATE driver_shifts
+            SET
+              end_time = NOW(),
+              end_location = NULL,
+              status = 'completed',
+              metadata = COALESCE(metadata, '{}'::jsonb) || $2::jsonb,
+              updated_at = NOW()
+            WHERE id = $1::uuid
+          `, id, JSON.stringify(metadata));
+
+          // Update driver status
+          await prisma.$executeRawUnsafe(`
+            UPDATE drivers
+            SET
+              is_on_duty = false,
+              current_shift_id = NULL,
+              shift_start_time = NULL,
+              last_location_update = NOW(),
+              updated_at = NOW()
+            WHERE id = $1::uuid
+          `, shift?.driver_id);
+        }
 
         break;
 

--- a/src/app/api/tracking/shifts/route.ts
+++ b/src/app/api/tracking/shifts/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withAuth } from '@/lib/auth-middleware';
 import { prisma } from '@/utils/prismaDB';
+import { getDriverForUser } from '@/lib/auth/driver-ownership';
 import type { DriverShift } from '@/types/tracking';
 
 // GET - Get shifts for a driver or all active shifts (admin)
@@ -47,9 +48,17 @@ export async function GET(request: NextRequest) {
 
     // If user is DRIVER, only show their own shifts
     if (authResult.context.user.type === 'DRIVER') {
-      // Assume driver has a profile linking to the drivers table
-      query += ` AND ds.driver_id = (SELECT id FROM drivers WHERE user_id = $${paramCounter})`;
-      params.push(authResult.context.user.id);
+      const ownDriver = await getDriverForUser(authResult.context.user.id);
+      if (!ownDriver) {
+        // No driver row for this user — they have no shifts.
+        return NextResponse.json({
+          success: true,
+          data: [],
+          pagination: { limit, offset, total: 0 }
+        });
+      }
+      query += ` AND ds.driver_id = $${paramCounter}`;
+      params.push(ownDriver.id);
       paramCounter++;
     } else if (driverId) {
       query += ` AND ds.driver_id = $${paramCounter}`;
@@ -165,23 +174,17 @@ export async function POST(request: NextRequest) {
     }
 
     // Get driver ID from user profile
-    const driverResult = await prisma.$queryRawUnsafe<{ id: string; current_shift_id?: string }[]>(`
-      SELECT id, current_shift_id 
-      FROM drivers 
-      WHERE user_id = $1 AND is_active = true
-    `, authResult.context.user.id);
+    const driver = await getDriverForUser(authResult.context.user.id);
 
-    if (driverResult.length === 0) {
+    if (!driver || !driver.isActive) {
       return NextResponse.json(
         { success: false, error: 'Driver profile not found or inactive' },
         { status: 404 }
       );
     }
 
-    const driver = driverResult[0];
-
     // Check if driver already has an active shift
-    if (driver?.current_shift_id) {
+    if (driver.currentShiftId) {
       return NextResponse.json(
         { success: false, error: 'Driver already has an active shift' },
         { status: 409 }

--- a/src/components/Driver/DriverTrackingPortal.tsx
+++ b/src/components/Driver/DriverTrackingPortal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import toast from "react-hot-toast";
 import {
   CheckCircle2,
   CloudOff,
@@ -151,7 +152,17 @@ export default function DriverTrackingPortal() {
   const advanceStatus = async (deliveryId: string, status: DriverStatus) => {
     setUpdatingId(deliveryId);
     try {
-      await updateDeliveryStatus(deliveryId, status, currentLocation || undefined);
+      const ok = await updateDeliveryStatus(
+        deliveryId,
+        status,
+        currentLocation || undefined,
+      );
+      if (!ok) {
+        // The update failed server-side (auth, network, validation). Without
+        // this the button just does nothing and the driver assumes a freeze.
+        toast.error("Couldn't update the delivery status. Please try again.");
+      }
+      return ok;
     } finally {
       setUpdatingId(null);
     }
@@ -207,14 +218,19 @@ export default function DriverTrackingPortal() {
           queued={queuedItems}
         />
 
-        {locationError || shiftError || deliveriesError ? (
-          <div className="flex items-start gap-2 rounded-2xl border border-driver-error/30 bg-driver-error-bg px-4 py-3 text-driver-error-ink">
-            <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" />
-            <span className="text-[13px] font-semibold">
-              {locationError || shiftError || deliveriesError}
-            </span>
-          </div>
-        ) : null}
+        {/* Show every active error — `a || b || c` masks shift/delivery
+            failures whenever a location-permission error is present. */}
+        {[locationError, shiftError, deliveriesError]
+          .filter((message): message is string => Boolean(message))
+          .map((message) => (
+            <div
+              key={message}
+              className="flex items-start gap-2 rounded-2xl border border-driver-error/30 bg-driver-error-bg px-4 py-3 text-driver-error-ink"
+            >
+              <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" />
+              <span className="text-[13px] font-semibold">{message}</span>
+            </div>
+          ))}
 
         {!isOnline ? (
           <div className="flex items-center gap-2 rounded-2xl border border-driver-warning/30 bg-driver-warning-bg px-4 py-3 text-driver-warning-ink">

--- a/src/components/Driver/DriverTrackingPortal.tsx
+++ b/src/components/Driver/DriverTrackingPortal.tsx
@@ -183,8 +183,10 @@ export default function DriverTrackingPortal() {
 
   const onPodComplete = async () => {
     if (!podTarget) return;
-    await advanceStatus(podTarget.deliveryId, DriverStatus.COMPLETED);
-    setPodTarget(null);
+    // Keep the POD sheet open on failure so the driver can retry instead of
+    // having to re-capture the proof after only seeing the error toast.
+    const ok = await advanceStatus(podTarget.deliveryId, DriverStatus.COMPLETED);
+    if (ok) setPodTarget(null);
   };
 
   const headerRight = useMemo(() => {
@@ -220,11 +222,17 @@ export default function DriverTrackingPortal() {
 
         {/* Show every active error — `a || b || c` masks shift/delivery
             failures whenever a location-permission error is present. */}
-        {[locationError, shiftError, deliveriesError]
-          .filter((message): message is string => Boolean(message))
-          .map((message) => (
+        {(
+          [
+            ["location", locationError],
+            ["shift", shiftError],
+            ["deliveries", deliveriesError],
+          ] as Array<[string, string | null | undefined]>
+        )
+          .filter(([, message]) => Boolean(message))
+          .map(([source, message]) => (
             <div
-              key={message}
+              key={source}
               className="flex items-start gap-2 rounded-2xl border border-driver-error/30 bg-driver-error-bg px-4 py-3 text-driver-error-ink"
             >
               <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" />

--- a/src/components/Driver/__tests__/DriverTrackingPortal.test.tsx
+++ b/src/components/Driver/__tests__/DriverTrackingPortal.test.tsx
@@ -27,9 +27,16 @@ jest.mock("@/components/Driver/DriverLiveMap", () => ({
   ),
 }));
 
-// POD capture pulls in camera APIs — stub it for the sheet path.
+// POD capture pulls in camera APIs — stub it for the sheet path. The stub
+// exposes a button so tests can drive the upload-complete callback.
 jest.mock("@/components/Driver/ProofOfDeliveryCapture", () => ({
-  ProofOfDeliveryCapture: () => <div data-testid="pod-capture" />,
+  ProofOfDeliveryCapture: ({ onUploadComplete }: any) => (
+    <div data-testid="pod-capture">
+      <button onClick={() => onUploadComplete("https://pod.example/photo.jpg")}>
+        finish pod upload
+      </button>
+    </div>
+  ),
 }));
 
 const mockUseDriverTracking = useDriverTracking as jest.MockedFunction<
@@ -218,6 +225,62 @@ describe("DriverTrackingPortal (redesigned)", () => {
     renderPortal();
     expect(screen.getByText(/location access denied/i)).toBeInTheDocument();
     expect(screen.getByText(/^access denied$/i)).toBeInTheDocument();
+  });
+
+  it("renders one banner per error source even when messages are identical", () => {
+    // The banner list is keyed by source slot, not message text — two sources
+    // failing with the same wording must not collapse into one banner.
+    mockUseDriverTracking.mockReturnValue(
+      baseCtx({
+        shiftError: "Access denied",
+        deliveriesError: "Access denied",
+      }),
+    );
+    renderPortal();
+    expect(screen.getAllByText(/^access denied$/i)).toHaveLength(2);
+  });
+
+  it("keeps the POD sheet open when completing the delivery fails", async () => {
+    updateDeliveryStatus.mockResolvedValueOnce(false);
+    mockUseDriverTracking.mockReturnValue(
+      baseCtx({
+        isShiftActive: true,
+        currentShift: { id: "s1", driverId: "driver-1", startTime: new Date() },
+        currentLocation: sampleLocation,
+        activeDeliveries: [
+          {
+            id: "del-1",
+            cateringRequestId: "cr-1",
+            driverId: "driver-1",
+            status: DriverStatus.ARRIVED_TO_CLIENT,
+            deliveryLocation: { coordinates: [-122.41, 37.77] },
+          },
+        ],
+      }),
+    );
+    renderPortal();
+
+    // The final step routes through proof-of-delivery capture.
+    fireEvent.click(screen.getByText(/complete delivery/i));
+    expect(await screen.findByTestId("pod-capture")).toBeInTheDocument();
+
+    // Drive the capture flow to completion; the status update fails.
+    fireEvent.click(screen.getByRole("button", { name: /finish pod upload/i }));
+    await waitFor(() =>
+      expect(updateDeliveryStatus).toHaveBeenCalledWith(
+        "del-1",
+        DriverStatus.COMPLETED,
+        sampleLocation,
+      ),
+    );
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        expect.stringMatching(/couldn't update the delivery status/i),
+      ),
+    );
+    // podTarget is only cleared on success — the sheet must stay open so the
+    // driver can retry without re-capturing the proof.
+    expect(screen.getByTestId("pod-capture")).toBeInTheDocument();
   });
 
   it("shows an offline banner when offline", () => {

--- a/src/components/Driver/__tests__/DriverTrackingPortal.test.tsx
+++ b/src/components/Driver/__tests__/DriverTrackingPortal.test.tsx
@@ -12,6 +12,13 @@ jest.mock("@/contexts/DriverTrackingContext", () => ({
   DriverTrackingProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+jest.mock("react-hot-toast", () => ({
+  __esModule: true,
+  default: { error: jest.fn(), success: jest.fn() },
+}));
+
+import toast from "react-hot-toast";
+
 // Light map mock (real one needs Mapbox + a token).
 jest.mock("@/components/Driver/DriverLiveMap", () => ({
   __esModule: true,
@@ -149,6 +156,68 @@ describe("DriverTrackingPortal (redesigned)", () => {
         sampleLocation,
       ),
     );
+  });
+
+  it("toasts when a status update fails instead of failing silently", async () => {
+    updateDeliveryStatus.mockResolvedValueOnce(false);
+    mockUseDriverTracking.mockReturnValue(
+      baseCtx({
+        isShiftActive: true,
+        currentShift: { id: "s1", driverId: "driver-1", startTime: new Date() },
+        currentLocation: sampleLocation,
+        activeDeliveries: [
+          {
+            id: "del-1",
+            cateringRequestId: "cr-1",
+            driverId: "driver-1",
+            status: DriverStatus.ASSIGNED,
+            deliveryLocation: { coordinates: [-122.41, 37.77] },
+          },
+        ],
+      }),
+    );
+    renderPortal();
+    fireEvent.click(screen.getByText(/on my way to vendor/i));
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        expect.stringMatching(/couldn't update the delivery status/i),
+      ),
+    );
+  });
+
+  it("does not toast when a status update succeeds", async () => {
+    mockUseDriverTracking.mockReturnValue(
+      baseCtx({
+        isShiftActive: true,
+        currentShift: { id: "s1", driverId: "driver-1", startTime: new Date() },
+        currentLocation: sampleLocation,
+        activeDeliveries: [
+          {
+            id: "del-1",
+            cateringRequestId: "cr-1",
+            driverId: "driver-1",
+            status: DriverStatus.ASSIGNED,
+            deliveryLocation: { coordinates: [-122.41, 37.77] },
+          },
+        ],
+      }),
+    );
+    renderPortal();
+    fireEvent.click(screen.getByText(/on my way to vendor/i));
+    await waitFor(() => expect(updateDeliveryStatus).toHaveBeenCalled());
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("shows all error banners at once instead of masking later ones", () => {
+    mockUseDriverTracking.mockReturnValue(
+      baseCtx({
+        locationError: "Location access denied",
+        deliveriesError: "Access denied",
+      }),
+    );
+    renderPortal();
+    expect(screen.getByText(/location access denied/i)).toBeInTheDocument();
+    expect(screen.getByText(/^access denied$/i)).toBeInTheDocument();
   });
 
   it("shows an offline banner when offline", () => {

--- a/src/lib/auth/__tests__/driver-ownership.test.ts
+++ b/src/lib/auth/__tests__/driver-ownership.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for the shared driver-ownership helper.
+ *
+ * Regression guard for the profile_id/user_id split: `drivers.profile_id` is
+ * the canonical auth-user link (unique FK to profiles.id) while `user_id` is a
+ * legacy duplicate that is NULL on most rows. Ownership checks that look at
+ * `user_id` alone deny nearly every real driver, so these tests pin the
+ * generated SQL to matching on BOTH columns.
+ */
+
+import {
+  driverOwnershipCondition,
+  getDriverForUser,
+  userOwnsDriver,
+} from "../driver-ownership";
+import { prisma } from "@/utils/prismaDB";
+
+jest.mock("@/utils/prismaDB", () => ({
+  prisma: { $queryRawUnsafe: jest.fn() },
+}));
+
+const mockQuery = (prisma as unknown as { $queryRawUnsafe: jest.Mock })
+  .$queryRawUnsafe;
+
+const DRIVER_ID = "11111111-1111-4111-8111-111111111111";
+const USER_ID = "22222222-2222-4222-8222-222222222222";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("driverOwnershipCondition", () => {
+  it("matches on profile_id OR user_id (never user_id alone)", () => {
+    const sql = driverOwnershipCondition(2);
+    expect(sql).toContain("profile_id = $2::uuid");
+    expect(sql).toContain("user_id = $2::uuid");
+    expect(sql).toMatch(/OR/);
+  });
+
+  it("prefixes both columns with the table alias", () => {
+    const sql = driverOwnershipCondition(3, "dr");
+    expect(sql).toContain("dr.profile_id = $3::uuid");
+    expect(sql).toContain("dr.user_id = $3::uuid");
+  });
+});
+
+describe("userOwnsDriver", () => {
+  it("returns false for a null driverId without touching the DB", async () => {
+    expect(await userOwnsDriver(null, USER_ID)).toBe(false);
+    expect(await userOwnsDriver(undefined, USER_ID)).toBe(false);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("queries by both linkage columns and returns true on a match", async () => {
+    mockQuery.mockResolvedValue([{ id: DRIVER_ID }]);
+
+    const owns = await userOwnsDriver(DRIVER_ID, USER_ID);
+
+    expect(owns).toBe(true);
+    const [sql, ...params] = mockQuery.mock.calls[0];
+    expect(sql).toContain("profile_id = $2::uuid");
+    expect(sql).toContain("user_id = $2::uuid");
+    expect(sql).toContain("deleted_at IS NULL");
+    expect(params).toEqual([DRIVER_ID, USER_ID]);
+  });
+
+  it("returns false when no row links the driver to the user", async () => {
+    mockQuery.mockResolvedValue([]);
+    expect(await userOwnsDriver(DRIVER_ID, USER_ID)).toBe(false);
+  });
+
+  it("adds the is_active filter only when requireActive is set", async () => {
+    mockQuery.mockResolvedValue([{ id: DRIVER_ID }]);
+
+    await userOwnsDriver(DRIVER_ID, USER_ID);
+    expect(mockQuery.mock.calls[0][0]).not.toContain("is_active");
+
+    await userOwnsDriver(DRIVER_ID, USER_ID, { requireActive: true });
+    expect(mockQuery.mock.calls[1][0]).toContain("is_active = true");
+  });
+});
+
+describe("getDriverForUser", () => {
+  it("resolves the driver row via both linkage columns", async () => {
+    mockQuery.mockResolvedValue([
+      { id: DRIVER_ID, is_active: true, current_shift_id: null },
+    ]);
+
+    const driver = await getDriverForUser(USER_ID);
+
+    expect(driver).toEqual({
+      id: DRIVER_ID,
+      isActive: true,
+      currentShiftId: null,
+    });
+    const [sql, ...params] = mockQuery.mock.calls[0];
+    expect(sql).toContain("profile_id = $1::uuid");
+    expect(sql).toContain("user_id = $1::uuid");
+    expect(sql).toContain("deleted_at IS NULL");
+    expect(params).toEqual([USER_ID]);
+  });
+
+  it("returns null when the user has no driver row", async () => {
+    mockQuery.mockResolvedValue([]);
+    expect(await getDriverForUser(USER_ID)).toBeNull();
+  });
+});

--- a/src/lib/auth/driver-ownership.ts
+++ b/src/lib/auth/driver-ownership.ts
@@ -1,0 +1,91 @@
+import { prisma } from '@/utils/prismaDB';
+
+/**
+ * Driver ↔ auth-user linkage.
+ *
+ * The `drivers` table carries two columns that can point at the authenticated
+ * user (`profiles.id` === Supabase auth uid):
+ *
+ *  - `profile_id` — the canonical link: unique, FK to `profiles.id`.
+ *  - `user_id`    — a legacy duplicate with no FK; NULL on most rows.
+ *
+ * Ownership checks MUST accept either column until `user_id` is backfilled
+ * and dropped. Checking `user_id` alone denies every driver whose row only
+ * has `profile_id` set (most of them) — drivers resolve their own record via
+ * `profile_id` (see /api/auth/session) and then get 403s on every write.
+ *
+ * All driver-ownership decisions belong in this module. Do not inline
+ * `user_id = $n` (or `profile_id = $n`) checks in routes.
+ */
+
+/**
+ * SQL fragment matching a drivers row linked to the auth user via either
+ * column. For routes that must embed the condition in a larger query (e.g.
+ * inside a pg transaction). `paramIndex` is the 1-based placeholder position
+ * of the auth user id; it may be referenced by other parts of the query too.
+ */
+export function driverOwnershipCondition(paramIndex: number, alias = ''): string {
+  const p = alias ? `${alias}.` : '';
+  return `(${p}profile_id = $${paramIndex}::uuid OR ${p}user_id = $${paramIndex}::uuid)`;
+}
+
+export interface DriverIdentity {
+  id: string;
+  isActive: boolean;
+  currentShiftId: string | null;
+}
+
+/** Resolve the (non-deleted) driver row belonging to an authenticated user. */
+export async function getDriverForUser(
+  authUserId: string
+): Promise<DriverIdentity | null> {
+  const rows = await prisma.$queryRawUnsafe<
+    { id: string; is_active: boolean; current_shift_id: string | null }[]
+  >(
+    `
+    SELECT id, is_active, current_shift_id
+    FROM drivers
+    WHERE ${driverOwnershipCondition(1)}
+    AND deleted_at IS NULL
+    LIMIT 1
+  `,
+    authUserId
+  );
+
+  const row = rows[0];
+  if (!row) return null;
+  return {
+    id: row.id,
+    isActive: row.is_active,
+    currentShiftId: row.current_shift_id,
+  };
+}
+
+/**
+ * True when the given drivers row belongs to the authenticated user.
+ * `driverId` may be null/undefined (e.g. an unassigned delivery) — that is
+ * never owned.
+ */
+export async function userOwnsDriver(
+  driverId: string | null | undefined,
+  authUserId: string,
+  opts: { requireActive?: boolean } = {}
+): Promise<boolean> {
+  if (!driverId) return false;
+
+  const rows = await prisma.$queryRawUnsafe<{ id: string }[]>(
+    `
+    SELECT id
+    FROM drivers
+    WHERE id = $1::uuid
+    AND ${driverOwnershipCondition(2)}
+    AND deleted_at IS NULL
+    ${opts.requireActive ? 'AND is_active = true' : ''}
+    LIMIT 1
+  `,
+    driverId,
+    authUserId
+  );
+
+  return rows.length > 0;
+}

--- a/src/lib/auth/driver-ownership.ts
+++ b/src/lib/auth/driver-ownership.ts
@@ -1,13 +1,16 @@
 import { prisma } from '@/utils/prismaDB';
+import { createClient } from '@/utils/supabase/server';
+import { getUserRole } from '@/lib/auth';
 
 /**
  * Driver ↔ auth-user linkage.
  *
  * The `drivers` table carries two columns that can point at the authenticated
- * user (`profiles.id` === Supabase auth uid):
+ * user, in one id space (`profiles.id` === `auth.users.id` === auth uid):
  *
  *  - `profile_id` — the canonical link: unique, FK to `profiles.id`.
- *  - `user_id`    — a legacy duplicate with no FK; NULL on most rows.
+ *  - `user_id`    — a legacy duplicate (FK to `auth.users.id`, which the
+ *                   Prisma schema does not model); NULL on most rows.
  *
  * Ownership checks MUST accept either column until `user_id` is backfilled
  * and dropped. Checking `user_id` alone denies every driver whose row only
@@ -27,6 +30,44 @@ import { prisma } from '@/utils/prismaDB';
 export function driverOwnershipCondition(paramIndex: number, alias = ''): string {
   const p = alias ? `${alias}.` : '';
   return `(${p}profile_id = $${paramIndex}::uuid OR ${p}user_id = $${paramIndex}::uuid)`;
+}
+
+export interface ActionCaller {
+  userId: string;
+  isPrivileged: boolean;
+}
+
+/**
+ * Resolve the authenticated caller of a server action. Server actions are
+ * plain POST endpoints — every action that reads or mutates driver data must
+ * authenticate the caller itself; nothing upstream does it for them.
+ * Returns null when unauthenticated.
+ */
+export async function getActionCaller(): Promise<ActionCaller | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  const role = (await getUserRole(user.id))?.toUpperCase();
+  return {
+    userId: user.id,
+    isPrivileged: role === 'ADMIN' || role === 'SUPER_ADMIN',
+  };
+}
+
+/**
+ * Owner-or-admin gate for server actions acting on a driver's data:
+ * admins may act on any driver; everyone else only on their own driver row.
+ */
+export async function callerMayActOnDriver(
+  driverId: string | null | undefined
+): Promise<boolean> {
+  const caller = await getActionCaller();
+  if (!caller) return false;
+  if (caller.isPrivileged) return true;
+  return userOwnsDriver(driverId, caller.userId);
 }
 
 export interface DriverIdentity {

--- a/src/lib/auth/driver-ownership.ts
+++ b/src/lib/auth/driver-ownership.ts
@@ -26,6 +26,9 @@ import { getUserRole } from '@/lib/auth';
  * column. For routes that must embed the condition in a larger query (e.g.
  * inside a pg transaction). `paramIndex` is the 1-based placeholder position
  * of the auth user id; it may be referenced by other parts of the query too.
+ *
+ * `alias` is interpolated raw into SQL — it must ALWAYS be a hardcoded
+ * literal at the call site, never request-derived data.
  */
 export function driverOwnershipCondition(paramIndex: number, alias = ''): string {
   const p = alias ? `${alias}.` : '';


### PR DESCRIPTION
## Summary

Periodic `development → main` promotion. **1 PR / 9 commits** since the last sync ([#439](https://github.com/ReadySet1/ready-set/pull/439), 2026-06-09). CI and Security are green on the development head (`397ea96f`).

### Security
- #441 Driver ownership / authz overhaul:
  - New canonical authz module `src/lib/auth/driver-ownership.ts` — all driver↔auth-user ownership decisions live here; ownership checks accept both `profile_id` (canonical) and `user_id` (legacy) link columns
  - Driver-tracking server actions now resolve and authorize the caller themselves (`getActionCaller()` / `callerMayActOnDriver()`) — admin-only for `createDelivery` / `assignDeliveryToDriver`, owner-or-admin for the rest
  - Hardened tracking API routes (deliveries, drivers, locations, shifts, POD, driver stats) from pre-landing review findings
  - Server-side delivery status-transition validation; completion made idempotent

### Fixes
- #441 Surface delivery status-update failures in the driver tracking UI (keep POD sheet open on failure, de-duped banner keys)

### Docs / Tests
- Architecture + CLAUDE.md docs for the driver-ownership module and the server-action auth convention
- New unit tests for `driver-ownership`, delivery status transitions, and tracking action security; fixed pre-existing stale assertions in orders PATCH tests

## ⚠️ Release notes

- **DB migration included:** `20260611000000_backfill_driver_user_id` — data-only backfill that syncs the `drivers.user_id` / `drivers.profile_id` auth-link columns in both directions. Idempotent, FK-guarded, no schema change. Must be applied to the production database as part of this deploy.
- **Image build:** the GHCR "Build & Push Image" run on `397ea96f` died mid-build (transient runner failure); it has been re-run — verify it's green before relying on the self-host image.
- **release-please:** after merge, the bot should open the next `chore(main): release X.Y.Z` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)