### PR TITLE
fix(driver): walk-test blockers — POD upload, end-shift guard, Connecting hang, labels & empty states

### DIFF
--- a/docs/issues-tracker/README.md
+++ b/docs/issues-tracker/README.md
@@ -1,0 +1,22 @@
+# Driver App — Issues Tracker (2026-06-16 walk test)
+
+First real-device GPS walk test (Emmanuel, CDMX, `development` → rs-dev). Screenshots in this folder (`IMG_0825`–`0835`, `Driver Tracking Portal …png`) are the evidence; **`IMG_0835` shows the POD upload failure** ("Failed to upload proof of delivery", only "Try Again"). Full plan: `~/.claude/plans/awesome-we-have-a-crispy-bird.md`.
+
+**Branches:** PR1 (blocking bugs) = `fix/driver-walk-test-blockers`. PR2 (perf/persistence) + signature = follow-ups.
+
+Legend: ✅ fixed (PR1) · 🔜 PR2 · ⏸️ deferred (awaiting design) · 📝 follow-up
+
+| # | Issue (reporter words) | Surface | Root cause | Fix | Status |
+|---|---|---|---|---|---|
+| a | "Dashboard shows *En route to Resto* even before the driver starts the shift" | Admin order/status views | Informal "Resto" copy; status display reflects the stored `driverStatus`, and stale test rows carried `EN_ROUTE_TO_VENDOR` | Copy "Resto" → "Restaurant" (`delivery-status-transitions.ts`, `Orders/DriverStatus.tsx`, `useDeliveryStatusRealtime.ts`); stale rows cleaned in rs-dev | ✅ |
+| b | "Blank squares appear when the driver has no info" | Driver Home (stats/cards) | `StatTile` rendered `value` raw → null/NaN = blank tile; `DriverStatsPanel` called `.toFixed()`/`Math.round()` on possibly-undefined stats | `StatTile` "—" fallback; coalesce stats `?? 0`; `DeliveryCard` stop-name fallback | ✅ |
+| c | "App feels sluggish — loading things all the time" | Whole driver flow | 60s poll **+** refetch on every `visibilitychange` (storm) replacing content with spinners; uncached mount fetches | Background refetch + debounce/TanStack-Query migration; consolidate mount fetches | 🔜 PR2 |
+| d | "Driver app shows *Assigned – In progress*" | Driver delivery timeline | `StatusTimeline` showed "In progress now" on the active step even when that step is ASSIGNED (not started) | ASSIGNED active step now reads "Awaiting start" | ✅ |
+| e | "Driver status shows *Connecting…* on /admin/catering-orders/[order]" | Admin order detail | `useDeliveryStatusRealtime` subscribed with **no pre-auth check and no timeout** → hangs `isConnecting=true` forever when the browser has no session (REA-DRT-07) | Pre-connect `getSession()` check + 12s timeout → resolves to "Offline" (clickable to reconnect) | ✅ |
+| f | "Tab switch sometimes errors; switching apps stops tracking" | Driver tracking | Visibility handlers don't re-arm `watchPosition` / reconnect a disconnected channel; mobile suspends background GPS; handlers can fire against torn-down refs | Re-arm watch + reconnect on visible; guard handlers; optional wake-lock; document web background-GPS limits | 🔜 PR2 |
+| g | "Recipient signature + printed name not implemented" | POD | Photo-only POD; schema has unused `deliverySignatureUrl`/`signatureRequired`/`photoRequired` but no `recipient_name` | Signature-pad + name capture, `recipient_name` migration, storage + upload | ⏸️ awaiting Claude Design (own PR) |
+| h | "POD photo upload errors with no skip; couldn't finish delivery — yet could still end the shift" | Driver POD + shift | (1) POD route wrote dead `proof_of_delivery`/`metadata` columns → 500; (2) POD hard-gated with no fallback; (3) `endDriverShift` had no active-delivery guard | (1) Use real `delivery_photo_url`/`delivery_notes` (+pod-gallery); (2) "Complete anyway — upload later" via `usePODOfflineQueue`; (3) end-shift blocks on active deliveries (admin `force`) | ✅ |
+
+## Also found / deferred
+- **Live location not persisting** — with realtime on, GPS broadcasts over WebSocket (admin "Live Data") but `driver_locations` got 0 writes → no history/trail/mileage. Dual-write fix → **🔜 PR2**.
+- **Dead-column landmines (same class as #h, NOT in the walk path):** `/api/tracking/deliveries/[id]` GET/PATCH and the base-route `POST /api/tracking/deliveries` still reference `proof_of_delivery`/`metadata`/`catering_request_id`/`on_demand_id`/`completed_at`. No UI callers (the portal uses server actions), so they don't block the driver — **📝 follow-up** to align them (and the `createDelivery` server action) with the real schema.

--- a/src/__tests__/actions/tracking/driver-actions.test.ts
+++ b/src/__tests__/actions/tracking/driver-actions.test.ts
@@ -193,6 +193,8 @@ describe('Driver Tracking Actions', () => {
         driver_id: validDriverId,
         status: 'active',
       }]);
+      // End-shift guard: blocking active-delivery count (none).
+      (mockPrisma.$queryRawUnsafe as jest.Mock).mockResolvedValueOnce([{ n: 0 }]);
       // Mock UPDATE shift with end time
       (mockPrisma.$executeRawUnsafe as jest.Mock).mockResolvedValueOnce(1);
       // Mock UPDATE shift with mileage (safety net)
@@ -233,6 +235,8 @@ describe('Driver Tracking Actions', () => {
         driver_id: validDriverId,
         status: 'paused',
       }]);
