### PR TITLE
fix: driver-history authz + runnable driver e2e suite

### DIFF
--- a/.env.test.example
+++ b/.env.test.example
@@ -6,9 +6,12 @@
 NEXT_PUBLIC_SUPABASE_URL=https://your-test-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-test-project-anon-key
 
-# Database URL for test data setup
-# Format: postgresql://[user]:[password]@[host]:[port]/[database]
-DATABASE_URL=postgresql://postgres:[password]@db.[project-ref].supabase.co:5432/postgres
+# Database URL for test data setup.
+# Use the CONNECTION POOLER host (port 6543) — the direct host
+# (db.[ref].supabase.co:5432) is often unreachable from local/CI networks and
+# will crash Prisma with PrismaClientInitializationError when the dev server boots.
+# Format: postgresql://postgres.[project-ref]:[password]@[region].pooler.supabase.com:6543/postgres
+DATABASE_URL=postgresql://postgres.[project-ref]:[password]@[region].pooler.supabase.com:6543/postgres
 
 # Optional: Service role key for admin operations in tests
 SUPABASE_SERVICE_ROLE_KEY=your-test-project-service-role-key
@@ -20,5 +23,10 @@ TEST_CLIENT_EMAIL=test-client@example.com
 TEST_CLIENT_PASSWORD=TestPassword123!
 TEST_VENDOR_EMAIL=test-vendor@example.com
 TEST_VENDOR_PASSWORD=TestPassword123!
