### PR TITLE
fix(driver): cast driver_id to ::uuid in driver_locations INSERT (re-walk follow-up to #451)

### DIFF
--- a/src/app/api/tracking/locations/__tests__/insert-columns.test.ts
+++ b/src/app/api/tracking/locations/__tests__/insert-columns.test.ts
@@ -141,4 +141,19 @@ describe('locations POST — uuid cast regression', () => {
     expect(updateCall).toBeDefined();
     expect(updateCall![0]).toContain('WHERE id = $3::uuid');
   });
+
+  it('casts the driver-id param to ::uuid in the driver_locations INSERT', async () => {
+    mockWithAuth.mockResolvedValue({ success: true, context: { user: { id: 'admin-1', type: 'ADMIN' } } });
+
+    await POST(createPostRequest('http://localhost:3000/api/tracking/locations', validBody));
+
+    const insertCall = mockTxQuery.mock.calls.find(
+      ([sql]) => typeof sql === 'string' && sql.includes('INSERT INTO driver_locations'),
+    );
+    expect(insertCall).toBeDefined();
+    // driver_id ($1) goes into a uuid column; Prisma binds it as text, so the
+    // VALUES expression must cast or PG throws "column is of type uuid but
+    // expression is of type text".
+    expect(insertCall![0]).toContain('VALUES ($1::uuid');
+  });
 });

--- a/src/app/api/tracking/locations/route.ts
+++ b/src/app/api/tracking/locations/route.ts
@@ -106,7 +106,7 @@ export async function POST(request: NextRequest) {
           is_moving,
           recorded_at
         )
-        VALUES ($1, ST_SetSRID(ST_MakePoint($2, $3), 4326)::geography, $3, $2, $4, $5, $6, $7, $8, $9, NOW())
+        VALUES ($1::uuid, ST_SetSRID(ST_MakePoint($2, $3), 4326)::geography, $3, $2, $4, $5, $6, $7, $8, $9, NOW())
         RETURNING
           id,
           ST_AsGeoJSON(location) as location_geojson,


### PR DESCRIPTION
Follow-up to #451, surfaced on the live CDMX re-walk.

#451 cast the ownership/UPDATE **comparisons** (`id = $1::uuid`), which cleared the `operator does not exist: uuid = text` error. But the location-write transaction then reached the **INSERT**, which bound `driver_id` (`$1`) as text into the uuid `driver_locations.driver_id` column. Postgres rejected it with:

```
column "driver_id" is of type uuid but expression is of type text
```

so GPS writes still 500'd — one statement further down. This casts the INSERT's `VALUES ($1::uuid, …)`.

- Verified live: on the re-walk the original operator error was gone, replaced by this column-type error on the next statement; `driver_locations` stayed empty.
- Regression test extended to assert the INSERT casts `$1::uuid`. Suite 5/5 green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)