+      // End-shift guard: blocking active-delivery count (none).
+      (mockPrisma.$queryRawUnsafe as jest.Mock).mockResolvedValueOnce([{ n: 0 }]);
       (mockPrisma.$executeRawUnsafe as jest.Mock).mockResolvedValue(1);
 
       const result = await endDriverShift(validShiftId, mockLocationUpdate);
@@ -245,6 +249,8 @@ describe('Driver Tracking Actions', () => {
         driver_id: validDriverId,
         status: 'active',
       }]);
+      // End-shift guard: blocking active-delivery count (none).
+      (mockPrisma.$queryRawUnsafe as jest.Mock).mockResolvedValueOnce([{ n: 0 }]);
       (mockPrisma.$executeRawUnsafe as jest.Mock).mockRejectedValueOnce(
         new Error('Database error')
       );
@@ -260,9 +266,45 @@ describe('Driver Tracking Actions', () => {
         driver_id: validDriverId,
         status: 'active',
       }]);
+      // End-shift guard: blocking active-delivery count (none).
+      (mockPrisma.$queryRawUnsafe as jest.Mock).mockResolvedValueOnce([{ n: 0 }]);
       (mockPrisma.$executeRawUnsafe as jest.Mock).mockResolvedValue(1);
 
       const result = await endDriverShift(validShiftId, mockLocationUpdate, 25.5);
+
+      expect(result.success).toBe(true);
+    });
+
+    it('blocks ending a shift while active deliveries remain', async () => {
+      (mockPrisma.$queryRawUnsafe as jest.Mock).mockResolvedValueOnce([{
+        driver_id: validDriverId,
+        status: 'active',
+      }]);
+      // Blocking guard reports active deliveries → end is refused.
+      (mockPrisma.$queryRawUnsafe as jest.Mock).mockResolvedValueOnce([{ n: 2 }]);
+
+      const result = await endDriverShift(validShiftId, mockLocationUpdate);
+
+      expect(result.success).toBe(false);
+      expect(result.activeDeliveries).toBe(2);
+      expect(mockPrisma.$executeRawUnsafe).not.toHaveBeenCalled();
+    });
+
+    it('lets an admin force-end a shift with active deliveries', async () => {
+      mockGetActionCaller.mockResolvedValue({ userId: 'admin-1', isPrivileged: true });
+      (mockPrisma.$queryRawUnsafe as jest.Mock).mockResolvedValueOnce([{
+        driver_id: validDriverId,
+        status: 'active',
+      }]);
+      // force=true + privileged skips the blocking query entirely.
+      (mockPrisma.$executeRawUnsafe as jest.Mock).mockResolvedValue(1);
+
+      const result = await endDriverShift(
+        validShiftId,
+        mockLocationUpdate,
+        undefined,
+        { force: true },
+      );
 
       expect(result.success).toBe(true);
     });

--- a/src/app/actions/tracking/delivery-actions.ts
+++ b/src/app/actions/tracking/delivery-actions.ts
@@ -329,7 +329,7 @@ export async function getDriverActiveDeliveries(driverId: string): Promise<Deliv
         d.updated_at
       FROM deliveries d
       WHERE d.driver_id = $1::uuid
-      AND d.status NOT IN ('DELIVERED', 'CANCELLED')
+      AND d.status NOT IN ('COMPLETED', 'DELIVERED', 'CANCELLED')
       AND d.deleted_at IS NULL
       ORDER BY d.assigned_at ASC
     `, driverId);

--- a/src/app/actions/tracking/driver-actions.ts
+++ b/src/app/actions/tracking/driver-actions.ts
@@ -20,7 +20,7 @@ import {
   calculateShiftMileageWithBreakdown,
   calculateShiftMileageWithValidation,
 } from '@/services/tracking/mileage';
-import { callerMayActOnDriver } from '@/lib/auth/driver-ownership';
+import { callerMayActOnDriver, getActionCaller } from '@/lib/auth/driver-ownership';
 
 /**
  * Start a new driver shift
@@ -120,7 +120,7 @@ export async function endDriverShift(
   endLocation: LocationUpdate,
   finalMileage?: number,
   metadata: Record<string, any> = {}
-): Promise<{ success: boolean; error?: string }> {
+): Promise<{ success: boolean; error?: string; activeDeliveries?: number }> {
   try {
     // Get shift info and ensure it is active before proceeding
     const shiftInfo = await prisma.$queryRawUnsafe<{
@@ -143,6 +143,48 @@ export async function endDriverShift(
     // AuthZ: only the shift's driver (or an admin) may end it.
     if (!(await callerMayActOnDriver(shift?.driver_id))) {
       return { success: false, error: 'Access denied' };
+    }
+
+    // Guard: a driver may not end a shift while they still have active
+    // deliveries — doing so would strand an in-progress order. Admins may
+    // override by passing metadata.force. "Active" = a non-terminal row in the
+    // `deliveries` table (what the live portal shows), or a catering/on-demand
+    // order the driver has actually started (driverStatus in a movement stage).
+    const caller = await getActionCaller();
+    const force = metadata?.force === true && (caller?.isPrivileged ?? false);
+    if (!force) {
+      const blocking = await prisma.$queryRawUnsafe<{ n: bigint }[]>(`
+        SELECT
+          (
+            SELECT COUNT(*) FROM deliveries
+            WHERE driver_id = $1::uuid
+              AND deleted_at IS NULL
+              AND status NOT IN ('COMPLETED','CANCELLED','DELIVERED')
+          )
+          +
+          (
+            SELECT COUNT(*)
+            FROM dispatches di
+            LEFT JOIN catering_requests cr ON cr.id = di."cateringRequestId"
+            LEFT JOIN on_demand_requests od ON od.id = di."onDemandId"
+            WHERE di."driverId" = (SELECT profile_id FROM drivers WHERE id = $1::uuid)
+              AND (
+                (cr.id IS NOT NULL AND cr."deletedAt" IS NULL
+                  AND cr."driverStatus" IN ('EN_ROUTE_TO_VENDOR','ARRIVED_AT_VENDOR','PICKED_UP','EN_ROUTE_TO_CLIENT','ARRIVED_TO_CLIENT'))
+                OR (od.id IS NOT NULL AND od."deletedAt" IS NULL
+                  AND od."driverStatus" IN ('EN_ROUTE_TO_VENDOR','ARRIVED_AT_VENDOR','PICKED_UP','EN_ROUTE_TO_CLIENT','ARRIVED_TO_CLIENT'))
+              )
+          ) AS n
+      `, shift?.driver_id);
+
+      const activeCount = Number(blocking[0]?.n ?? 0);
+      if (activeCount > 0) {
+        return {
+          success: false,
+          error: `You still have ${activeCount} active ${activeCount === 1 ? 'delivery' : 'deliveries'}. Complete or cancel ${activeCount === 1 ? 'it' : 'them'} before ending your shift.`,
+          activeDeliveries: activeCount,
+        };
+      }
     }
 
     // Always record the end location in the database first so that the

--- a/src/app/api/tracking/deliveries/[id]/pod/route.ts
+++ b/src/app/api/tracking/deliveries/[id]/pod/route.ts
@@ -33,7 +33,7 @@ export async function POST(
 
     // Verify delivery exists and user has permission
     const verifyQuery = `
