### PR TITLE
fix(driver): cast uuid params in tracking locations route (GPS writes were 500'ing)

### DIFF
--- a/src/app/api/tracking/locations/__tests__/insert-columns.test.ts
+++ b/src/app/api/tracking/locations/__tests__/insert-columns.test.ts
@@ -78,3 +78,67 @@ describe('locations POST — INSERT columns regression', () => {
     expect(sql).toContain('longitude');
   });
 });
+
+/**
+ * Regression test for the uuid/text cast bug.
+ *
+ * Bug: `WHERE id = $1` compared the uuid `drivers.id` column against a
+ * text-bound Prisma param, so Postgres threw
+ * `operator does not exist: uuid = text` and every GPS write 500'd. Every
+ * drivers-id comparison in this route must cast the param to ::uuid.
+ */
+describe('locations POST — uuid cast regression', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEnforceRateLimit.mockResolvedValue(null);
+    mockWithRawTx.mockImplementation((fn: any) =>
+      fn({ $queryRawUnsafe: mockTxQuery, $executeRawUnsafe: mockTxExec }),
+    );
+    mockTxQuery.mockImplementation((sql: string) => {
+      if (sql.includes('SELECT id FROM drivers')) return Promise.resolve([{ id: 'driver-1' }]);
+      if (sql.includes('INSERT INTO driver_locations')) {
+        return Promise.resolve([
+          { id: 'loc-1', location_geojson: JSON.stringify({ type: 'Point', coordinates: [-122.4194, 37.7749] }) },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+    mockTxExec.mockResolvedValue(1);
+  });
+
+  it('casts the driver-id param to ::uuid in the DRIVER ownership check', async () => {
+    mockWithAuth.mockResolvedValue({ success: true, context: { user: { id: 'auth-1', type: 'DRIVER' } } });
+
+    await POST(createPostRequest('http://localhost:3000/api/tracking/locations', validBody));
+
+    const ownershipCall = mockTxQuery.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('SELECT id FROM drivers'),
+    );
+    expect(ownershipCall).toBeDefined();
+    expect(ownershipCall![0]).toContain('id = $1::uuid');
+  });
+
+  it('casts the driver-id param to ::uuid in the ADMIN existence check', async () => {
+    mockWithAuth.mockResolvedValue({ success: true, context: { user: { id: 'admin-1', type: 'ADMIN' } } });
+
+    await POST(createPostRequest('http://localhost:3000/api/tracking/locations', validBody));
+
+    const ownershipCall = mockTxQuery.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('SELECT id FROM drivers'),
+    );
+    expect(ownershipCall).toBeDefined();
+    expect(ownershipCall![0]).toContain('id = $1::uuid');
+  });
+
+  it('casts the driver-id param to ::uuid in the last-known-location UPDATE', async () => {
+    mockWithAuth.mockResolvedValue({ success: true, context: { user: { id: 'admin-1', type: 'ADMIN' } } });
+
+    await POST(createPostRequest('http://localhost:3000/api/tracking/locations', validBody));
+
+    const updateCall = mockTxExec.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('UPDATE drivers'),
+    );
+    expect(updateCall).toBeDefined();
+    expect(updateCall![0]).toContain('WHERE id = $3::uuid');
+  });
+});

--- a/src/app/api/tracking/locations/route.ts
+++ b/src/app/api/tracking/locations/route.ts
@@ -75,12 +75,12 @@ export async function POST(request: NextRequest) {
     const locationRow = await withRawTx(async (tx) => {
       const driverCheck = isDriver
         ? await tx.$queryRawUnsafe<{ id: string }[]>(
-            `SELECT id FROM drivers WHERE id = $1 AND ${driverOwnershipCondition(2)} AND is_active = true`,
+            `SELECT id FROM drivers WHERE id = $1::uuid AND ${driverOwnershipCondition(2)} AND is_active = true`,
             driver_id,
             auth.context.user.id,
           )
         : await tx.$queryRawUnsafe<{ id: string }[]>(
-            'SELECT id FROM drivers WHERE id = $1 AND is_active = true',
+            'SELECT id FROM drivers WHERE id = $1::uuid AND is_active = true',
             driver_id,
           );
 
@@ -138,7 +138,7 @@ export async function POST(request: NextRequest) {
           last_known_location = ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography,
           last_location_update = NOW(),
           updated_at = NOW()
-        WHERE id = $3
+        WHERE id = $3::uuid
         `,
         longitude,
         latitude,
@@ -200,7 +200,7 @@ export async function GET(request: NextRequest) {
     // A DRIVER may only read their own location history.
     if (auth.context.user.type === 'DRIVER') {
       const owns = await rawQuery<{ id: string }>(
-        `SELECT id FROM drivers WHERE id = $1 AND ${driverOwnershipCondition(2)}`,
+        `SELECT id FROM drivers WHERE id = $1::uuid AND ${driverOwnershipCondition(2)}`,
         [driver_id, auth.context.user.id],
       );
       if (owns.length === 0) {
@@ -226,7 +226,7 @@ export async function GET(request: NextRequest) {
         created_at
       FROM driver_locations
       WHERE
-        driver_id = $1
+        driver_id = $1::uuid
         AND recorded_at >= NOW() - INTERVAL '${hours} hours'
       ORDER BY recorded_at DESC
       LIMIT $2


### PR DESCRIPTION
## What

GPS writes to `POST /api/tracking/locations` were 500'ing on every ping with Postgres `operator does not exist: uuid = text`. The driver-ownership/existence checks and the GET history path compared the uuid `drivers.id` / `driver_locations.driver_id` columns against text-bound Prisma params with **no cast**. This adds `::uuid` to all five comparison sites.

## Why it mattered

Found during the **2026-06-17 CDMX driver re-walk** (live test on `development.readysetllc.com`). The driver started a shift and the order state-machine advanced normally (`ASSIGNED → EN_ROUTE_TO_CLIENT`), but **every GPS point was silently dropped**:
- `driver_locations` had **0 rows** for the shift (newest row in the whole table was 18 days old)
- `drivers.last_location_update` froze at the shift-start value
- Admin live map showed only the single shift-start position; Avg Speed / Total KM / track all 0

Postgres logs showed the `uuid = text` ERROR recurring at the ~2-min GPS cadence, starting 14s after shift start.

## Fix

`::uuid` casts on all five `drivers.id` / `driver_locations.driver_id` comparisons in `locations/route.ts` (POST ownership DRIVER + ADMIN paths, POST last-known-location UPDATE, GET history ownership + lookup). Matches the pattern already in `driver-ownership.ts` (`userOwnsDriver`); the `$2` auth-uid comparisons were already cast via `driverOwnershipCondition`, the adjacent `id = $1` was missed.

## Tests

- New regression assertions verify the ownership SELECT and the UPDATE cast the id param to `::uuid` (prior tests mocked the DB, so the mismatch never surfaced).
- locations suite 4/4 green; `pnpm typecheck` clean.

## Follow-ups (not in this PR)

Same uncast pattern exists in sibling **admin-facing** routes the walk doesn't hit (`deliveries/[id]`, `shifts/[id]`, `deliveries` GET, `drivers` PATCH/DELETE) — fast follow on this branch. Logs also showed `permission denied for table drivers` and `column p.first_name does not exist` (separate issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)