### PR TITLE
fix(driver): gate GPS sync on a ref so iOS Safari posts locations

### DIFF
--- a/src/hooks/tracking/__tests__/useLocationTracking.test.ts
+++ b/src/hooks/tracking/__tests__/useLocationTracking.test.ts
@@ -256,7 +256,7 @@ describe('useLocationTracking', () => {
       expect(navigator.geolocation.watchPosition).toHaveBeenCalled();
     });
 
-    it('should set up periodic location updates', async () => {
+    it('sets up continuous tracking + the periodic offline sync', async () => {
       const { result } = renderHook(() => useLocationTracking());
 
       // Wait for initial mount effects
@@ -264,20 +264,19 @@ describe('useLocationTracking', () => {
         expect(result.current.isTracking).toBe(false);
       });
 
-      // Clear initial calls from mount
-      (navigator.geolocation.getCurrentPosition as jest.Mock).mockClear();
-
       await act(async () => {
         result.current.startTracking();
       });
 
-      // Fast-forward 30 seconds (TRACKING_INTERVAL)
+      // Fast-forward to the 2-minute offline-sync interval
       await act(async () => {
-        jest.advanceTimersByTime(30000);
+        jest.advanceTimersByTime(120000);
       });
 
-      // getCurrentPosition should be called for periodic update
-      expect(navigator.geolocation.getCurrentPosition).toHaveBeenCalled();
+      // Continuous GPS comes from watchPosition (not a getCurrentPosition poll —
+      // that was removed); startTracking also schedules a 2-minute offline sync.
+      expect(navigator.geolocation.watchPosition).toHaveBeenCalled();
+      expect(mockLocationStore.getUnsyncedLocations).toHaveBeenCalled();
     });
 
     it('should sync location to server when tracking', async () => {

--- a/src/hooks/tracking/useLocationTracking.ts
+++ b/src/hooks/tracking/useLocationTracking.ts
@@ -95,6 +95,13 @@ export function useLocationTracking(): UseLocationTrackingReturn {
   const isMountedRef = useRef(true); // Track if component is mounted
   const cachedDriverIdRef = useRef<string | null>(null);
   const lastSyncTimeRef = useRef<number>(0);
+  // Mirror isTracking into a ref so the long-lived watchPosition callback always
+  // reads the live value. The callback registered in startTracking() captures the
+  // isTracking *state* from the same render that calls setIsTracking(true) — i.e.
+  // still false — so the `if (isTracking)` sync gate stayed shut: the device
+  // painted the dot but never POSTed. Bit iOS Safari specifically (Android's
+  // render/callback timing happened to resolve the gate open).
+  const isTrackingRef = useRef(false);
 
   // Get driver ID from session, cached to avoid repeated /api/auth/session fetches
   const getDriverId = useCallback(async (): Promise<string | null> => {
@@ -370,15 +377,17 @@ export function useLocationTracking(): UseLocationTrackingReturn {
       // Update last location reference
       lastLocationRef.current = locationUpdate;
 
-      // Sync to server if tracking is active
-      if (isTracking) {
+      // Sync to server if tracking is active. Read the ref, not the captured
+      // `isTracking` state, so the long-lived watchPosition callback always sees
+      // the current value (see isTrackingRef note above).
+      if (isTrackingRef.current) {
         await syncLocationToServer(locationUpdate);
       }
     } catch (error) {
       console.error('Error handling position update:', error);
       setError(error instanceof Error ? error.message : 'Location update failed');
     }
-  }, [formatLocationUpdate, isTracking, syncLocationToServer]);
+  }, [formatLocationUpdate, syncLocationToServer]);
 
   // Handle geolocation errors
   const handleGeolocationError = useCallback((err: unknown, silent = false) => {
@@ -434,6 +443,7 @@ export function useLocationTracking(): UseLocationTrackingReturn {
     }
 
     setIsTracking(true);
+    isTrackingRef.current = true;
     setError(null);
 
     // Start watching position — watchPosition provides continuous updates,
@@ -457,6 +467,7 @@ export function useLocationTracking(): UseLocationTrackingReturn {
   // Stop location tracking
   const stopTracking = useCallback(() => {
     setIsTracking(false);
+    isTrackingRef.current = false;
 
     if (watchIdRef.current !== null) {
       navigator.geolocation.clearWatch(watchIdRef.current);
@@ -632,6 +643,12 @@ export function useLocationTracking(): UseLocationTrackingReturn {
       stopTracking();
     };
   }, [stopTracking]);
+
+  // Keep the tracking ref in lock-step with state (belt-and-suspenders for the
+  // eager assignments in start/stopTracking).
+  useEffect(() => {
+    isTrackingRef.current = isTracking;
+  }, [isTracking]);
 
   // Monitor online/offline status
   useEffect(() => {


### PR DESCRIPTION
Third fix in the driver-tracking-hardening chain (after #451 + #452), surfaced by the CDMX walk tests.

## Symptom
iPhone (Safari) showed the live dot + "Online · real-time" but `driver_locations` stayed empty. The two **Android** walks posted every cycle (and exposed the `uuid` bugs #451/#452 fixed); both **Safari** sessions — a 34-min walk and a foreground stationary test — wrote **nothing**, with no client write attempts ever reaching the DB.

## Root cause (stale closure)
`startTracking()` registers a long-lived `watchPosition` callback bound to `handlePositionUpdate` captured from the render that calls `setIsTracking(true)` — so its `isTracking` is still **false**. The callback paints the dot (`setCurrentLocation`) but its `if (isTracking)` server-sync gate reads that stale `false` and skips the POST forever. Android's render/callback timing resolved the gate open; iOS Safari/WebKit resolved it shut.

## Fix
- Mirror `isTracking` into `isTrackingRef`; gate the sync on the ref so the long-lived callback always reads the live value.
- `handlePositionUpdate` no longer depends on `isTracking` (now stable).
- Updated the one test that asserted the obsolete 30s `getCurrentPosition` poll (removed long ago for `watchPosition`); it only passed via the unstable-callback side effect this fix removes.

51/51 hook tests green; typecheck clean.

## Note
This is the client-send fix. The separate iOS **background** geolocation limitation (WebKit suspends timers/geolocation when the tab isn't foreground) is unchanged — drivers on iPhone still need the app foreground while moving. Tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)