-      SELECT d.id, d.proof_of_delivery, d.driver_id
+      SELECT d.id, d.driver_id
       FROM deliveries d
       WHERE d.id = $1
     `;
@@ -41,7 +41,6 @@ export async function POST(
     const verifyResult = await prisma.$queryRawUnsafe<
       {
         id: string;
-        proof_of_delivery: string | null;
         driver_id: string | null;
       }[]
     >(verifyQuery, deliveryId);
@@ -108,23 +107,24 @@ export async function POST(
       );
     }
 
-    // Update the delivery record with the photo URL
+    // Update the delivery record with the photo URL. NOTE: the `deliveries`
+    // table has no `proof_of_delivery`/`metadata` columns — the real column is
+    // `delivery_photo_url`. Audit details (uploader, timestamp, storage path)
+    // are appended to `delivery_notes`, mirroring uploadProofOfDelivery in
+    // src/app/actions/tracking/delivery-actions.ts. The storage path is kept in
+    // the note so DELETE can recover it without a metadata column.
     await prisma.$executeRawUnsafe(
       `
       UPDATE deliveries
       SET
-        proof_of_delivery = $2,
-        metadata = COALESCE(metadata, '{}'::jsonb) || $3::jsonb,
+        delivery_photo_url = $2,
+        delivery_notes = COALESCE(delivery_notes, '') || $3,
         updated_at = NOW()
       WHERE id = $1::uuid
     `,
       deliveryId,
       uploadResult.url,
-      JSON.stringify({
-        podUploadedAt: new Date().toISOString(),
-        podUploadedBy: authResult.context.user.id,
-        podStoragePath: uploadResult.path,
-      })
+      ` [POD photo uploaded ${new Date().toISOString()} by ${authResult.context.user.id} | path:${uploadResult.path}]`
     );
 
     return NextResponse.json({
@@ -172,8 +172,7 @@ export async function GET(
     const query = `
       SELECT
         d.id,
-        d.proof_of_delivery,
-        d.metadata,
+        d.delivery_photo_url,
         d.driver_id
       FROM deliveries d
       WHERE d.id = $1
@@ -182,8 +181,7 @@ export async function GET(
     const result = await prisma.$queryRawUnsafe<
       {
         id: string;
-        proof_of_delivery: string | null;
-        metadata: Record<string, unknown> | null;
+        delivery_photo_url: string | null;
         driver_id: string | null;
       }[]
     >(query, deliveryId);
@@ -208,7 +206,7 @@ export async function GET(
       }
     }
 
