### PR TITLE
fix(tracking): live-map pickup pin, driver name, mileage, offline state + dedupe catering timeline

### DIFF
--- a/docs/issues-tracker/CONTINUATION-2026-06-18.md
+++ b/docs/issues-tracker/CONTINUATION-2026-06-18.md
@@ -1,0 +1,73 @@
+# Driver-Tracking Punch-List — Continuation / Handoff (2026-06-18)
+
+**Status:** paused for infra migration. This doc is the durable resume point (lives in git, so it survives the move). Full design rationale is in the approved plan at `~/.claude/plans/can-we-plan-everything-replicated-flask.md` (may not migrate — the essentials are duplicated below).
+
+**Source of the work:** the 2026-06-17 walk-test punch-list in `docs/issues-tracker/README.md` → table "2026-06-17 — validation re-test" (LM-1…LM-6, CO-1…CO-3, UX-1…UX-3).
+
+**Strategy (decided with the user):** 3 staged PRs against `development`; design-review-first for the visual items; code fallbacks now, data backfill later.
+
+---
+
+## ✅ DONE — PR1 `fix/tracking-map-data` (branch off `origin/development`)
+
+Commits:
+- `5bd2a15` fix(tracking): pickup pin, driver name, mileage, offline state on admin live map — **LM-1, LM-2, LM-3, LM-4**
+- `6b44cf1` fix(orders): remove duplicate delivery timeline on catering order page — **CO-3**
+
+What landed:
+- **LM-1** pickup/restaurant marker on `/admin/tracking` map — `src/components/Dashboard/Tracking/LiveDriverMap.tsx` (`createPickupMarkerElement`, `pickupMarkersRef`, pickup effect, legend) + `PICKUP_MARKER_COLOR` in `src/constants/tracking-colors.ts`.
+- **LM-2** driver name + "Not set" vehicle in map popup — `LiveDriverMap.tsx` `createPopupContent`.
+- **LM-3** feed emits `total_distance_miles` + `delivery_count` — `src/app/api/tracking/live/route.ts` (`ActiveDriverRow`, SELECT, mapping); popup reads top-level fields.
+- **LM-4** stale→"Offline (no GPS)" state — shared `isLocationStale` in `src/lib/realtime/stale-detection.ts` (+ test `src/lib/realtime/__tests__/stale-detection.test.ts`), used by `LiveDriverMap.tsx` (`getDriverColor`, `DRIVER_STATUS_COLORS.stale`) and `DriverStatusList.tsx` (status dot + Offline badge).
+- **CO-3** removed duplicate sidebar `<DeliveryTimeline>` — `src/components/Orders/SingleOrder.tsx`.
+
+Validated: `pnpm typecheck` ✅ · `pnpm lint` ✅ (only pre-existing warnings) · 185 admin-tracking tests + 4 new `isLocationStale` tests ✅.
+
+**LM-6** (filters): already shipped before this work — no change needed.
+
+**Resume note:** if the PR was opened, finish review/merge. If not, `git push -u origin fix/tracking-map-data` then open a PR vs `development`.
+
+---
+
+## ⏳ TODO — PR2 `fix/tracking-realtime-detail` (NOT STARTED)
+
+Branch off `origin/development`.
+
+### CO-2 — catering page realtime stuck on "connecting" / not updating
+- Root cause is **not** a missing include (the PATCH already `include`s `dispatches.driver` — `src/app/api/orders/[order_number]/route.ts` ~648-680; broadcast guard ~748-754; channel/event names match the subscriber).
+- **Do:**
+  1. **Polling fallback** — add TanStack Query `refetchInterval` (~20-30s, enabled while `isActiveOrder`) to the order query in `src/components/Orders/SingleOrder.tsx` so status updates even when realtime fails. (Primary fix for "not updating".)
+  2. **Honest indicator** — confirm the #446 timeout in `src/hooks/tracking/useDeliveryStatusRealtime.ts` (~202-221) resolves "connecting"→"Offline"; ensure `src/hooks/tracking/useDriverRealtimeLocation.ts` also has a timeout so `secondChannelReady`/the indicator can't hang (SingleOrder gating ~234-256).
+  3. **Confirm broadcast emits** with a seeded assigned+active driver (test order may simply have no dispatched driver). Only if still failing, switch the status channel to Supabase Postgres-changes (like `driver-locations`).
+
+### LM-5 — Deliveries tab: pickup "N/A" + no detail drill-in
+- **Do:**
+  1. **Verify columns first** — `docs/issues-tracker/README.md` flags `proof_of_delivery`/`metadata`/`completed_at`/`catering_request_id`/`on_demand_id` in `src/app/api/tracking/deliveries/[id]/route.ts` GET as possible dead columns; reconcile vs `prisma/schema.prisma` + POD fix (#h → `delivery_photo_url`/`delivery_notes`) before exposing in UI.
+  2. **View-details drawer** — add a button to `DeliveryCard` in `src/components/Dashboard/Tracking/DeliveryAssignmentPanel.tsx` (~133-307) opening a Dialog/Sheet from `src/components/ui/`, populated by `GET /api/tracking/deliveries/[id]`.
+  3. **Pickup text fallback** — in the feed deliveries mapping (`src/app/api/tracking/live/route.ts` ~387-421) return pickup address *text* even when coords are null, so `formatLocation()` (`DeliveryAssignmentPanel.tsx:177`) shows the address instead of "N/A". (Full coord backfill = D1.)
+
+---
+
+## ⏳ TODO — PR3 `design/tracking-ux` (NOT STARTED, design-review-led)
+
+**Step 1:** run `/design-review` on `/admin/catering-orders/[order_number]` and `/driver/deliveries/[order_number]`, then implement against findings. Pre-identified fixes to validate:
+- **CO-1** catering layout — `src/components/Orders/SingleOrder.tsx`: `flex-wrap` the order-details row (~918-958); fix Assign-Driver button overlap (`ml-auto` not fixed `ml-6`, ~963-973); reflow header title+button (~896-975); responsive realtime indicator (~990-998).
+- **UX-1** navigate-to-pickup — `src/components/Driver/DriverDeliveryDetail.tsx`: make `mapsHref` (~122-129) fall back to `lat/lng` when street text is empty (button currently *disappears* when address text is blank — the real walk-test symptom); raise prominence.
+- **UX-2** status CTA affordance — `src/components/Driver/ui/NextAction.tsx` (~57-105): give the sticky "NEXT STEP" CTA unmistakable button chrome + explicit imperative so it doesn't read as an info banner.
+- **UX-3** = net effect of UX-1/UX-2.
+
+---
+
+## ⏳ Deferred workstreams (tracked, not in PR1-3)
+- **D1 — Data backfill (ops):** geocode existing pickup `addresses` (`latitude`/`longitude`); populate `drivers.vehicle_number` (or wire a real vehicle source). Unblocks real values behind LM-2 vehicle + LM-5 pickup.
+- **D2 — Native background GPS:** "driver shows stopped when app closed" true fix needs a native wrapper / background geolocation (web suspends background GPS). See native-wrapper spec (2026-06-17). PR1 only improves admin-side presentation.
+- **D3 — Server-action deploy-skew hardening:** the `IMG_0842` "Server Action … not found" error is a stale-bundle digest mismatch. Add a client error boundary that detects `failed-to-find-server-action` and auto-reloads.
+
+---
+
+## How to resume after migration
+1. `cd repos/ready-set && git fetch origin`
+2. Confirm PR1: `git log origin/fix/tracking-map-data` (or check the open PR). If unpushed, push it and open the PR.
+3. Start PR2: `git checkout -b fix/tracking-realtime-detail origin/development` and work the CO-2 + LM-5 checklist above.
+4. Re-read `docs/issues-tracker/README.md` (punch-list) and this file for context.
+5. Pre-PR gates: `pnpm typecheck && pnpm lint && pnpm test` (scope to touched areas).

--- a/src/app/api/tracking/live/route.ts
+++ b/src/app/api/tracking/live/route.ts
@@ -33,6 +33,8 @@ interface ActiveDriverRow {
   shift_status: string | null;
   shift_start: Date | null;
   total_distance: number | null;
+  total_distance_miles: number | null;
+  delivery_count: number | null;
   active_deliveries: number | string;
 }
 
@@ -194,6 +196,8 @@ export async function GET(request: NextRequest) {
                 ds.status as shift_status,
                 ds.shift_start,
                 ds.total_distance,
+                ds.total_distance_miles,
+                ds.delivery_count,
                 COUNT(CASE WHEN del.status NOT IN ('delivered', 'cancelled') THEN 1 END) as active_deliveries
               FROM drivers d
               LEFT JOIN profiles p ON d.profile_id = p.id
@@ -356,6 +360,12 @@ export async function GET(request: NextRequest) {
                   shiftStatus: driver.shift_status,
                   shiftStart: driver.shift_start,
                   totalDistance: driver.total_distance || 0,
+                  // Primary miles column written by the mileage service at shift end
+                  // (services/tracking/mileage.ts). Consumed by the Drivers tab + map popup.
+                  totalDistanceMiles: driver.total_distance_miles || 0,
+                  // Per-shift completed-delivery counter, incremented on delivery completion
+                  // (api/tracking/deliveries/[id]/route.ts).
+                  deliveryCount: driver.delivery_count || 0,
                   activeDeliveries: (() => {
                     const raw = driver.active_deliveries;
                     const count =

--- a/src/components/Dashboard/Tracking/DriverStatusList.tsx
+++ b/src/components/Dashboard/Tracking/DriverStatusList.tsx
@@ -19,6 +19,7 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { TrackedDriver } from '@/types/tracking';
+import { isLocationStale } from '@/lib/realtime/stale-detection';
 
 interface LocationData {
   driverId: string;
@@ -133,6 +134,8 @@ export default function DriverStatusList({
     const locationData = getLocationData(driver.id);
     const timeSinceUpdate = getTimeSinceUpdate(driver);
     const signalStrength = getSignalStrength(locationData?.accuracy);
+    // On duty but no recent GPS fix (app closed / lost signal) → offline, not "stopped".
+    const isStale = driver.isOnDuty && isLocationStale(driver.lastLocationUpdate);
 
     return (
       <Card className={cn('transition-all duration-200 hover:shadow-md', {
@@ -145,8 +148,9 @@ export default function DriverStatusList({
             <div className="flex-1">
               <div className="flex items-center space-x-3 mb-2">
                 <div className={cn('w-3 h-3 rounded-full', {
-                  'bg-green-500 animate-pulse': driver.isOnDuty && locationData?.isMoving,
-                  'bg-yellow-500': driver.isOnDuty && !locationData?.isMoving,
+                  'bg-green-500 animate-pulse': driver.isOnDuty && !isStale && locationData?.isMoving,
+                  'bg-yellow-500': driver.isOnDuty && !isStale && !locationData?.isMoving,
+                  'bg-slate-400': isStale,
                   'bg-gray-400': !driver.isOnDuty
                 })} />
                 
@@ -168,12 +172,15 @@ export default function DriverStatusList({
                   {driver.isOnDuty ? 'On Duty' : 'Off Duty'}
                 </Badge>
                 
-                {locationData && (
+                {locationData && !isStale && (
                   <Badge variant="outline" className="text-xs">
                     {locationData.activityType === 'driving' && '🚗 Driving'}
                     {locationData.activityType === 'walking' && '🚶 Walking'}
                     {locationData.activityType === 'stationary' && '⏸️ Stopped'}
                   </Badge>
+                )}
+                {isStale && (
+                  <Badge variant="outline" className="text-xs">📴 Offline</Badge>
                 )}
               </div>
 

--- a/src/components/Dashboard/Tracking/LiveDriverMap.tsx
+++ b/src/components/Dashboard/Tracking/LiveDriverMap.tsx
@@ -18,8 +18,9 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { TrackedDriver, DeliveryTracking } from '@/types/tracking';
-import { DRIVER_STATUS_COLORS, BATTERY_STATUS_COLORS, DELIVERY_MARKER_COLOR } from '@/constants/tracking-colors';
+import { DRIVER_STATUS_COLORS, BATTERY_STATUS_COLORS, DELIVERY_MARKER_COLOR, PICKUP_MARKER_COLOR } from '@/constants/tracking-colors';
 import { MAP_CONFIG, MARKER_CONFIG, BATTERY_THRESHOLDS } from '@/constants/tracking-config';
+import { isLocationStale } from '@/lib/realtime/stale-detection';
 import { captureException, captureMessage, addSentryBreadcrumb } from '@/lib/monitoring/sentry';
 
 // Ensure Mapbox token is available
@@ -63,6 +64,7 @@ export default function LiveDriverMap({
   const mapRef = useRef<mapboxgl.Map | null>(null);
   const markersRef = useRef<Map<string, mapboxgl.Marker>>(new Map());
   const deliveryMarkersRef = useRef<Map<string, mapboxgl.Marker>>(new Map());
+  const pickupMarkersRef = useRef<Map<string, mapboxgl.Marker>>(new Map());
   const [selectedDriver, setSelectedDriver] = useState<string | null>(null);
   const [mapStyle, setMapStyle] = useState<MapStyle>('streets');
   const [mapLoaded, setMapLoaded] = useState(false);
@@ -133,14 +135,17 @@ export default function LiveDriverMap({
       // Capture refs at the time of effect setup for cleanup
       const markersRefCurrent = markersRef.current;
       const deliveryMarkersRefCurrent = deliveryMarkersRef.current;
+      const pickupMarkersRefCurrent = pickupMarkersRef.current;
 
       return () => {
         // Clean up markers before removing map to prevent memory leaks
         // Use captured refs to avoid stale closure issues
         markersRefCurrent.forEach(marker => marker.remove());
         deliveryMarkersRefCurrent.forEach(marker => marker.remove());
+        pickupMarkersRefCurrent.forEach(marker => marker.remove());
         markersRefCurrent.clear();
         deliveryMarkersRefCurrent.clear();
+        pickupMarkersRefCurrent.clear();
 
         map.remove();
         mapRef.current = null;
@@ -171,6 +176,9 @@ export default function LiveDriverMap({
   // Get driver color based on status
   const getDriverColor = useCallback((driver: TrackedDriver): string => {
     if (!driver.isOnDuty) return DRIVER_STATUS_COLORS.offDuty;
+
+    // On duty but no recent GPS fix (app closed / lost signal) → offline, not "stopped".
+    if (isLocationStale(driver.lastLocationUpdate)) return DRIVER_STATUS_COLORS.stale;
 
     const recentLocation = recentLocations.find(loc => loc.driverId === driver.id);
     if (recentLocation) {
@@ -274,6 +282,37 @@ export default function LiveDriverMap({
     return el;
   }, []);
 
+  // Create pickup (restaurant) marker element — distinct violet rounded-square
+  // with a shopping-bag glyph, so it reads differently from the orange drop-off pin.
+  const createPickupMarkerElement = useCallback((): HTMLDivElement => {
+    const el = document.createElement('div');
+    el.className = 'pickup-marker';
+    el.style.width = `${MARKER_CONFIG.DELIVERY_MARKER_SIZE}px`;
+    el.style.height = `${MARKER_CONFIG.DELIVERY_MARKER_SIZE}px`;
+
+    el.innerHTML = `
+      <div style="
+        width: ${MARKER_CONFIG.DELIVERY_MARKER_SIZE}px;
+        height: ${MARKER_CONFIG.DELIVERY_MARKER_SIZE}px;
+        background-color: ${PICKUP_MARKER_COLOR};
+        border-radius: 6px;
+        border: 2px solid white;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      ">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4Z"/>
+          <path d="M3 6h18"/>
+          <path d="M16 10a4 4 0 0 1-8 0"/>
+        </svg>
+      </div>
+    `;
+
+    return el;
+  }, []);
+
   // Create popup content
   const createPopupContent = useCallback((driver: TrackedDriver): string => {
     const battery = getBatteryStatus(driver.id);
@@ -282,9 +321,9 @@ export default function LiveDriverMap({
 
     return `
       <div style="padding: 8px; min-width: 200px;">
-        <div style="font-weight: 600; margin-bottom: 8px;">Driver #${driver.employeeId}</div>
+        <div style="font-weight: 600; margin-bottom: 8px;">${driver.name || `Driver #${driver.employeeId}`}</div>
         <div style="font-size: 12px; color: #6b7280; margin-bottom: 8px;">
-          Vehicle: ${driver.vehicleNumber || 'N/A'}
+          Vehicle: ${driver.vehicleNumber || 'Not set'}
         </div>
         <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px;">
           <span style="
@@ -303,10 +342,10 @@ export default function LiveDriverMap({
             </span>
           ` : ''}
         </div>
-        ${driver.currentShift ? `
+        ${driver.isOnDuty ? `
           <div style="font-size: 11px; color: #6b7280;">
-            <div>Deliveries: ${driver.currentShift.deliveryCount || 0}</div>
-            <div>Distance: ${Math.round((driver.currentShift.totalDistanceMiles || 0) * 10) / 10} mi</div>
+            <div>Deliveries: ${driver.deliveryCount || 0}</div>
+            <div>Distance: ${Math.round((driver.totalDistanceMiles || 0) * 10) / 10} mi</div>
           </div>
         ` : ''}
       </div>
@@ -483,6 +522,54 @@ export default function LiveDriverMap({
     });
   }, [deliveries, mapLoaded, createDeliveryMarkerElement]);
 
+  // Update pickup (restaurant) markers — one per delivery that has a known pickup point
+  useEffect(() => {
+    if (!mapRef.current || !mapLoaded) return;
+
+    const currentDeliveryIds = new Set(deliveries.map(d => d.id));
+
+    // Remove pickup markers for deliveries that are no longer in the list
+    pickupMarkersRef.current.forEach((marker, deliveryId) => {
+      if (!currentDeliveryIds.has(deliveryId)) {
+        marker.remove();
+        pickupMarkersRef.current.delete(deliveryId);
+      }
+    });
+
+    // Add or update a pickup marker for each delivery with pickup coordinates
+    deliveries.forEach(delivery => {
+      if (!delivery.pickupLocation?.coordinates) return;
+
+      const [lng, lat] = delivery.pickupLocation.coordinates;
+
+      if (pickupMarkersRef.current.has(delivery.id)) {
+        const marker = pickupMarkersRef.current.get(delivery.id)!;
+        marker.setLngLat([lng, lat]);
+      } else {
+        const el = createPickupMarkerElement();
+        const popup = new mapboxgl.Popup({ offset: 15 })
+          .setHTML(`
+            <div style="padding: 8px;">
+              <div style="font-weight: 600; margin-bottom: 4px;">Pickup Location</div>
+              <div style="font-size: 12px; color: #6b7280;">
+                Order #${delivery.id.substring(0, 8)}
+              </div>
+            </div>
+          `);
+
+        const marker = new mapboxgl.Marker({
+          element: el,
+          anchor: 'center'
+        })
+          .setLngLat([lng, lat])
+          .setPopup(popup)
+          .addTo(mapRef.current!);
+
+        pickupMarkersRef.current.set(delivery.id, marker);
+      }
+    });
+  }, [deliveries, mapLoaded, createPickupMarkerElement]);
+
   // Zoom controls
   const zoomIn = () => {
     mapRef.current?.zoomIn();
@@ -618,8 +705,16 @@ export default function LiveDriverMap({
             <span>Off Duty</span>
           </div>
           <div className="flex items-center space-x-2">
+            <div className="w-3 h-3 bg-slate-500 rounded-full" />
+            <span>Offline (no GPS)</span>
+          </div>
+          <div className="flex items-center space-x-2">
             <div className="w-3 h-3 bg-orange-500 rounded-full" />
             <span>Delivery</span>
+          </div>
+          <div className="flex items-center space-x-2">
+            <div className="w-3 h-3 bg-violet-500 rounded-sm" />
+            <span>Pickup</span>
           </div>
         </div>
       </div>

--- a/src/components/Orders/SingleOrder.tsx
+++ b/src/components/Orders/SingleOrder.tsx
@@ -1262,31 +1262,9 @@ const SingleOrder: React.FC<SingleOrderProps> = ({
               </div>
             </div>
 
-            {/* Order Timeline — hidden on mobile, visible on desktop sidebar */}
-            <div className="hidden overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm md:block">
-              <div className="border-b border-slate-100 p-6">
-                <h2 className="text-lg font-semibold text-slate-800">
-                  Timeline
-                </h2>
-              </div>
-              <div className="p-6">
-                <DeliveryTimeline
-                  createdAt={order.createdAt}
-                  enRouteToVendorAt={(order as any).deliveryTimestamps?.enRouteToVendorAt}
-                  arrivedAtVendorAt={(order as any).deliveryTimestamps?.arrivedAtVendorAt}
-                  pickedUpAt={(order as any).deliveryTimestamps?.pickedUpAt}
-                  enRouteAt={(order as any).deliveryTimestamps?.enRouteAt}
-                  arrivedAtClientAt={(order as any).deliveryTimestamps?.arrivedAtClientAt}
-                  deliveredAt={(order as any).deliveryTimestamps?.deliveredAt}
-                  estimatedPickupTime={order.pickupDateTime}
-                  estimatedDeliveryTime={order.arrivalDateTime ?? order.completeDateTime}
-                  currentStatus={order.driverStatus}
-                  canUpdateStatus={canUserUpdateTimeline}
-                  onStatusUpdate={updateDriverStatus}
-                  compact
-                />
-              </div>
-            </div>
+            {/* Timeline intentionally rendered once, in the main column above
+                (see "Delivery Timeline"). A second sidebar copy duplicated the
+                pickup/delivery times on desktop. */}
           </div>
         </div>
       </motion.div>

--- a/src/constants/tracking-colors.ts
+++ b/src/constants/tracking-colors.ts
@@ -14,6 +14,8 @@ export const DRIVER_STATUS_COLORS = {
   onDuty: '#3b82f6',
   /** Driver is off duty - gray-400 */
   offDuty: '#94a3b8',
+  /** Driver is on duty but hasn't reported GPS recently (app closed / lost signal) - slate-500 */
+  stale: '#64748b',
 } as const;
 
 export const BATTERY_STATUS_COLORS = {
@@ -26,6 +28,7 @@ export const BATTERY_STATUS_COLORS = {
 } as const;
 
 export const DELIVERY_MARKER_COLOR = '#f97316'; // orange-500
+export const PICKUP_MARKER_COLOR = '#8b5cf6'; // violet-500 (restaurant / pickup point)
 
 export type DriverStatusColor = typeof DRIVER_STATUS_COLORS[keyof typeof DRIVER_STATUS_COLORS];
 export type BatteryStatusColor = typeof BATTERY_STATUS_COLORS[keyof typeof BATTERY_STATUS_COLORS];

--- a/src/lib/realtime/__tests__/stale-detection.test.ts
+++ b/src/lib/realtime/__tests__/stale-detection.test.ts
@@ -1,0 +1,24 @@
+import { isLocationStale, STALE_LOCATION_THRESHOLD_MS } from '../stale-detection';
+
+describe('isLocationStale', () => {
+  it('treats a missing timestamp as stale', () => {
+    expect(isLocationStale(undefined)).toBe(true);
+    expect(isLocationStale(null)).toBe(true);
+  });
+
+  it('treats an unparseable timestamp as stale', () => {
+    expect(isLocationStale('not-a-date')).toBe(true);
+  });
+
+  it('returns false for a fresh fix within the threshold', () => {
+    const recent = new Date(Date.now() - (STALE_LOCATION_THRESHOLD_MS - 30_000));
+    expect(isLocationStale(recent)).toBe(false);
+    expect(isLocationStale(recent.toISOString())).toBe(false);
+  });
+
+  it('returns true once the fix is older than the threshold', () => {
+    const old = new Date(Date.now() - (STALE_LOCATION_THRESHOLD_MS + 30_000));
+    expect(isLocationStale(old)).toBe(true);
+    expect(isLocationStale(old.toISOString())).toBe(true);
+  });
+});

--- a/src/lib/realtime/stale-detection.ts
+++ b/src/lib/realtime/stale-detection.ts
@@ -28,6 +28,18 @@ export const STALE_LOCATION_THRESHOLD_MS = 5 * 60 * 1000;
  */
 export const STALE_CHECK_INTERVAL_MS = 60 * 1000;
 
+/**
+ * Lightweight helper for UI components: is a driver's last GPS fix older than the
+ * stale threshold (or missing entirely)? Lets the admin map / driver list render an
+ * "offline" state — distinct from "stopped" — without instantiating the full detector.
+ */
+export function isLocationStale(lastLocationUpdate?: Date | string | null): boolean {
+  if (!lastLocationUpdate) return true;
+  const last = new Date(lastLocationUpdate).getTime();
+  if (Number.isNaN(last)) return true;
+  return Date.now() - last > STALE_LOCATION_THRESHOLD_MS;
+}
+
 // ============================================================================
 // Types
 // ============================================================================


### PR DESCRIPTION
## Summary

Closes the first, high-confidence batch of the **2026-06-17 driver-tracking walk-test punch-list** (`docs/issues-tracker/README.md` → table "2026-06-17 — validation re-test"). Targets the admin live map (`/admin/tracking`) and the catering order page.

| Issue | Fix |
|---|---|
| **LM-1** | Render a distinct **violet restaurant/pickup marker** per delivery on the live map (the SSE feed already provides `pickupLocation`); own marker ref + cleanup + legend entry. |
| **LM-2** | Map popup shows the driver's resolved **name** (falls back to `Driver #<employeeId>`) and a clearer **"Not set"** vehicle fallback. |
| **LM-3** | Live SSE feed now selects `total_distance_miles` + `delivery_count` and maps them to the fields the Drivers tab & popup read (was emitting legacy `total_distance` and omitting the count). Popup reads top-level fields instead of the never-populated `currentShift`. |
| **LM-4** | On-duty drivers with no recent GPS now show **"Offline (no GPS)"** instead of "Stopped", via a shared `isLocationStale` helper (reused by map + list). Display-only; native background GPS is a separate effort. |
| **CO-3** | Removed the **duplicate sidebar `DeliveryTimeline`** on the catering order page (was showing the delivery time twice on desktop). |

## Validation

- `pnpm typecheck` ✅
- `pnpm lint` ✅ (only pre-existing warnings in untouched files)
- Tests ✅ — 185 admin-tracking tests + 4 new `isLocationStale` unit tests

## Test plan

- `/admin/tracking` → **Map** tab: each active delivery shows a violet pickup pin **and** an orange drop-off pin; driver popup shows **name** + **miles** + **delivery count**; a driver with no GPS fix in 5 min shows **Offline**.
- **Drivers** tab: distance/count non-zero for a driver with a completed shift; a stale driver shows the **Offline** badge instead of "Stopped".
- `/admin/catering-orders/<order_number>`: a **single** delivery timeline on desktop (no duplicated time).

## Not in this PR (follow-ups)

See `docs/issues-tracker/CONTINUATION-2026-06-18.md` for the full resume plan.

- **PR2** (`fix/tracking-realtime-detail`) — CO-2 (catering page realtime / "connecting") + LM-5 (delivery detail drill-in + pickup text fallback)
- **PR3** (`design/tracking-ux`, design-review-led) — CO-1 (catering layout) + UX-1/2/3 (driver action-button discoverability)
- **Deferred** — D1 data backfill (`vehicle_number`, pickup geocoding), D2 native background GPS (true persistent tracking), D3 server-action deploy-skew hardening

🤖 Generated with [Claude Code](https://claude.com/claude-code)
