### PR TITLE
feat: add CaterCow and FreshRoll partner logos

### DIFF
--- a/src/components/FoodDelivery/DeliveryPartners.tsx
+++ b/src/components/FoodDelivery/DeliveryPartners.tsx
@@ -85,6 +85,18 @@ const DEFAULT_FOOD_PARTNERS: PartnerLogo[] = [
       alt: "La BBQ logo",
       url: "https://labarbecue.com/#",
     },
+    {
+      name: "CaterCow",
+      image: getCloudinaryUrl("food/partners/catercow"),
+      alt: "CaterCow logo",
+      url: "https://www.catercow.com/",
+    },
+    {
+      name: "FreshRoll",
+      image: getCloudinaryUrl("food/partners/freshroll"),
+      alt: "FreshRoll Vietnamese Rolls & Bowls logo",
+      url: "https://freshroll.square.site/",
+    },
   ];
 
 const DeliveryPartners: React.FC<DeliveryPartnersProps> = ({


### PR DESCRIPTION
## Summary

- Add **CaterCow** and **FreshRoll Vietnamese Rolls & Bowls** to the "Our Food Delivery Partners" logo grid
- Both logos were pre-uploaded to Cloudinary (`food/partners/catercow`, `food/partners/freshroll`)
- Partner count goes from 10 → 12 (8 in the main grid row, 4 in the centered overflow row)

## Changes

**`src/components/FoodDelivery/DeliveryPartners.tsx`**
- Added CaterCow entry (`catercow.com`)
- Added FreshRoll entry (`freshroll.square.site`)

## Database migrations

None — this is a UI-only change with no schema modifications.

## Breaking changes

None.

## Testing performed

- **Typecheck**: `pnpm typecheck` passes
- **Lint**: `pnpm lint` passes (no new warnings)
- **Prisma validate**: passes
- **Manual**: Verified Cloudinary public IDs resolve correctly via `getCloudinaryUrl()`

## Reviewer checklist

- [x] Confirm Cloudinary images render at correct aspect ratios (object-contain)
- [x] Verify responsive grid layout still looks balanced with 12 logos (4 in overflow row)
- [x] Confirm partner URLs are correct: `https://www.catercow.com/` and `https://freshroll.square.site/`
- [x] Check alt text is appropriate for accessibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)