-    if (!delivery.proof_of_delivery) {
+    if (!delivery.delivery_photo_url) {
       return NextResponse.json({
         success: true,
         hasPhoto: false,
@@ -216,16 +214,10 @@ export async function GET(
       });
     }
 
-    const metadata = delivery.metadata as Record<string, unknown> | null;
-
     return NextResponse.json({
       success: true,
       hasPhoto: true,
-      url: delivery.proof_of_delivery,
-      metadata: {
-        uploadedAt: metadata?.podUploadedAt || null,
-        storagePath: metadata?.podStoragePath || null,
-      },
+      url: delivery.delivery_photo_url,
     });
   } catch (error) {
     Sentry.captureException(error, {
@@ -262,17 +254,16 @@ export async function DELETE(
       return authResult.response;
     }
 
-    // Get the current POD storage path
+    // Get the current POD URL
     const query = `
-      SELECT proof_of_delivery, metadata
+      SELECT delivery_photo_url
       FROM deliveries
       WHERE id = $1
     `;
 
     const result = await prisma.$queryRawUnsafe<
       {
-        proof_of_delivery: string | null;
-        metadata: Record<string, unknown> | null;
+        delivery_photo_url: string | null;
       }[]
     >(query, deliveryId);
 
@@ -285,16 +276,16 @@ export async function DELETE(
 
     const delivery = result[0]!;
 
-    if (!delivery.proof_of_delivery) {
+    if (!delivery.delivery_photo_url) {
       return NextResponse.json(
         { success: false, error: 'No proof of delivery photo to delete' },
         { status: 400 }
       );
     }
 
-    // Delete from storage if we have the path
-    const deliveryMetadata = delivery.metadata as Record<string, unknown> | null;
-    const storagePath = deliveryMetadata?.podStoragePath as string | undefined;
+    // Delete from storage. Recover the storage path from the public URL
+    // (.../delivery-proofs/<path>) since there is no metadata column.
+    const storagePath = delivery.delivery_photo_url.split('/delivery-proofs/')[1];
     if (storagePath) {
       const deleteResult = await deletePODImage(storagePath);
       if (deleteResult.error) {
@@ -312,17 +303,13 @@ export async function DELETE(
       `
       UPDATE deliveries
       SET
-        proof_of_delivery = NULL,
-        metadata = COALESCE(metadata, '{}'::jsonb) || $2::jsonb,
+        delivery_photo_url = NULL,
+        delivery_notes = COALESCE(delivery_notes, '') || $2,
         updated_at = NOW()
       WHERE id = $1::uuid
     `,
       deliveryId,
-      JSON.stringify({
-        podDeletedAt: new Date().toISOString(),
-        podDeletedBy: authResult.context.user.id,
-        podStoragePath: null,
-      })
+      ` [POD deleted ${new Date().toISOString()} by ${authResult.context.user.id}]`
     );
 
     return NextResponse.json({

--- a/src/app/api/tracking/deliveries/pod-gallery/route.ts
+++ b/src/app/api/tracking/deliveries/pod-gallery/route.ts
@@ -32,25 +32,26 @@ export async function GET(request: NextRequest) {
     const offset = (page - 1) * pageSize;
 
     // Build dynamic query with parameterized filters
+    // NOTE: the `deliveries` table carries its own order_number/customer_name/
+    // delivery_address and has NO catering_request_id/on_demand_id/proof_of_delivery/
+    // completed_at columns — query its real columns directly (no order-table joins).
     let query = `
       SELECT
         d.id,
         d.id as delivery_id,
-        COALESCE(cr.order_number, od.order_number, d.id::text) as order_number,
-        COALESCE(d.delivery_photo_url, d.proof_of_delivery::text) as photo_url,
-        COALESCE(d.delivered_at, d.completed_at, d.created_at) as captured_at,
+        COALESCE(d.order_number, d.id::text) as order_number,
+        d.delivery_photo_url as photo_url,
+        COALESCE(d.delivered_at, d.created_at) as captured_at,
         d.status,
         dr.id as driver_id,
-        COALESCE(p.name, p.contact_name, 'Unknown Driver') as driver_name,
-        COALESCE(cr.contact_name, od.contact_name, '') as customer_name,
-        COALESCE(cr.address, od.address, '') as delivery_address
+        COALESCE(p.name, 'Unknown Driver') as driver_name,
+        COALESCE(d.customer_name, '') as customer_name,
+        COALESCE(d.delivery_address, '') as delivery_address
       FROM deliveries d
       LEFT JOIN drivers dr ON d.driver_id = dr.id
       LEFT JOIN profiles p ON dr.profile_id = p.id
-      LEFT JOIN catering_requests cr ON d.catering_request_id = cr.id
-      LEFT JOIN on_demand od ON d.on_demand_id = od.id
       WHERE d.deleted_at IS NULL
-        AND (d.delivery_photo_url IS NOT NULL OR d.proof_of_delivery IS NOT NULL)
+        AND d.delivery_photo_url IS NOT NULL
     `;
 
     const params: any[] = [];
@@ -66,9 +67,9 @@ export async function GET(request: NextRequest) {
     // Add search filter (search across order number, driver name, customer name)
     if (search) {
       query += ` AND (
-        COALESCE(cr.order_number, od.order_number, '') ILIKE $${paramCounter}
-        OR COALESCE(p.name, p.contact_name, '') ILIKE $${paramCounter}
-        OR COALESCE(cr.contact_name, od.contact_name, '') ILIKE $${paramCounter}
+        COALESCE(d.order_number, '') ILIKE $${paramCounter}
+        OR COALESCE(p.name, '') ILIKE $${paramCounter}
+        OR COALESCE(d.customer_name, '') ILIKE $${paramCounter}
       )`;
       params.push(`%${search}%`);
       paramCounter++;
@@ -76,13 +77,13 @@ export async function GET(request: NextRequest) {
 
     // Add date range filters
     if (dateFrom) {
-      query += ` AND COALESCE(d.delivered_at, d.completed_at, d.created_at) >= $${paramCounter}::timestamptz`;
+      query += ` AND COALESCE(d.delivered_at, d.created_at) >= $${paramCounter}::timestamptz`;
       params.push(dateFrom);
       paramCounter++;
     }
 
     if (dateTo) {
-      query += ` AND COALESCE(d.delivered_at, d.completed_at, d.created_at) <= $${paramCounter}::timestamptz`;
+      query += ` AND COALESCE(d.delivered_at, d.created_at) <= $${paramCounter}::timestamptz`;
       params.push(dateTo);
       paramCounter++;
     }
@@ -93,15 +94,13 @@ export async function GET(request: NextRequest) {
       FROM deliveries d
       LEFT JOIN drivers dr ON d.driver_id = dr.id
       LEFT JOIN profiles p ON dr.profile_id = p.id
-      LEFT JOIN catering_requests cr ON d.catering_request_id = cr.id
-      LEFT JOIN on_demand od ON d.on_demand_id = od.id
       WHERE d.deleted_at IS NULL
-        AND (d.delivery_photo_url IS NOT NULL OR d.proof_of_delivery IS NOT NULL)
+        AND d.delivery_photo_url IS NOT NULL
         ${driverId ? `AND d.driver_id = $1::uuid` : ''}
         ${search ? `AND (
-          COALESCE(cr.order_number, od.order_number, '') ILIKE $${driverId ? 2 : 1}
-          OR COALESCE(p.name, p.contact_name, '') ILIKE $${driverId ? 2 : 1}
-          OR COALESCE(cr.contact_name, od.contact_name, '') ILIKE $${driverId ? 2 : 1}
+          COALESCE(d.order_number, '') ILIKE $${driverId ? 2 : 1}
+          OR COALESCE(p.name, '') ILIKE $${driverId ? 2 : 1}
+          OR COALESCE(d.customer_name, '') ILIKE $${driverId ? 2 : 1}
         )` : ''}
     `;
 
@@ -111,7 +110,7 @@ export async function GET(request: NextRequest) {
     if (search) countParams.push(`%${search}%`);
 
     // Add ordering and pagination to main query
-    query += ` ORDER BY COALESCE(d.delivered_at, d.completed_at, d.created_at) DESC NULLS LAST`;
+    query += ` ORDER BY COALESCE(d.delivered_at, d.created_at) DESC NULLS LAST`;
     query += ` LIMIT $${paramCounter} OFFSET $${paramCounter + 1}`;
     params.push(pageSize, offset);
 

--- a/src/components/Driver/DriverStatsPanel.tsx
+++ b/src/components/Driver/DriverStatsPanel.tsx
@@ -82,18 +82,18 @@ export function DriverStatsPanel({ driverId }: DriverStatsPanelProps) {
           <StatTile
             icon={Route}
             label="Miles"
-            value={Math.round(data.distanceStats.totalMiles)}
+            value={Math.round(data.distanceStats.totalMiles ?? 0)}
             delta={showTrends ? pct(data.trends?.distanceChange) : undefined}
           />
           <StatTile
             icon={Gauge}
             label="Avg mi/drop"
-            value={data.distanceStats.averageMilesPerDelivery.toFixed(1)}
+            value={(data.distanceStats.averageMilesPerDelivery ?? 0).toFixed(1)}
           />
           <StatTile
             icon={Clock}
             label="Hours"
-            value={data.shiftStats.totalHoursWorked.toFixed(1)}
+            value={(data.shiftStats.totalHoursWorked ?? 0).toFixed(1)}
             sub={`${data.shiftStats.totalShifts} shifts`}
           />
         </div>

--- a/src/components/Driver/ProofOfDeliveryCapture.tsx
+++ b/src/components/Driver/ProofOfDeliveryCapture.tsx
@@ -149,6 +149,40 @@ export function ProofOfDeliveryCapture({
   }, [state.previewUrl]);
 
   /**
+   * Queue the captured photo for background upload and let the delivery
+   * complete now. Used when offline, on a network error, or when the driver
+   * taps "Complete anyway" after a failed upload — a failed photo must never
+   * trap the driver mid-delivery (the real URL lands when the queue syncs).
+   */
+  const queueForLater = useCallback(async () => {
+    if (!state.file) return;
+    const apiEndpoint = uploadEndpoint || `/api/tracking/deliveries/${deliveryId}/pod`;
+    try {
+      await queuePODUpload(deliveryId, orderNumber, state.file, apiEndpoint, {
+        capturedAt: new Date(),
+        compressionApplied: true,
+        originalSize: state.file.size,
+      });
+      setState((prev) => ({ ...prev, status: 'queued' }));
+      const metadata: PODMetadata = {
+        deliveryId,
+        capturedAt: new Date(),
+        uploadedAt: new Date(),
+        compressionApplied: true,
+        compressedSize: state.file.size,
+        originalFilename: state.file.name,
+      };
+      // Use the local preview as a temporary URL; the persisted URL is written
+      // when the queued upload syncs in the background.
+      onUploadComplete(state.previewUrl || '', metadata);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to queue upload';
+      setState((prev) => ({ ...prev, status: 'error', error: errorMessage }));
+      onError?.(errorMessage);
+    }
+  }, [state.file, state.previewUrl, deliveryId, orderNumber, uploadEndpoint, queuePODUpload, onUploadComplete, onError]);
+
+  /**
    * Upload the captured photo (with offline support)
    */
   const handleUpload = useCallback(async () => {
@@ -163,49 +197,10 @@ export function ProofOfDeliveryCapture({
 
     const apiEndpoint = uploadEndpoint || `/api/tracking/deliveries/${deliveryId}/pod`;
 
-    // Check if we're offline - queue for later
+    // Offline → queue for later and let completion proceed.
     if (!offlineStatus.isOnline) {
-      try {
-        await queuePODUpload(
-          deliveryId,
-          orderNumber,
-          state.file,
-          apiEndpoint,
-          {
-            capturedAt: new Date(),
-            compressionApplied: true,
-            originalSize: state.file.size,
-          }
-        );
-
-        setState((prev) => ({
-          ...prev,
-          status: 'queued',
-        }));
-
-        // Create metadata for parent callback
-        const metadata: PODMetadata = {
-          deliveryId,
-          capturedAt: new Date(),
-          uploadedAt: new Date(),
-          compressionApplied: true,
-          compressedSize: state.file.size,
-          originalFilename: state.file.name,
-        };
-
-        // Notify parent - use preview URL as temporary URL
-        onUploadComplete(state.previewUrl || '', metadata);
-        return;
-      } catch (err) {
-        const errorMessage = err instanceof Error ? err.message : 'Failed to queue upload';
-        setState((prev) => ({
-          ...prev,
-          status: 'error',
-          error: errorMessage,
-        }));
-        onError?.(errorMessage);
-        return;
-      }
+      await queueForLater();
+      return;
     }
 
     // Online - proceed with direct upload
@@ -254,42 +249,14 @@ export function ProofOfDeliveryCapture({
       // Notify parent of successful upload
       onUploadComplete(result.url, metadata);
     } catch (err) {
-      // Check if this is a network error - queue for later
+      // Network error → queue silently for background sync and complete.
       if (!navigator.onLine || (err instanceof TypeError && err.message.includes('fetch'))) {
-        try {
-          await queuePODUpload(
-            deliveryId,
-            orderNumber,
-            state.file,
-            apiEndpoint,
-            {
-              capturedAt: new Date(),
-              compressionApplied: true,
-              originalSize: state.file.size,
-            }
-          );
-
-          setState((prev) => ({
-            ...prev,
-            status: 'queued',
-          }));
-
-          const metadata: PODMetadata = {
-            deliveryId,
-            capturedAt: new Date(),
-            uploadedAt: new Date(),
-            compressionApplied: true,
-            compressedSize: state.file.size,
-            originalFilename: state.file.name,
-          };
-
-          onUploadComplete(state.previewUrl || '', metadata);
-          return;
-        } catch (queueErr) {
-          // If queuing also fails, show error
-        }
+        await queueForLater();
+        return;
       }
 
+      // Server/other error → surface it, but the error UI offers "Complete
+      // anyway" (queueForLater) so a failed upload never traps the driver.
       const errorMessage = err instanceof Error ? err.message : 'Upload failed';
       setState((prev) => ({
         ...prev,
@@ -298,7 +265,7 @@ export function ProofOfDeliveryCapture({
       }));
       onError?.(errorMessage);
     }
-  }, [state.file, state.previewUrl, deliveryId, orderNumber, uploadEndpoint, offlineStatus.isOnline, queuePODUpload, onUploadComplete, onError]);
+  }, [state.file, deliveryId, uploadEndpoint, offlineStatus.isOnline, queueForLater, onUploadComplete, onError]);
 
   /**
    * Render camera permission error state
@@ -448,10 +415,20 @@ export function ProofOfDeliveryCapture({
         <AlertCircle className="h-4 w-4" />
         <AlertDescription>{state.error}</AlertDescription>
       </Alert>
-      <Button variant="outline" onClick={handleRetake} className="gap-2">
-        <RotateCcw className="h-4 w-4" />
-        Try Again
-      </Button>
+      <div className="flex w-full flex-col gap-2">
+        <Button variant="outline" onClick={handleRetake} className="gap-2">
+          <RotateCcw className="h-4 w-4" />
+          Try Again
+        </Button>
+        {/* A failed upload must never trap the driver: let them complete now;
+            the photo is queued and uploaded in the background. */}
+        {state.file ? (
+          <Button onClick={queueForLater} className="gap-2">
+            <CloudUpload className="h-4 w-4" />
+            Complete anyway — upload photo later
+          </Button>
+        ) : null}
+      </div>
     </div>
   );
 

--- a/src/components/Driver/ui/DeliveryCard.tsx
+++ b/src/components/Driver/ui/DeliveryCard.tsx
@@ -99,7 +99,7 @@ function Stop({ tone, name }: { tone: "info" | "brand"; name: string }) {
         )}
       />
       <span className="truncate text-[13.5px] font-bold text-driver-text">
-        {name}
+        {name || "—"}
       </span>
     </div>
   );

--- a/src/components/Driver/ui/StatTile.tsx
+++ b/src/components/Driver/ui/StatTile.tsx
@@ -6,7 +6,9 @@ import { cn } from "@/lib/utils";
 interface StatTileProps {
   icon: LucideIcon;
   label: string;
-  value: string | number;
+  /** Accepts nullish/NaN defensively — rendered as "—" so a missing stat
+   *  never shows a blank tile. */
+  value: string | number | null | undefined;
   sub?: string;
   /** Trend delta, e.g. "+12%" (green) or "-3%" (red). */
   delta?: string;
@@ -57,7 +59,12 @@ export function StatTile({
         ) : null}
       </div>
       <div className="text-[20px] font-extrabold leading-[1.05] tracking-[-0.02em] text-driver-text">
-        {value}
+        {value === null ||
+        value === undefined ||
+        value === "" ||
+        (typeof value === "number" && Number.isNaN(value))
+          ? "—"
+          : value}
       </div>
       <div className="text-[11px] font-bold leading-tight text-driver-muted">
         {label}

--- a/src/components/Driver/ui/StatusTimeline.tsx
+++ b/src/components/Driver/ui/StatusTimeline.tsx
@@ -84,7 +84,7 @@ export function StatusTimeline({
               </div>
               {active ? (
                 <div className="text-[11.5px] font-semibold text-driver-on-brand">
-                  In progress now
+                  {stage === DriverStatus.ASSIGNED ? "Awaiting start" : "In progress now"}
                 </div>
               ) : done && ts ? (
                 <div className="text-[11.5px] font-semibold text-driver-muted">

--- a/src/components/Orders/DriverStatus.tsx
+++ b/src/components/Orders/DriverStatus.tsx
@@ -48,7 +48,7 @@ interface DriverStatusCardProps {
 // Update the status maps to use the enum with UPPERCASE keys
 const driverStatusMap: Record<DriverStatus, string> = {
   [DriverStatus.ASSIGNED]: "🚗 Assigned",
-  [DriverStatus.EN_ROUTE_TO_VENDOR]: "🚗 En Route to Resto",
+  [DriverStatus.EN_ROUTE_TO_VENDOR]: "🚗 En Route to Restaurant",
   [DriverStatus.ARRIVED_AT_VENDOR]: "🏪 Arrived at Vendor",
   [DriverStatus.PICKED_UP]: "📦 Pick Up Completed",
   [DriverStatus.EN_ROUTE_TO_CLIENT]: "🚚 En Route to Client",
@@ -241,7 +241,7 @@ export const DriverStatusCard: React.FC<DriverStatusCardProps> = ({
                   indicatorClassName="transition-all duration-500 bg-amber-600"
                 />
                 <div className="mt-1 flex justify-between text-xs text-slate-500">
-                  <span className="text-center">En Route to Resto</span>
+                  <span className="text-center">En Route to Restaurant</span>
                   <span className="text-center">Arrived at Vendor</span>
                   <span className="text-center">Pick Up Completed</span>
                   <span className="text-center">En Route to Client</span>
@@ -281,7 +281,7 @@ export const DriverStatusCard: React.FC<DriverStatusCardProps> = ({
                     })}
                   />
                   <div className="mt-1 flex justify-between text-[11px] text-slate-500">
-                    <span className="text-center">En Route<br />to Resto</span>
+                    <span className="text-center">En Route<br />to Restaurant</span>
                     <span className="text-center">Arrived<br />at Vendor</span>
                     <span className="text-center">Pick Up<br />Completed</span>
                   </div>

--- a/src/hooks/tracking/__tests__/useDeliveryStatusRealtime.test.ts
+++ b/src/hooks/tracking/__tests__/useDeliveryStatusRealtime.test.ts
@@ -36,6 +36,20 @@ jest.mock('@/lib/realtime', () => ({
   },
 }));
 
+// The hook now does a pre-connection auth check (getSession) before
+// subscribing (REA-DRT-07 guard) — mock a valid session so the channel
+// connects in tests.
+jest.mock('@/utils/supabase/client', () => ({
+  createClient: jest.fn(() => ({
+    auth: {
+      getSession: jest.fn().mockResolvedValue({
+        data: { session: { access_token: 'test-token', user: { id: 'test-user' } } },
+        error: null,
+      }),
+    },
+  })),
+}));
+
 import toast from 'react-hot-toast';
 import { createDriverStatusChannel, REALTIME_EVENTS } from '@/lib/realtime';
 

--- a/src/hooks/tracking/useDeliveryStatusRealtime.ts
+++ b/src/hooks/tracking/useDeliveryStatusRealtime.ts
@@ -23,13 +23,17 @@ import type { DeliveryStatusUpdatedPayload, DeliveryTrackingStatus } from '@/lib
 // Status display configuration
 const STATUS_DISPLAY: Record<DeliveryTrackingStatus, { emoji: string; label: string }> = {
   ASSIGNED: { emoji: '📋', label: 'Driver Assigned' },
-  EN_ROUTE_TO_VENDOR: { emoji: '🚗', label: 'Driver En Route to Resto' },
+  EN_ROUTE_TO_VENDOR: { emoji: '🚗', label: 'Driver En Route to Restaurant' },
   ARRIVED_AT_VENDOR: { emoji: '🏪', label: 'Driver Arrived at Pickup' },
   PICKED_UP: { emoji: '📦', label: 'Order Picked Up' },
   EN_ROUTE_TO_CLIENT: { emoji: '🚚', label: 'Driver En Route' },
   ARRIVED_TO_CLIENT: { emoji: '📍', label: 'Driver Arrived' },
   COMPLETED: { emoji: '✅', label: 'Delivery Completed' },
 };
+
+// If the channel neither connects nor errors within this window, stop showing
+// "Connecting…" and surface a resolved (error/fallback) state.
+const CONNECT_TIMEOUT_MS = 12_000;
 
 interface UseDeliveryStatusRealtimeOptions {
   /**
@@ -112,6 +116,7 @@ export function useDeliveryStatusRealtime({
   const [error, setError] = useState<string | null>(null);
 
   const channelRef = useRef<DriverStatusChannel | null>(null);
+  const connectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Combine orderId and orderIds into a single set for filtering
   const orderIdsToTrack = useRef<Set<string>>(new Set());
@@ -190,12 +195,41 @@ export function useDeliveryStatusRealtime({
     setError(null);
 
     try {
+      // Pre-connection auth check: without an active browser session the
+      // Realtime WebSocket never opens and the channel hangs in "connecting"
+      // forever (REA-DRT-07). Resolve to a non-connecting state instead of
+      // leaving the UI stuck on "Connecting…".
+      const { createClient } = await import('@/utils/supabase/client');
+      const supabase = createClient();
+      const { data: { session }, error: authError } = await supabase.auth.getSession();
+      if (authError || !session) {
+        setIsConnecting(false);
+        setIsConnected(false);
+        setError('Live updates unavailable — no active session');
+        onConnectionChange?.(false);
+        return;
+      }
+
+      // Safety net: if the channel neither connects nor errors within the
+      // window, stop showing "Connecting…".
+      if (connectTimeoutRef.current) clearTimeout(connectTimeoutRef.current);
+      connectTimeoutRef.current = setTimeout(() => {
+        connectTimeoutRef.current = null;
+        setIsConnecting(false);
+        setError((prev) => prev ?? 'Live updates timed out');
+        onConnectionChange?.(false);
+      }, CONNECT_TIMEOUT_MS);
+
       const channel = createDriverStatusChannel();
       channelRef.current = channel;
 
       await channel.subscribe({
         onStatusUpdate: undefined, // We handle driver shift status separately
         onConnect: () => {
+          if (connectTimeoutRef.current) {
+            clearTimeout(connectTimeoutRef.current);
+            connectTimeoutRef.current = null;
+          }
           setIsConnected(true);
           setIsConnecting(false);
           setError(null);
@@ -206,6 +240,10 @@ export function useDeliveryStatusRealtime({
           onConnectionChange?.(false);
         },
         onError: (err) => {
+          if (connectTimeoutRef.current) {
+            clearTimeout(connectTimeoutRef.current);
+            connectTimeoutRef.current = null;
+          }
           setError(err.message);
           setIsConnected(false);
           setIsConnecting(false);
@@ -216,6 +254,10 @@ export function useDeliveryStatusRealtime({
       // Listen specifically for delivery status updates
       channel.on(REALTIME_EVENTS.DELIVERY_STATUS_UPDATED, handleStatusUpdate);
     } catch (err) {
+      if (connectTimeoutRef.current) {
+        clearTimeout(connectTimeoutRef.current);
+        connectTimeoutRef.current = null;
+      }
       setError(err instanceof Error ? err.message : 'Failed to connect');
       setIsConnected(false);
       setIsConnecting(false);
@@ -246,6 +288,10 @@ export function useDeliveryStatusRealtime({
   // Cleanup on unmount
   useEffect(() => {
     return () => {
+      if (connectTimeoutRef.current) {
+        clearTimeout(connectTimeoutRef.current);
+        connectTimeoutRef.current = null;
+      }
       if (channelRef.current) {
         void channelRef.current.unsubscribe().catch(() => {
           // Ignore cleanup errors

--- a/src/lib/delivery-status-transitions.ts
+++ b/src/lib/delivery-status-transitions.ts
@@ -7,7 +7,7 @@ import { DriverStatus } from '@/types/user';
 
 /**
  * Ordered list of driver statuses representing the delivery lifecycle
- * Flow: Assigned → En Route to Resto → Arrived at Vendor → Pick Up Completed → En Route to Client → Arrived at Client → Delivered
+ * Flow: Assigned → En Route to Restaurant → Arrived at Vendor → Pick Up Completed → En Route to Client → Arrived at Client → Delivered
  */
 export const STATUS_ORDER: DriverStatus[] = [
   DriverStatus.ASSIGNED,
@@ -24,7 +24,7 @@ export const STATUS_ORDER: DriverStatus[] = [
  */
 export const STATUS_LABELS: Record<DriverStatus, string> = {
   [DriverStatus.ASSIGNED]: 'Assigned',
-  [DriverStatus.EN_ROUTE_TO_VENDOR]: 'En Route to Resto',
+  [DriverStatus.EN_ROUTE_TO_VENDOR]: 'En Route to Restaurant',
   [DriverStatus.ARRIVED_AT_VENDOR]: 'Arrived at Vendor',
   [DriverStatus.PICKED_UP]: 'Pick Up Completed',
   [DriverStatus.EN_ROUTE_TO_CLIENT]: 'En Route to Client',


### PR DESCRIPTION
First real-device GPS walk test (CDMX, 2026-06-16) surfaced 8 issues. This is **PR1 — the blocking bugs**. Perf/persistence/background-GPS (PR2) and the signature/recipient-name feature (awaiting Claude Design) are deferred to follow-up PRs. Full triage: `docs/issues-tracker/README.md`.

## Fixes
- **POD photo upload was 500-ing (issue h).** `/api/tracking/deliveries/[id]/pod` (POST/GET/DELETE) and the admin `pod-gallery` wrote to non-existent `proof_of_delivery`/`metadata` columns — now use the real `delivery_photo_url` (+ `delivery_notes` audit). The `delivery-proofs` storage bucket was already fine.
- **A failed photo no longer traps the driver (issue h).** `ProofOfDeliveryCapture` adds **"Complete anyway — upload photo later"** (queues via the existing `usePODOfflineQueue`, then completes; the URL is reconciled when the queue syncs).
- **Can't end a shift mid-delivery (issue h).** `endDriverShift` blocks while the driver has active deliveries (admin `force` override). Also fixed `getDriverActiveDeliveries`' wrong `'DELIVERED'` terminal filter (real terminal is `COMPLETED`).
- **Admin order page stuck on "Connecting…" (issue e).** `useDeliveryStatusRealtime` now does a pre-connect `getSession()` check + 12s timeout (REA-DRT-07 class), resolving to "Offline" instead of spinning forever.
- **Status-label bugs (issues a, d).** "Resto" → "Restaurant"; the ASSIGNED timeline step reads "Awaiting start" instead of "Assigned – In progress".
- **Blank squares (issue b).** `StatTile` / `DriverStatsPanel` / `DeliveryCard` render `—` fallbacks for missing data.

## Not in this PR (documented in the tracker)
- **PR2:** sluggishness / refetch storms (c), tab-switch errors + background-GPS (f), and live-location persistence (history was empty — broadcast-only, no DB writes).
- **Feature:** signature + recipient-name capture (g) — its own PR once the Claude Design lands.
- **Follow-up:** the same dead-column bug exists in `/api/tracking/deliveries/[id]` GET/PATCH and the base-route POST, but they have **no UI callers** (the portal uses server actions), so they don't block the driver.

## Testing
- `pnpm pre-push-check` ✅ (typecheck + lint + prisma validate)
- Targeted tracking suites ✅ — POD routes, delivery-status-transitions, `useDeliveryStatusRealtime`, `driver-actions` (incl. 2 new end-shift-guard tests), `delivery-actions.security`, `usePODOfflineQueue`, driver home. Updated 2 stale mocks for the new auth-check / guard behavior.
- On-device re-test available via the seeded `WALK-TEST-AM/PM` orders in rs-dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)