-# TEST_ADMIN_EMAIL=test-admin@example.com
-# TEST_ADMIN_PASSWORD=TestPassword123!
+# Driver account is required for the driver-flow specs
+# (driver-shift-workflow, driver-history-export).
+TEST_DRIVER_EMAIL=driver.test@example.com
+TEST_DRIVER_PASSWORD=TestDriver123!
+# Admin account is required for the "Admin Downloads Driver History" specs.
+TEST_ADMIN_EMAIL=admin.test@example.com
+TEST_ADMIN_PASSWORD=TestAdmin123!

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -41,6 +41,28 @@ pnpm playwright test --headed
 pnpm playwright test --project=chromium
 ```
 
+### Driver-flow specs (driver-shift-workflow, driver-history-export)
+
+These specs require the driver and admin test accounts and load `.env.test`
+explicitly (Playwright's config does not). Run them serially — they share a
+single driver account + dev server, so parallel workers overload the dev server
+and race on shift state:
+
+```bash
+# Seed the driver's assigned delivery first (idempotent)
+pnpm exec dotenv -e .env.test -- tsx e2e/test-data-setup.ts setup
+
+# Run the driver specs serially against Chromium
+pnpm exec dotenv -e .env.test -- playwright test driver --project=chromium --workers=1
+```
+
+Notes:
+- `DATABASE_URL` in `.env.test` must use the Supabase **connection pooler**
+  (port 6543); the direct host crashes Prisma when the dev server boots.
+- Geolocation is provided by Playwright (`grantPermissions` + `setGeolocation`);
+  the portal acquires it asynchronously, so the specs wait for the resolved
+  "Start shift"/"On shift" state rather than network idle.
+
 ## Test Infrastructure
 
 ### Authentication
@@ -81,9 +103,13 @@ test.withRole('my test', async ({ authenticatedPage, role }) => {
 Test data is managed through:
 - **Setup Script**: `e2e/test-data-setup.ts` creates test users and data
 - **Test Users**:
-  - `test-client@example.com` (CLIENT role)
-  - `test-vendor@example.com` (VENDOR role)
-  - Password: `TestPassword123!`
+  - `test-client@example.com` (CLIENT role) — password `TestPassword123!`
+  - `test-vendor@example.com` (VENDOR role) — password `TestPassword123!`
+  - `driver.test@example.com` (DRIVER role) — password `TestDriver123!`
+  - `admin.test@example.com` (ADMIN role) — password `TestAdmin123!`
+- **Seeded driver delivery**: `createDriverDeliveryData()` assigns an active
+  catering delivery to the driver so the shift-workflow specs render the
+  "Active deliveries" section.
 
 **Creating test data:**
 

--- a/e2e/auth/setup.ts
+++ b/e2e/auth/setup.ts
@@ -48,12 +48,16 @@ const TEST_USERS = {
     password: getRequiredEnv('TEST_VENDOR_PASSWORD', 'E2E test vendor authentication'),
     role: 'VENDOR',
   },
-  // Add ADMIN when available
-  // ADMIN: {
-  //   email: getRequiredEnv('TEST_ADMIN_EMAIL', 'E2E test admin authentication'),
-  //   password: getRequiredEnv('TEST_ADMIN_PASSWORD', 'E2E test admin authentication'),
-  //   role: 'ADMIN',
-  // },
+  DRIVER: {
+    email: getRequiredEnv('TEST_DRIVER_EMAIL', 'E2E test driver authentication'),
+    password: getRequiredEnv('TEST_DRIVER_PASSWORD', 'E2E test driver authentication'),
+    role: 'DRIVER',
+  },
+  ADMIN: {
+    email: getRequiredEnv('TEST_ADMIN_EMAIL', 'E2E test admin authentication'),
+    password: getRequiredEnv('TEST_ADMIN_PASSWORD', 'E2E test admin authentication'),
+    role: 'ADMIN',
+  },
 };
 
 const authDir = path.join(__dirname, '..', '.auth');
@@ -96,16 +100,18 @@ async function authenticate(
     console.log(`  → Waiting for authentication (timeout: ${timeout}ms, isCI: ${isCI})...`);
 
     try {
-      await page.waitForURL(/\/(admin|client|vendor|dashboard)/, {
+      // 'load' instead of 'networkidle': the driver dashboard polls continuously
+      // (live tracking), so it never reaches network idle.
+      await page.waitForURL(/\/(admin|client|vendor|dashboard|driver)/, {
         timeout,
-        waitUntil: 'networkidle',
+        waitUntil: 'load',
       });
     } catch (error) {
       // Enhanced error logging for debugging
       const currentURL = page.url();
       console.error(`  ❌ Authentication timeout after ${timeout}ms`);
       console.error(`  Current URL: ${currentURL}`);
-      console.error(`  Expected URL pattern: /(admin|client|vendor|dashboard)/`);
+      console.error(`  Expected URL pattern: /(admin|client|vendor|dashboard|driver)/`);
 
       // Take screenshot for debugging (only in CI)
       if (isCI) {

--- a/e2e/driver-history-export.spec.ts
+++ b/e2e/driver-history-export.spec.ts
@@ -15,22 +15,55 @@
  * @see REA-313
  */
 
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, request as playwrightRequest, type Page } from '@playwright/test';
+
+// Reuse the driver session created by e2e/auth/setup.ts
+test.use({ storageState: 'e2e/.auth/driver.json' });
+
+// A syntactically valid UUID that does not belong to any driver — used to
+// assert the 404 path on the (now uuid-validated) history routes.
+const UNKNOWN_DRIVER_UUID = '00000000-0000-4000-8000-0000000000ff';
+
+// The seeded e2e test driver's drivers-table row id (driver.test@example.com).
+// Stable fixture in the rs-dev database; see e2e/test-data-setup.ts.
+const TEST_DRIVER_ROW_ID = '05295b7a-df7d-4ea4-aae8-e9cba3f1c071';
+
+// The history view cold-compiles its route and fetches data client-side — give
+// each test headroom beyond the default 30s so settle waits + downloads fit.
+test.beforeEach(() => {
+  test.setTimeout(60_000);
+});
 
 /**
  * Helper to wait for page to be ready after navigation
  */
 async function waitForPageReady(page: Page) {
-  await page.waitForLoadState('networkidle');
-  await page.waitForTimeout(500);
+  await page.waitForLoadState('domcontentloaded');
+  // The history view fetches its data client-side and shows a spinner until it
+  // resolves — `networkidle` is unreliable here because the page hits a brief
+  // idle window *before* the fetch starts. Instead wait for the settled UI:
+  // the export/date controls (success), the error state, or a sign-in redirect.
+  // Generous timeout covers Next.js dev cold-compile of the history route on
+  // first hit (the page shows a spinner until the data fetch resolves).
+  await page
+    .locator('input[type="date"]')
+    .or(page.getByRole('button', { name: /export|download|pdf|csv/i }))
+    .or(page.getByText(/couldn.t load history/i))
+    .or(page.getByRole('link', { name: /sign in|log ?in/i }))
+    .first()
+    .waitFor({ state: 'visible', timeout: 30000 })
+    .catch(() => {});
+  await page.waitForTimeout(300);
 }
 
 /**
  * Helper to check if authentication is required
  */
 async function checkAuthRequired(page: Page): Promise<boolean> {
-  const signInButton = page.locator('text=Sign In, text=Log in, text=Login').first();
-  return (await signInButton.count()) > 0;
+  // Unauthenticated access to a protected route redirects to the sign-in page.
+  if (/\/sign-in|\/login/.test(page.url())) return true;
+  const signInLink = page.getByRole('link', { name: /sign in|log ?in/i });
+  return (await signInLink.count()) > 0;
 }
 
 /**
@@ -265,8 +298,16 @@ test.describe('Driver History Export', () => {
   });
 
   test.describe('Admin Downloads Driver History', () => {
-    test('should navigate to admin driver management', async ({ page }) => {
-      await page.goto('/admin/drivers');
+    // This section acts as an admin, not the driver. The admin views a specific
+    // driver's history at /admin/drivers/[driverId]/history (there is no
+    // /admin/drivers index page); admin authorization on the underlying
+    // /api/drivers/[driverId]/history route is what this exercises.
+    test.use({ storageState: 'e2e/.auth/admin.json' });
+
+    const adminHistoryUrl = `/admin/drivers/${TEST_DRIVER_ROW_ID}/history`;
+
+    test('admin can reach a driver history page', async ({ page }) => {
+      await page.goto(adminHistoryUrl);
       await waitForPageReady(page);
 
       if (await checkAuthRequired(page)) {
@@ -274,12 +315,12 @@ test.describe('Driver History Export', () => {
         return;
       }
 
-      // Verify we're on an admin page
-      await expect(page).toHaveURL(/\/admin/);
+      // Stays on the admin history route (not redirected to / or /sign-in)
+      await expect(page).toHaveURL(new RegExp(`/admin/drivers/${TEST_DRIVER_ROW_ID}/history`));
     });
 
-    test('should display list of drivers', async ({ page }) => {
-      await page.goto('/admin/drivers');
+    test('admin sees the driver history view (summary / breakdown)', async ({ page }) => {
+      await page.goto(adminHistoryUrl);
       await waitForPageReady(page);
 
       if (await checkAuthRequired(page)) {
@@ -287,28 +328,28 @@ test.describe('Driver History Export', () => {
         return;
       }
 
-      // Look for driver list elements
-      const driverListIndicators = [
-        page.locator('text=Drivers'),
+      // The admin history view renders the same summary + weekly breakdown the
+      // driver sees. Accept any of the section markers.
+      const indicators = [
+        page.getByText(/history/i),
+        page.getByText(/total/i),
+        page.getByText(/week/i),
         page.locator('table'),
-        page.locator('[data-testid*="driver"]'),
-        page.locator('text=Employee ID'),
-        page.locator('text=Name'),
       ];
 
-      let hasDriverList = false;
-      for (const indicator of driverListIndicators) {
+      let hasHistoryView = false;
+      for (const indicator of indicators) {
         if ((await indicator.count()) > 0) {
-          hasDriverList = true;
+          hasHistoryView = true;
           break;
         }
       }
 
-      expect(hasDriverList).toBe(true);
+      expect(hasHistoryView).toBe(true);
     });
 
-    test('should access driver history from driver details', async ({ page }) => {
-      await page.goto('/admin/drivers');
+    test('admin sees export buttons on the driver history page', async ({ page }) => {
+      await page.goto(adminHistoryUrl);
       await waitForPageReady(page);
 
       if (await checkAuthRequired(page)) {
@@ -316,130 +357,93 @@ test.describe('Driver History Export', () => {
         return;
       }
 
-      // Click on first driver in list
-      const driverRow = page.locator('tr').filter({ hasText: /@/ }).first();
-      const driverLink = page.getByRole('link').filter({ hasText: /view|details|history/i }).first();
+      const exportButton = page
+        .getByRole('button', { name: /export|download|pdf|csv/i })
+        .first();
 
-      if ((await driverRow.count()) > 0) {
-        await driverRow.click();
-        await waitForPageReady(page);
-      } else if ((await driverLink.count()) > 0) {
-        await driverLink.click();
-        await waitForPageReady(page);
-      } else {
-        test.skip(true, 'No driver found in list');
-        return;
-      }
-
-      // Look for history section or link
-      const historyIndicators = [
-        page.locator('text=History'),
-        page.getByRole('link', { name: /history/i }),
-        page.getByRole('tab', { name: /history/i }),
-      ];
-
-      let hasHistoryAccess = false;
-      for (const indicator of historyIndicators) {
-        if ((await indicator.count()) > 0) {
-          hasHistoryAccess = true;
-          break;
-        }
-      }
-
-      expect.soft(hasHistoryAccess).toBe(true);
-    });
-
-    test('should download driver history PDF as admin', async ({ page }) => {
-      // Navigate to a specific driver's history
-      await page.goto('/admin/drivers');
-      await waitForPageReady(page);
-
-      if (await checkAuthRequired(page)) {
-        test.skip(true, 'Admin authentication required');
-        return;
-      }
-
-      // This test requires navigating to a specific driver's history page
-      // The exact flow depends on the admin UI implementation
-
-      // Look for export functionality
-      const exportButton = page.getByRole('button', { name: /export|download/i }).first();
-
-      if ((await exportButton.count()) === 0) {
-        test.skip(true, 'No export button found on admin page');
-        return;
-      }
-
-      // Verify button is accessible
+      await expect(exportButton).toBeVisible();
       await expect(exportButton).toBeEnabled();
+    });
+
+    test('admin can fetch the driver history via API', async ({ request }) => {
+      // request inherits the admin storageState from this describe block.
+      const response = await request.get(
+        `/api/drivers/${TEST_DRIVER_ROW_ID}/history`
+      );
+      expect(response.status()).toBe(200);
+      const body = await response.json();
+      expect(body).toHaveProperty('summary');
     });
   });
 
+  // The `request` fixture inherits the driver storageState (test.use above),
+  // so it is authenticated. For the unauthenticated cases we spin up a fresh
+  // request context with no storage state.
   test.describe('History API Endpoints', () => {
-    test('should return 401 when not authenticated', async ({ request }) => {
+    test('should return 401 when not authenticated', async ({ baseURL }) => {
+      // storageState: undefined overrides the file-level driver session, which
+      // Playwright otherwise applies as the default for request.newContext().
+      const anon = await playwrightRequest.newContext({ baseURL, storageState: undefined });
+      const response = await anon.get(`/api/drivers/${UNKNOWN_DRIVER_UUID}/history`);
+      expect(response.status()).toBe(401);
+      await anon.dispose();
+    });
+
+    test('should return 400 for a non-UUID driver id when authenticated', async ({ request }) => {
       const response = await request.get('/api/drivers/test-driver-id/history');
-
-      expect(response.status()).toBe(401);
-
-      const body = await response.json();
-      expect(body).toHaveProperty('error');
+      expect(response.status()).toBe(400);
     });
 
-    test('should return JSON history data when authenticated', async ({ page, request }) => {
-      // First authenticate via page
-      await page.goto('/driver/tracking');
-      await waitForPageReady(page);
-
-      if (await checkAuthRequired(page)) {
-        test.skip(true, 'Authentication required - skipping API test');
-        return;
-      }
-
-      // Get current driver ID from page context or URL
-      // This depends on how the driver ID is exposed in the UI
-
-      // For now, test the endpoint format
-      const testResponse = await request.get('/api/drivers/test/history', {
-        headers: {
-          'Accept': 'application/json',
-        },
+    test('should return 404 for an unknown (valid UUID) driver when authenticated', async ({ request }) => {
+      const response = await request.get(`/api/drivers/${UNKNOWN_DRIVER_UUID}/history`, {
+        headers: { Accept: 'application/json' },
       });
-
-      // Should return 401 (unauthorized) or 404 (not found) or 200 (success)
-      expect([200, 401, 403, 404]).toContain(testResponse.status());
+      // The authed driver does not own this id and it does not exist → 403/404.
+      expect([403, 404]).toContain(response.status());
     });
 
-    test('should support format parameter for CSV', async ({ request }) => {
-      const response = await request.get('/api/drivers/test-driver-id/history?format=csv');
-
-      // Without auth, should return 401
-      expect(response.status()).toBe(401);
-    });
-
-    test('should support date range parameters', async ({ request }) => {
-      const startDate = '2025-01-01';
-      const endDate = '2025-01-31';
-
-      const response = await request.get(
-        `/api/drivers/test-driver-id/history?startDate=${startDate}&endDate=${endDate}`
+    test('should support format parameter for CSV (unauthenticated → 401)', async ({ baseURL }) => {
+      // storageState: undefined overrides the file-level driver session, which
+      // Playwright otherwise applies as the default for request.newContext().
+      const anon = await playwrightRequest.newContext({ baseURL, storageState: undefined });
+      const response = await anon.get(
+        `/api/drivers/${UNKNOWN_DRIVER_UUID}/history?format=csv`
       );
-
-      // Without auth, should return 401
       expect(response.status()).toBe(401);
+      await anon.dispose();
+    });
+
+    test('should support date range parameters (unauthenticated → 401)', async ({ baseURL }) => {
+      // storageState: undefined overrides the file-level driver session, which
+      // Playwright otherwise applies as the default for request.newContext().
+      const anon = await playwrightRequest.newContext({ baseURL, storageState: undefined });
+      const response = await anon.get(
+        `/api/drivers/${UNKNOWN_DRIVER_UUID}/history?startDate=2025-01-01&endDate=2025-01-31`
+      );
+      expect(response.status()).toBe(401);
+      await anon.dispose();
     });
   });
 
   test.describe('Export API Endpoints', () => {
-    test('should return 401 for unauthenticated PDF export', async ({ request }) => {
-      const response = await request.get('/api/drivers/test-driver-id/history/export');
-
+    test('should return 401 for unauthenticated PDF export', async ({ baseURL }) => {
+      // storageState: undefined overrides the file-level driver session, which
+      // Playwright otherwise applies as the default for request.newContext().
+      const anon = await playwrightRequest.newContext({ baseURL, storageState: undefined });
+      const response = await anon.get(`/api/drivers/${UNKNOWN_DRIVER_UUID}/history/export`);
       expect(response.status()).toBe(401);
+      await anon.dispose();
     });
 
-    test('should return 401 for unauthenticated CSV export', async ({ request }) => {
-      const response = await request.get('/api/drivers/test-driver-id/history/export?format=csv');
-
+    test('should return 401 for unauthenticated CSV export', async ({ baseURL }) => {
+      // storageState: undefined overrides the file-level driver session, which
+      // Playwright otherwise applies as the default for request.newContext().
+      const anon = await playwrightRequest.newContext({ baseURL, storageState: undefined });
+      const response = await anon.get(
+        `/api/drivers/${UNKNOWN_DRIVER_UUID}/history/export?format=csv`
+      );
       expect(response.status()).toBe(401);
+      await anon.dispose();
     });
   });
 
@@ -521,7 +525,7 @@ test.describe('Driver History Export', () => {
         }
 
         // Look for error message
-        const errorMessage = page.locator('text=Invalid, text=Error, [role="alert"]').first();
+        const errorMessage = page.getByText(/invalid|error/i).or(page.locator('[role="alert"]')).first();
         // This is expected behavior - soft assertion
         expect.soft(await errorMessage.count()).toBeGreaterThanOrEqual(0);
       }
@@ -556,7 +560,7 @@ test.describe('Full Driver History Export Workflow', () => {
     console.log('✅ Step 1: Navigated to history page');
 
     // Step 2: Verify history data is displayed
-    const historyContent = page.locator('text=Shift, text=Week, text=Total').first();
+    const historyContent = page.getByText(/shift|week|total|deliver/i).first();
     await expect.soft(historyContent).toBeVisible({ timeout: 10000 });
     console.log('✅ Step 2: History data displayed');
 

--- a/e2e/driver-shift-workflow.spec.ts
+++ b/e2e/driver-shift-workflow.spec.ts
@@ -17,6 +17,16 @@
 
 import { test, expect, type Page, type BrowserContext } from '@playwright/test';
 
+// Reuse the driver session created by e2e/auth/setup.ts
+test.use({ storageState: 'e2e/.auth/driver.json' });
+
+// The driver portal acquires geolocation, loads shift state, and (on a dev
+// server) cold-compiles routes on first hit — give each test headroom beyond
+// the default 30s so the settle waits don't collide with the test timeout.
+test.beforeEach(() => {
+  test.setTimeout(60_000);
+});
+
 // Test coordinates for geolocation simulation
 const TEST_LOCATIONS = {
   // Starting location: Los Angeles downtown
@@ -45,18 +55,32 @@ async function setGeolocation(
  * Helper to wait for page to be ready after navigation
  */
 async function waitForPageReady(page: Page) {
-  await page.waitForLoadState('networkidle');
-  // Additional wait for React hydration
-  await page.waitForTimeout(500);
+  await page.waitForLoadState('domcontentloaded');
+  // The driver portal polls continuously and never reaches network idle. Wait
+  // for the portal to settle into a RESOLVED state — geolocation is acquired
+  // asynchronously, so "Request location permission" shows transiently before
+  // "Start shift". Waiting for the resolved control (start/end shift / on shift)
+  // avoids inspecting the portal mid-acquisition. Generous timeout covers
+  // Next.js dev cold-compile of the route on first hit. Catches so the
+  // location-denied test (which never resolves) still proceeds.
+  await page
+    .getByRole('button', { name: /start shift|end shift/i })
+    .or(page.getByText(/on shift/i))
+    .first()
+    .waitFor({ state: 'visible', timeout: 30000 })
+    .catch(() => {});
+  // Additional wait for React hydration / context shift-state load
+  await page.waitForTimeout(1000);
 }
 
 /**
  * Helper to check if driver authentication is required
  */
 async function checkAuthRequired(page: Page): Promise<boolean> {
-  const signInButton = page.locator('text=Sign In, text=Log in, text=Login').first();
-  const authRequired = (await signInButton.count()) > 0;
-  return authRequired;
+  // Unauthenticated access to a protected route redirects to the sign-in page.
+  if (/\/sign-in|\/login/.test(page.url())) return true;
+  const signInLink = page.getByRole('link', { name: /sign in|log ?in/i });
+  return (await signInLink.count()) > 0;
 }
 
 test.describe('Driver Shift Workflow', () => {
@@ -93,14 +117,19 @@ test.describe('Driver Shift Workflow', () => {
         return;
       }
 
-      // Wait for location to be displayed (coordinates format)
-      // The component displays coordinates like "34.0522, -118.2437"
-      const coordsPattern = /34\.\d+.*-118\.\d+/;
-
-      // Look for location display - may take time for GPS to acquire
+      // The redesigned portal no longer prints raw lat/lng. Location acquisition
+      // is reflected by (a) the HealthBar GPS chip showing a "<n>m" accuracy
+      // reading, or (b) the pre-shift "Start shift" CTA, which only appears once
+      // currentLocation resolves, or (c) an already-active shift.
       await expect(async () => {
-        const pageContent = await page.content();
-        expect(pageContent).toMatch(coordsPattern);
+        const gpsAccuracy = page.getByText(/\d+\s*m\b/);
+        const startShift = page.getByRole('button', { name: /start shift/i });
+        const onShift = page.getByText(/on shift/i);
+        const located =
+          (await gpsAccuracy.count()) > 0 ||
+          (await startShift.count()) > 0 ||
+          (await onShift.count()) > 0;
+        expect(located).toBe(true);
       }).toPass({ timeout: 10000 });
     });
 
@@ -153,11 +182,10 @@ test.describe('Driver Shift Workflow', () => {
 
       // Wait for shift to start - should see shift status change
       await expect(async () => {
-        const endShiftButton = page.getByRole('button', { name: /end shift/i });
-        const activeShiftIndicator = page.locator('text=Active Shift, text=Active');
-
-        const hasEndButton = await endShiftButton.count() > 0;
-        const hasActiveIndicator = await activeShiftIndicator.count() > 0;
+        const hasEndButton =
+          (await page.getByRole('button', { name: /end shift/i }).count()) > 0;
+        const hasActiveIndicator =
+          (await page.getByText(/on shift/i).count()) > 0;
 
         expect(hasEndButton || hasActiveIndicator).toBe(true);
       }).toPass({ timeout: 10000 });
@@ -175,36 +203,31 @@ test.describe('Driver Shift Workflow', () => {
         return;
       }
 
-      // Check for active shift indicators
-      const shiftStatusIndicators = [
-        page.locator('text=Active Shift'),
-        page.locator('text=Active'),
-        page.getByRole('button', { name: /end shift/i }),
-        page.locator('text=Duration'),
-      ];
-
-      // At least one indicator should be visible if shift is active
-      let hasActiveShift = false;
-      for (const indicator of shiftStatusIndicators) {
-        if ((await indicator.count()) > 0) {
-          hasActiveShift = true;
-          break;
-        }
-      }
+      // Active shift is signalled by the "On shift" label / "End shift" button.
+      // waitForPageReady already waited for the portal to settle, so the shift
+      // state loaded from the server is reflected before we decide whether to
+      // start one (avoids clicking "Start shift" while one is already active).
+      const isActive = async () =>
+        (await page.getByRole('button', { name: /end shift/i }).count()) > 0 ||
+        (await page.getByText(/on shift/i).count()) > 0;
 
       // If no active shift, start one first
-      if (!hasActiveShift) {
+      if (!(await isActive())) {
         const startButton = page.getByRole('button', { name: /start shift/i });
         if ((await startButton.count()) > 0) {
           await startButton.click();
-          await page.waitForTimeout(2000);
+        } else {
+          test.skip(true, 'Could not start a shift (no Start shift button — location unavailable)');
+          return;
         }
       }
 
       // Now verify shift is active
       await expect(async () => {
-        const activeIndicator = page.locator('text=Active Shift, text=Active, text=Duration').first();
-        expect(await activeIndicator.count()).toBeGreaterThan(0);
+        const active =
+          (await page.getByRole('button', { name: /end shift/i }).count()) > 0 ||
+          (await page.getByText(/on shift/i).count()) > 0;
+        expect(active).toBe(true);
       }).toPass({ timeout: 10000 });
     });
   });
@@ -461,78 +484,11 @@ test.describe('Driver Shift Workflow', () => {
   });
 
   test.describe('Break Management', () => {
-    test('should show break buttons when shift is active', async ({ page, context }) => {
-      await context.grantPermissions(['geolocation']);
-      await setGeolocation(context, TEST_LOCATIONS.start);
-
-      await page.goto('/driver/tracking');
-      await waitForPageReady(page);
-
-      if (await checkAuthRequired(page)) {
-        test.skip(true, 'Driver authentication required');
-        return;
-      }
-
-      // Check if shift is active first
-      const endShiftButton = page.getByRole('button', { name: /end shift/i });
-      if ((await endShiftButton.count()) === 0) {
-        test.skip(true, 'No active shift - break buttons only visible during shift');
-        return;
-      }
-
-      // Look for break buttons
-      const breakButtons = [
-        page.getByRole('button', { name: /break/i }),
-        page.getByRole('button', { name: /meal/i }),
-      ];
-
-      let hasBreakButton = false;
-      for (const button of breakButtons) {
-        if ((await button.count()) > 0) {
-          hasBreakButton = true;
-          break;
-        }
-      }
-
-      expect(hasBreakButton).toBe(true);
-    });
-
-    test('should start break when break button is clicked', async ({ page, context }) => {
-      await context.grantPermissions(['geolocation']);
-      await setGeolocation(context, TEST_LOCATIONS.start);
-
-      await page.goto('/driver/tracking');
-      await waitForPageReady(page);
-
-      if (await checkAuthRequired(page)) {
-        test.skip(true, 'Driver authentication required');
-        return;
-      }
-
-      const breakButton = page.getByRole('button', { name: /break/i }).first();
-
-      if ((await breakButton.count()) === 0) {
-        test.skip(true, 'No break button found');
-        return;
-      }
-
-      // Check if already on break
-      const onBreakIndicator = page.locator('text=On Break');
-      if ((await onBreakIndicator.count()) > 0) {
-        test.skip(true, 'Already on break');
-        return;
-      }
-
-      await breakButton.click();
-      await page.waitForTimeout(2000);
-
-      // Should now show "On Break" status or "End Break" button
-      const endBreakButton = page.getByRole('button', { name: /end break/i });
-      const onBreak = page.locator('text=On Break');
-
-      const isOnBreak = (await endBreakButton.count()) > 0 || (await onBreak.count()) > 0;
-      expect.soft(isOnBreak).toBe(true);
-    });
+    // Break / meal tracking was removed from the redesigned driver portal
+    // (the portal now exposes start shift, advance-delivery, end shift only).
+    // Kept as skipped so the intent is documented if breaks are reintroduced.
+    test.skip('should show break buttons when shift is active', async () => {});
+    test.skip('should start break when break button is clicked', async () => {});
   });
 
   test.describe('End Shift', () => {
@@ -578,13 +534,15 @@ test.describe('Driver Shift Workflow', () => {
       }
 
       await endShiftButton.click();
-      await page.waitForTimeout(2000);
 
-      // Should now show Start Shift button or shift summary
-      const startShiftButton = page.getByRole('button', { name: /start shift/i });
-      const hasStartButton = await startShiftButton.count() > 0;
-
-      expect.soft(hasStartButton).toBe(true);
+      // Ending a shift returns to the pre-shift view ("Start shift" / "Request
+      // location permission"). Poll instead of a fixed wait.
+      await expect(async () => {
+        const backToPreShift =
+          (await page.getByRole('button', { name: /start shift/i }).count()) > 0 ||
+          (await page.getByRole('button', { name: /request location|enable location|try again/i }).count()) > 0;
+        expect(backToPreShift).toBe(true);
+      }).toPass({ timeout: 10000 });
     });
 
     test('should display shift statistics during active shift', async ({ page, context }) => {
@@ -599,21 +557,21 @@ test.describe('Driver Shift Workflow', () => {
         return;
       }
 
-      // Check for shift statistics
-      const statsIndicators = [
-        page.locator('text=Duration'),
-        page.locator('text=Distance'),
-        page.locator('text=Deliveries'),
-        page.locator('text=/\\d+h \\d+m/'), // Duration format
-        page.locator('text=/\\d+ mi/'), // Distance format
-      ];
-
       // Only check if shift is active
       const endShiftButton = page.getByRole('button', { name: /end shift/i });
       if ((await endShiftButton.count()) === 0) {
         test.skip(true, 'No active shift - statistics only visible during shift');
         return;
       }
+
+      // The redesigned portal surfaces live shift stats via the ShiftPill:
+      // an "On shift" label plus a running duration ("M:SS" / "H:MM:SS"), and
+      // "Since <time>" on the control bar.
+      const statsIndicators = [
+        page.getByText(/on shift/i),
+        page.getByText(/\d+:\d{2}/), // running duration
+        page.getByText(/since/i),
+      ];
 
       let hasStats = false;
       for (const indicator of statsIndicators) {
@@ -629,9 +587,16 @@ test.describe('Driver Shift Workflow', () => {
 
   test.describe('Error Handling', () => {
     test('should show error message when location services are denied', async ({ page, context }) => {
-      // Do NOT grant geolocation permission
+      // Do NOT grant geolocation permission. Don't use waitForPageReady here:
+      // it waits for the resolved "Start shift" state, which never appears
+      // without location — wait only for the location-permission prompt.
       await page.goto('/driver/tracking');
-      await waitForPageReady(page);
+      await page.waitForLoadState('domcontentloaded');
+      await page
+        .getByRole('button', { name: /request location|enable location|try again/i })
+        .first()
+        .waitFor({ state: 'visible', timeout: 15000 })
+        .catch(() => {});
 
       if (await checkAuthRequired(page)) {
         test.skip(true, 'Driver authentication required');
@@ -748,9 +713,8 @@ test.describe('Full Shift Workflow Integration', () => {
     await setGeolocation(context, TEST_LOCATIONS.enRoute);
     await page.waitForTimeout(2000);
 
-    // Step 4: Check shift statistics are displayed
-    const durationText = page.locator('text=Duration');
-    await expect.soft(durationText.first()).toBeVisible();
+    // Step 4: Check live shift stats are displayed (ShiftPill: "On shift" + duration)
+    await expect.soft(page.getByText(/on shift/i).first()).toBeVisible();
 
     // Step 5: End shift
     const endButton = page.getByRole('button', { name: /end shift/i });

--- a/e2e/test-data-setup.ts
+++ b/e2e/test-data-setup.ts
@@ -237,10 +237,124 @@ async function createTestOrders(userId: string, userEmail: string) {
   }
 }
 
+// Driver e2e tests (driver-shift-workflow.spec.ts) need the test driver to
+// have at least one active assigned delivery so the "Active deliveries"
+// section, status buttons and POD flow render. The driver portal resolves
+// deliveries via dispatches.driverId = the driver's PROFILE id (see
+// src/app/api/driver-deliveries/route.ts), not the drivers-table row id.
+const TEST_DRIVER_EMAIL = 'driver.test@example.com';
+const DRIVER_ORDER_NUMBER = 'TEST-DRIVER-001';
+
+async function createDriverDeliveryData() {
+  const driverProfile = await prisma.profile.findUnique({
+    where: { email: TEST_DRIVER_EMAIL },
+  });
+  if (!driverProfile) {
+    console.log(`Driver ${TEST_DRIVER_EMAIL} not found - skipping driver delivery seed`);
+    return;
+  }
+
+  const client = await prisma.profile.findUnique({
+    where: { email: 'test-client@example.com' },
+  });
+  if (!client) {
+    console.log('test-client@example.com not found - run setup first');
+    return;
+  }
+
+  // Idempotent: reuse the order if it already exists, just ensure the dispatch
+  const existing = await prisma.cateringRequest.findUnique({
+    where: { orderNumber: DRIVER_ORDER_NUMBER },
+  });
+
+  let orderId: string;
+  let orderUserId: string;
+
+  if (existing) {
+    orderId = existing.id;
+    orderUserId = existing.userId;
+    // Keep the seeded order perpetually "active" for reruns
+    await prisma.cateringRequest.update({
+      where: { id: orderId },
+      data: {
+        status: 'ASSIGNED' as any,
+        driverStatus: 'ASSIGNED' as any,
+        completeDateTime: null,
+        deletedAt: null,
+        pickupDateTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
+        arrivalDateTime: new Date(Date.now() + 3 * 60 * 60 * 1000),
+      },
+    });
+    console.log(`Driver delivery order ${DRIVER_ORDER_NUMBER} already exists - refreshed`);
+  } else {
+    const pickupAddress = await prisma.address.create({
+      data: {
+        street1: '789 Driver Pickup St',
+        city: 'San Francisco',
+        state: 'CA',
+        zip: '94103',
+        createdBy: client.id,
+      },
+    });
+    const deliveryAddress = await prisma.address.create({
+      data: {
+        street1: '321 Driver Dropoff Ave',
+        city: 'San Francisco',
+        state: 'CA',
+        zip: '94110',
+        createdBy: client.id,
+      },
+    });
+
+    const order = await prisma.cateringRequest.create({
+      data: {
+        userId: client.id,
+        orderNumber: DRIVER_ORDER_NUMBER,
+        status: 'ASSIGNED' as any,
+        driverStatus: 'ASSIGNED' as any,
+        orderTotal: 120.0,
+        pickupDateTime: new Date(Date.now() + 2 * 60 * 60 * 1000),
+        arrivalDateTime: new Date(Date.now() + 3 * 60 * 60 * 1000),
+        pickupAddressId: pickupAddress.id,
+        deliveryAddressId: deliveryAddress.id,
+        specialNotes: 'Seeded delivery for driver e2e tests',
+      },
+    });
+    orderId = order.id;
+    orderUserId = client.id;
+    console.log(`Created driver delivery order ${DRIVER_ORDER_NUMBER}`);
+  }
+
+  const dispatch = await prisma.dispatch.findFirst({
+    where: { cateringRequestId: orderId, driverId: driverProfile.id },
+  });
+  if (!dispatch) {
+    await prisma.dispatch.create({
+      data: {
+        cateringRequestId: orderId,
+        driverId: driverProfile.id,
+        userId: orderUserId,
+      },
+    });
+    console.log(`Dispatched ${DRIVER_ORDER_NUMBER} to ${TEST_DRIVER_EMAIL}`);
+  }
+}
+
 async function cleanupTestData() {
   console.log('Cleaning up test data...');
 
   try {
+    // Delete the seeded driver delivery (dispatch first, FK constraint)
+    const driverOrder = await prisma.cateringRequest.findUnique({
+      where: { orderNumber: DRIVER_ORDER_NUMBER },
+    });
+    if (driverOrder) {
+      await prisma.dispatch.deleteMany({
+        where: { cateringRequestId: driverOrder.id },
+      });
+      await prisma.cateringRequest.delete({ where: { id: driverOrder.id } });
+    }
+
     // Delete test orders first (due to foreign key constraints)
     for (const order of testOrders) {
       if (order.orderType === 'catering') {
@@ -300,6 +414,7 @@ async function main() {
 
   if (action === 'setup') {
     await createTestUsers();
+    await createDriverDeliveryData();
     console.log('Test data setup completed successfully!');
   } else if (action === 'cleanup') {
     await cleanupTestData();

--- a/src/app/api/drivers/[driverId]/history/__tests__/route.test.ts
+++ b/src/app/api/drivers/[driverId]/history/__tests__/route.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Tests for /api/drivers/[driverId]/history and /api/drivers/[driverId]/history/export
+ *
+ * These routes expose driver shift/delivery history (JSON, CSV, PDF).
+ *
+ * Tests cover:
+ * - 401 for unauthenticated requests (via withAuth)
+ * - 400 for non-UUID driver ids (must not reach Prisma, which throws → 500)
+ * - 404 for unknown drivers
+ * - 403 for a driver requesting another driver's history
+ * - 200 for own data and for admins on any driver
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { GET as getHistory } from "../route";
+import { GET as getExport } from "../export/route";
+import { withAuth } from "@/lib/auth-middleware";
+import { getDriverForUser } from "@/lib/auth/driver-ownership";
+import { prisma } from "@/utils/prismaDB";
+import {
+  generateDriverHistoryPDF,
+  generateDriverHistoryCSV,
+} from "@/lib/pdf/driver-history-pdf";
+import { createGetRequest } from "@/__tests__/helpers/api-test-helpers";
+
+jest.mock("@/lib/auth-middleware", () => ({
+  withAuth: jest.fn(),
+}));
+
+jest.mock("@/lib/auth/driver-ownership", () => ({
+  getDriverForUser: jest.fn(),
+}));
+
+jest.mock("@/utils/prismaDB", () => ({
+  prisma: {
+    driver: {
+      findFirst: jest.fn(),
+    },
+    driverWeeklySummary: {
+      findMany: jest.fn(),
+    },
+    driverShift: {
+      findMany: jest.fn(),
+    },
+    delivery: {
+      count: jest.fn(),
+    },
+    $queryRaw: jest.fn(),
+  },
+}));
+
+jest.mock("@/lib/pdf/driver-history-pdf", () => ({
+  generateDriverHistoryPDF: jest.fn(),
+  generateDriverHistoryCSV: jest.fn(),
+}));
+
+jest.mock("@sentry/nextjs", () => ({
+  captureException: jest.fn(),
+}));
+
+// next.config.js modularizeImports rewrites `date-fns` named imports to
+// `date-fns/{{member}}`, whose CJS interop leaves `.default` undefined under
+// jest. Mock the submodules the routes use.
+jest.mock("date-fns/format", () => {
+  const fn = (d: Date | string) => new Date(d).toISOString().slice(0, 10);
+  return { __esModule: true, default: fn, format: fn };
+});
+jest.mock("date-fns/parseISO", () => {
+  const fn = (s: string) => new Date(s);
+  return { __esModule: true, default: fn, parseISO: fn };
+});
+jest.mock("date-fns/subWeeks", () => {
+  const fn = (d: Date | string, n: number) =>
+    new Date(new Date(d).getTime() - n * 7 * 24 * 60 * 60 * 1000);
+  return { __esModule: true, default: fn, subWeeks: fn };
+});
+jest.mock("date-fns/startOfWeek", () => {
+  const fn = (d: Date | string) => new Date(d);
+  return { __esModule: true, default: fn, startOfWeek: fn };
+});
+
+const mockWithAuth = withAuth as jest.MockedFunction<typeof withAuth>;
+const mockGetDriverForUser = getDriverForUser as jest.MockedFunction<
+  typeof getDriverForUser
+>;
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+const mockGeneratePDF = generateDriverHistoryPDF as jest.MockedFunction<
+  typeof generateDriverHistoryPDF
+>;
+const mockGenerateCSV = generateDriverHistoryCSV as jest.MockedFunction<
+  typeof generateDriverHistoryCSV
+>;
+
+const DRIVER_ID = "05295b7a-0000-4000-8000-000000000001";
+const OTHER_DRIVER_ID = "05295b7a-0000-4000-8000-000000000002";
+const AUTH_USER_ID = "3d3de599-0000-4000-8000-000000000003";
+
+const driverRow = {
+  id: DRIVER_ID,
+  employeeId: "driver-test",
+  vehicleNumber: "V-1",
+  profile: { id: AUTH_USER_ID, name: "Test Driver", email: "driver.test@example.com" },
+};
+
+function authAs(type: "DRIVER" | "ADMIN", id = AUTH_USER_ID) {
+  mockWithAuth.mockResolvedValueOnce({
+    success: true,
+    context: {
+      user: { id, email: "x@example.com", type },
+    },
+  } as any);
+}
+
+function authRejected(status = 401) {
+  mockWithAuth.mockResolvedValueOnce({
+    success: false,
+    response: NextResponse.json({ error: "Unauthorized" }, { status }),
+    context: { user: { id: "", email: "", type: "CLIENT" } },
+  } as any);
+}
+
+function makeContext(driverId: string) {
+  return { params: Promise.resolve({ driverId }) };
+}
+
+function historyRequest(driverId: string, query = ""): NextRequest {
+  return createGetRequest(
+    `http://localhost:3000/api/drivers/${driverId}/history${query}`
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (mockPrisma.driverWeeklySummary.findMany as jest.Mock).mockResolvedValue([]);
+  (mockPrisma.driverShift.findMany as jest.Mock).mockResolvedValue([]);
+  (mockPrisma.$queryRaw as jest.Mock).mockResolvedValue([]);
+  (mockPrisma.delivery.count as jest.Mock).mockResolvedValue(0);
+});
+
+describe("GET /api/drivers/[driverId]/history", () => {
+  it("returns 401 when unauthenticated", async () => {
+    authRejected();
+    const res = await getHistory(historyRequest(DRIVER_ID), makeContext(DRIVER_ID));
+    expect(res.status).toBe(401);
+    expect(mockPrisma.driver.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a non-UUID driver id without touching Prisma", async () => {
+    authAs("ADMIN");
+    const res = await getHistory(
+      historyRequest("test-driver-id"),
+      makeContext("test-driver-id")
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid driver ID");
+    expect(mockPrisma.driver.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the driver does not exist", async () => {
+    authAs("ADMIN");
+    (mockPrisma.driver.findFirst as jest.Mock).mockResolvedValueOnce(null);
+    const res = await getHistory(historyRequest(DRIVER_ID), makeContext(DRIVER_ID));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when a driver requests another driver's history", async () => {
+    authAs("DRIVER");
+    (mockPrisma.driver.findFirst as jest.Mock).mockResolvedValueOnce({
+      ...driverRow,
+      id: OTHER_DRIVER_ID,
+    });
+    mockGetDriverForUser.mockResolvedValueOnce({
+      id: DRIVER_ID,
+      isActive: true,
+      currentShiftId: null,
+    });
+    const res = await getHistory(
+      historyRequest(OTHER_DRIVER_ID),
+      makeContext(OTHER_DRIVER_ID)
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when the caller has no driver row", async () => {
+    authAs("DRIVER");
+    (mockPrisma.driver.findFirst as jest.Mock).mockResolvedValueOnce(driverRow);
+    mockGetDriverForUser.mockResolvedValueOnce(null);
+    const res = await getHistory(historyRequest(DRIVER_ID), makeContext(DRIVER_ID));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 200 with history for the driver's own data", async () => {
+    authAs("DRIVER");
+    (mockPrisma.driver.findFirst as jest.Mock).mockResolvedValueOnce(driverRow);
+    mockGetDriverForUser.mockResolvedValueOnce({
+      id: DRIVER_ID,
+      isActive: true,
+      currentShiftId: null,
+    });
+    const res = await getHistory(historyRequest(DRIVER_ID), makeContext(DRIVER_ID));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.driver.id).toBe(DRIVER_ID);
+    expect(body.summary).toBeDefined();
+    expect(body.weeklySummaries).toEqual([]);
+  });
+
+  it("returns 200 for an admin on any driver without an ownership lookup", async () => {
+    authAs("ADMIN");
+    (mockPrisma.driver.findFirst as jest.Mock).mockResolvedValueOnce(driverRow);
+    const res = await getHistory(historyRequest(DRIVER_ID), makeContext(DRIVER_ID));
+    expect(res.status).toBe(200);
+    expect(mockGetDriverForUser).not.toHaveBeenCalled();
+  });
+
+  it("returns CSV when format=csv", async () => {
+    authAs("ADMIN");
+    (mockPrisma.driver.findFirst as jest.Mock).mockResolvedValueOnce(driverRow);
+    const res = await getHistory(
+      historyRequest(DRIVER_ID, "?format=csv"),
+      makeContext(DRIVER_ID)
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/csv");
+  });
+});
+
+describe("GET /api/drivers/[driverId]/history/export", () => {
+  beforeEach(() => {
+    mockGeneratePDF.mockResolvedValue({
+      success: true,
+      buffer: Buffer.from("%PDF-fake"),
+      filename: "history.pdf",
+    } as any);
+    mockGenerateCSV.mockResolvedValue({
+      success: true,
+      csv: "a,b\n1,2",
+      filename: "history.csv",
+    } as any);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    authRejected();
+    const res = await getExport(historyRequest(DRIVER_ID), makeContext(DRIVER_ID));
+    expect(res.status).toBe(401);
+    expect(mockPrisma.driver.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a non-UUID driver id without touching Prisma", async () => {
+    authAs("ADMIN");
+    const res = await getExport(
+      historyRequest("test-driver-id"),
+      makeContext("test-driver-id")
+    );
+    expect(res.status).toBe(400);
+    expect(mockPrisma.driver.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the driver does not exist", async () => {
+    authAs("ADMIN");
+    (mockPrisma.driver.findFirst as jest.Mock).mockResolvedValueOnce(null);
+    const res = await getExport(historyRequest(DRIVER_ID), makeContext(DRIVER_ID));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when a driver exports another driver's history", async () => {
+    authAs("DRIVER");
+    (mockPrisma.driver.findFirst as jest.Mock).mockResolvedValueOnce({
+      ...driverRow,
+      id: OTHER_DRIVER_ID,
+    });
+    mockGetDriverForUser.mockResolvedValueOnce({
+      id: DRIVER_ID,
+      isActive: true,
+      currentShiftId: null,
+    });
+    const res = await getExport(
+      historyRequest(OTHER_DRIVER_ID),
+      makeContext(OTHER_DRIVER_ID)
+    );
+    expect(res.status).toBe(403);
+    expect(mockGeneratePDF).not.toHaveBeenCalled();
+  });
+
+  it("returns a PDF for the driver's own data", async () => {
+    authAs("DRIVER");
+    (mockPrisma.driver.findFirst as jest.Mock).mockResolvedValueOnce(driverRow);
+    mockGetDriverForUser.mockResolvedValueOnce({
+      id: DRIVER_ID,
+      isActive: true,
+      currentShiftId: null,
+    });
+    const res = await getExport(historyRequest(DRIVER_ID), makeContext(DRIVER_ID));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/pdf");
+  });
+
+  it("returns CSV when format=csv as admin", async () => {
+    authAs("ADMIN");
+    (mockPrisma.driver.findFirst as jest.Mock).mockResolvedValueOnce(driverRow);
+    const res = await getExport(
+      historyRequest(DRIVER_ID, "?format=csv"),
+      makeContext(DRIVER_ID)
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/csv");
+  });
+});

--- a/src/app/api/drivers/[driverId]/history/export/route.ts
+++ b/src/app/api/drivers/[driverId]/history/export/route.ts
@@ -11,7 +11,9 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
-import { createClient } from '@/utils/supabase/server';
+import { z } from 'zod';
+import { withAuth } from '@/lib/auth-middleware';
+import { getDriverForUser } from '@/lib/auth/driver-ownership';
 import { prisma } from '@/utils/prismaDB';
 import { parseISO, subWeeks, startOfWeek } from 'date-fns';
 import {
@@ -23,9 +25,9 @@ export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 export const maxDuration = 60; // PDF generation can take time
 
-interface AppMetadata {
-  role?: string;
-}
+const paramsSchema = z.object({
+  driverId: z.string().uuid('Invalid driver ID format'),
+});
 
 interface RouteParams {
   params: Promise<{ driverId: string }>;
@@ -41,22 +43,28 @@ interface RouteParams {
  */
 export async function GET(request: NextRequest, context: RouteParams) {
   try {
-    const { driverId } = await context.params;
+    // Authenticate request
+    const authResult = await withAuth(request, {
+      allowedRoles: ['DRIVER', 'ADMIN', 'SUPER_ADMIN', 'HELPDESK'],
+      requireAuth: true,
+    });
 
-    // Authorize user
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    if (!authResult.success) {
+      return authResult.response!;
     }
 
-    const isAdminUser = (user.app_metadata as AppMetadata)?.role === 'admin';
-    const isSuperAdmin = (user.app_metadata as AppMetadata)?.role === 'super_admin';
+    const { context: authContext } = authResult;
 
-    // Check if user can access this driver's data
+    // Validate route params before they reach Prisma (non-UUID ids throw)
+    const paramsValidation = paramsSchema.safeParse(await context.params);
+    if (!paramsValidation.success) {
+      return NextResponse.json(
+        { error: 'Invalid driver ID', details: paramsValidation.error.issues },
+        { status: 400 }
+      );
+    }
+    const { driverId } = paramsValidation.data;
+
     const driver = await prisma.driver.findFirst({
       where: { id: driverId, deletedAt: null },
       include: {
@@ -70,15 +78,16 @@ export async function GET(request: NextRequest, context: RouteParams) {
       return NextResponse.json({ error: 'Driver not found' }, { status: 404 });
     }
 
-    // Drivers can only access their own history
-    const isOwnData = driver.profile?.id === user.id;
-    const isAuthorized = isOwnData || isAdminUser || isSuperAdmin;
-
-    if (!isAuthorized) {
-      return NextResponse.json(
-        { error: 'Unauthorized - you can only export your own history' },
-        { status: 403 }
-      );
+    // Drivers can only export their own history; ownership goes through the
+    // driver-ownership module (accepts either profile_id or legacy user_id).
+    if (authContext.user.type === 'DRIVER') {
+      const ownDriver = await getDriverForUser(authContext.user.id);
+      if (!ownDriver || ownDriver.id !== driverId) {
+        return NextResponse.json(
+          { error: 'Unauthorized - you can only export your own history' },
+          { status: 403 }
+        );
+      }
     }
 
     // Parse query parameters

--- a/src/app/api/drivers/[driverId]/history/route.ts
+++ b/src/app/api/drivers/[driverId]/history/route.ts
@@ -11,16 +11,18 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
-import { createClient } from '@/utils/supabase/server';
+import { z } from 'zod';
+import { withAuth } from '@/lib/auth-middleware';
+import { getDriverForUser } from '@/lib/auth/driver-ownership';
 import { prisma } from '@/utils/prismaDB';
 import { format, parseISO, subWeeks, startOfWeek } from 'date-fns';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
 
-interface AppMetadata {
-  role?: string;
-}
+const paramsSchema = z.object({
+  driverId: z.string().uuid('Invalid driver ID format'),
+});
 
 interface RouteParams {
   params: Promise<{ driverId: string }>;
@@ -37,22 +39,28 @@ interface RouteParams {
  */
 export async function GET(request: NextRequest, context: RouteParams) {
   try {
-    const { driverId } = await context.params;
+    // Authenticate request
+    const authResult = await withAuth(request, {
+      allowedRoles: ['DRIVER', 'ADMIN', 'SUPER_ADMIN', 'HELPDESK'],
+      requireAuth: true,
+    });
 
-    // Authorize user
-    const supabase = await createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    if (!authResult.success) {
+      return authResult.response!;
     }
 
-    const isAdminUser = (user.app_metadata as AppMetadata)?.role === 'admin';
-    const isSuperAdmin = (user.app_metadata as AppMetadata)?.role === 'super_admin';
+    const { context: authContext } = authResult;
 
-    // Check if user can access this driver's data
+    // Validate route params before they reach Prisma (non-UUID ids throw)
+    const paramsValidation = paramsSchema.safeParse(await context.params);
+    if (!paramsValidation.success) {
+      return NextResponse.json(
+        { error: 'Invalid driver ID', details: paramsValidation.error.issues },
+        { status: 400 }
+      );
+    }
+    const { driverId } = paramsValidation.data;
+
     const driver = await prisma.driver.findFirst({
       where: { id: driverId, deletedAt: null },
       include: {
@@ -66,15 +74,16 @@ export async function GET(request: NextRequest, context: RouteParams) {
       return NextResponse.json({ error: 'Driver not found' }, { status: 404 });
     }
 
-    // Drivers can only access their own history
-    const isOwnData = driver.profile?.id === user.id;
-    const isAuthorized = isOwnData || isAdminUser || isSuperAdmin;
-
-    if (!isAuthorized) {
-      return NextResponse.json(
-        { error: 'Unauthorized - you can only access your own history' },
-        { status: 403 }
-      );
+    // Drivers can only access their own history; ownership goes through the
+    // driver-ownership module (accepts either profile_id or legacy user_id).
+    if (authContext.user.type === 'DRIVER') {
+      const ownDriver = await getDriverForUser(authContext.user.id);
+      if (!ownDriver || ownDriver.id !== driverId) {
+        return NextResponse.json(
+          { error: 'Unauthorized - you can only access your own history' },
+          { status: 403 }
+        );
+      }
     }
 
     // Parse query parameters


### PR DESCRIPTION
## Why

While verifying the driver flow after the #441 driver-ownership overhaul, two things surfaced:

1. **A real authz bug** in the driver-history routes — they predated #441 and never adopted the ownership convention.
2. **The driver Playwright e2e suite had never actually run** — no driver auth existed, so every test silently landed on the public sign-in page.

## What

### `security:` — driver-history route authz
`GET /api/drivers/[driverId]/history` and `.../history/export` now match the sibling `stats` route:
- **uuid-validate** `driverId` (was returning **500** on non-UUID ids because the raw param hit Prisma first → now **400**)
- authenticate via `withAuth({ allowedRoles })`
- resolve ownership through `getDriverForUser()` in `src/lib/auth/driver-ownership.ts` — accepts the canonical `profile_id` **or** the legacy `user_id` (the inline `driver.profile?.id === user.id` check missed the legacy linkage, the exact class of bug #441 fixed)

New route tests cover 400 / 401 / 403 / 404 / 200 for both JSON history and PDF/CSV export.

### `test:` — runnable driver e2e suite
- Added DRIVER + ADMIN logins to `e2e/auth/setup.ts`; specs reuse the saved sessions.
- Aligned assertions with the **redesigned driver portal** ("On shift"/"End shift", "Active deliveries", GPS-accuracy chip); removed break-management assertions (feature was removed); replaced invalid `text=A, text=B` comma-union locators with real `.or()`/regex locators.
- Rewrote the unauthenticated API checks to use a **true anon request context** and the new 400/404 paths; pointed the admin section at the real `/admin/drivers/[id]/history` route.
- Seeded an active assigned delivery for the test driver (`e2e/test-data-setup.ts`).
- Documented `TEST_DRIVER_*` / `TEST_ADMIN_*`, the **pooler** `DATABASE_URL` requirement, and serial execution.

## Verification

- `pnpm test -- driver tracking deliver` → **2,048 passed**, 0 failed (incl. new route tests).
- `pnpm pre-push-check` → green (typecheck + prisma + lint).
- Driver e2e (`playwright test driver --project=chromium --workers=1`): **36 passed / 11 skipped / 0 failed** across two consecutive runs.
- Live-server route matrix confirmed via curl: anon→401, non-UUID→400, foreign id→404, own→200, admin→200.

> Note: the driver specs require the `driver.test@example.com` / `admin.test@example.com` accounts in the rs-dev Supabase project (created as part of this work) and should run serially — see `e2e/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)