### PR TITLE
feat(driver): clearer Navigate button + choose maps app (Waze/Google/Apple)

### DIFF
--- a/src/components/Driver/DriverDeliveryDetail.tsx
+++ b/src/components/Driver/DriverDeliveryDetail.tsx
@@ -7,7 +7,6 @@ import {
   AlertTriangle,
   CheckCircle2,
   MapPin,
-  Navigation,
   Package,
   StickyNote,
   Store,
@@ -31,6 +30,7 @@ import {
   resolveDriverStatus,
 } from "@/components/Driver/ui";
 import { DriverPodSheet } from "@/components/Driver/ui/DriverPodSheet";
+import { NavigateButton } from "@/components/Driver/ui/NavigateButton";
 
 /**
  * Driver-specific Delivery Detail.
@@ -119,13 +119,12 @@ function formatAddressLines(addr?: AddressLike | null): string[] {
   return [line1, line2].filter((l) => l.length > 0);
 }
 
-function mapsHref(addr?: AddressLike | null): string | null {
+function addressQuery(addr?: AddressLike | null): string | null {
   if (!addr) return null;
   const q = [addr.street1, addr.street2, addr.city, addr.state, addr.zip]
     .filter(Boolean)
     .join(", ");
-  if (!q) return null;
-  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(q)}`;
+  return q || null;
 }
 
 interface DriverDeliveryDetailProps {
@@ -342,8 +341,8 @@ export function DriverDeliveryDetail({ orderNumber }: DriverDeliveryDetailProps)
     (order.pickupAddress?.isRestaurant ? "Restaurant" : "Pickup");
   const pickupLines = formatAddressLines(order.pickupAddress);
   const deliveryLines = formatAddressLines(order.deliveryAddress);
-  const pickupMaps = mapsHref(order.pickupAddress);
-  const deliveryMaps = mapsHref(order.deliveryAddress);
+  const pickupQuery = addressQuery(order.pickupAddress);
+  const deliveryQuery = addressQuery(order.deliveryAddress);
 
   return (
     <div className="flex flex-col gap-3 px-2 pb-32">
@@ -412,16 +411,12 @@ export function DriverDeliveryDetail({ orderNumber }: DriverDeliveryDetailProps)
             <span>{order.pickupNotes}</span>
           </div>
         ) : null}
-        {pickupMaps ? (
-          <a
-            href={pickupMaps}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex min-h-driver-touch items-center justify-center gap-2 rounded-xl border border-driver-border bg-driver-surface-alt px-4 text-[13.5px] font-extrabold text-driver-text active:translate-y-px"
-          >
-            <Navigation className="h-4 w-4" strokeWidth={2.4} />
-            Directions to pickup
-          </a>
+        {pickupQuery ? (
+          <NavigateButton
+            target={{ address: pickupQuery }}
+            label="Directions to pickup"
+            className="mt-0.5"
+          />
         ) : null}
       </DriverCard>
 
@@ -460,16 +455,12 @@ export function DriverDeliveryDetail({ orderNumber }: DriverDeliveryDetailProps)
             <span>{order.specialNotes}</span>
           </div>
         ) : null}
-        {deliveryMaps ? (
-          <a
-            href={deliveryMaps}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex min-h-driver-touch items-center justify-center gap-2 rounded-xl border border-driver-border bg-driver-surface-alt px-4 text-[13.5px] font-extrabold text-driver-text active:translate-y-px"
-          >
-            <Navigation className="h-4 w-4" strokeWidth={2.4} />
-            Directions to drop-off
-          </a>
+        {deliveryQuery ? (
+          <NavigateButton
+            target={{ address: deliveryQuery }}
+            label="Directions to drop-off"
+            className="mt-0.5"
+          />
         ) : null}
       </DriverCard>
 

--- a/src/components/Driver/DriverTrackingPortal.tsx
+++ b/src/components/Driver/DriverTrackingPortal.tsx
@@ -32,6 +32,7 @@ import {
   getStatusProgress,
 } from "@/components/Driver/ui";
 import { DriverPodSheet } from "@/components/Driver/ui/DriverPodSheet";
+import { NavigateButton } from "@/components/Driver/ui/NavigateButton";
 
 interface PodTarget {
   deliveryId: string;
@@ -397,15 +398,7 @@ export default function DriverTrackingPortal() {
                       )}
 
                       {typeof lat === "number" && typeof lng === "number" ? (
-                        <a
-                          href={`https://maps.google.com/?q=${lat},${lng}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="flex items-center justify-center gap-1.5 text-[12.5px] font-bold text-driver-on-brand"
-                        >
-                          <Navigation2 className="h-3.5 w-3.5" />
-                          Navigate
-                        </a>
+                        <NavigateButton target={{ lat, lng }} label="Navigate" />
                       ) : null}
                     </DriverCard>
                   );

--- a/src/components/Driver/ui/NavigateButton.tsx
+++ b/src/components/Driver/ui/NavigateButton.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { ChevronDown, Navigation } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  buildNavigationUrl,
+  getPreferredNavApp,
+  setPreferredNavApp,
+  type NavApp,
+  type NavTarget,
+} from "@/lib/driver-navigation";
+import { DriverButton } from "./DriverButton";
+import { NavigationAppSheet } from "./NavigationAppSheet";
+
+interface NavigateButtonProps {
+  target: NavTarget;
+  /** Button label, e.g. "Directions to pickup". Defaults to "Navigate". */
+  label?: string;
+  className?: string;
+}
+
+/**
+ * Prominent, brand-colored "Navigate" button for the driver app.
+ *
+ * Replaces the old low-contrast `<a>` links (a tester couldn't find them). The
+ * primary tap opens the driver's remembered maps app; the adjacent chevron opens
+ * a chooser (Google / Apple / Waze), persisting the choice for next time.
+ */
+export function NavigateButton({ target, label = "Navigate", className }: NavigateButtonProps) {
+  const [sheetOpen, setSheetOpen] = useState(false);
+  // Default to the SSR-safe value, then hydrate from localStorage on the client
+  // (avoids a hydration mismatch on the remembered preference).
+  const [pref, setPref] = useState<NavApp>("google");
+
+  useEffect(() => {
+    setPref(getPreferredNavApp());
+  }, []);
+
+  const openWith = useCallback(
+    (app: NavApp) => {
+      const url = buildNavigationUrl(app, target);
+      if (url) window.open(url, "_blank", "noopener,noreferrer");
+    },
+    [target],
+  );
+
+  const handleSelect = useCallback(
+    (app: NavApp) => {
+      setPreferredNavApp(app);
+      setPref(app);
+      setSheetOpen(false);
+      openWith(app);
+    },
+    [openWith],
+  );
+
+  return (
+    <div className={cn("flex items-stretch gap-1.5", className)}>
+      <DriverButton
+        variant="brand"
+        onClick={() => openWith(pref)}
+        aria-label={label}
+        className="flex-1"
+      >
+        <Navigation className="h-4 w-4" strokeWidth={2.6} />
+        {label}
+      </DriverButton>
+      <DriverButton
+        variant="outline"
+        onClick={() => setSheetOpen(true)}
+        aria-label="Choose navigation app"
+        className="px-3"
+      >
+        <ChevronDown className="h-4 w-4" strokeWidth={2.6} />
+      </DriverButton>
+      <NavigationAppSheet
+        open={sheetOpen}
+        onOpenChange={setSheetOpen}
+        current={pref}
+        onSelect={handleSelect}
+      />
+    </div>
+  );
+}

--- a/src/components/Driver/ui/NavigationAppSheet.tsx
+++ b/src/components/Driver/ui/NavigationAppSheet.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Check } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+import { NAV_APPS, type NavApp } from "@/lib/driver-navigation";
+import { useDriverTheme } from "./DriverThemeProvider";
+
+interface NavigationAppSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Currently-remembered app, highlighted in the list. */
+  current: NavApp;
+  /** Fired when the driver taps an app — persist + open should happen in the parent. */
+  onSelect: (app: NavApp) => void;
+}
+
+/** Bottom-sheet chooser for the driver's navigation app (Google / Apple / Waze).
+ *  Mirrors the DriverPodSheet pattern (driver-theme scoped bottom sheet). */
+export function NavigationAppSheet({
+  open,
+  onOpenChange,
+  current,
+  onSelect,
+}: NavigationAppSheetProps) {
+  const { resolved } = useDriverTheme();
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        className={cn(
+          "driver-theme rounded-t-3xl border-driver-border bg-driver-surface",
+          resolved === "dark" && "dark",
+        )}
+      >
+        <div className="mx-auto w-full max-w-md">
+          <SheetHeader className="items-start">
+            <SheetTitle className="text-[18px] font-extrabold text-driver-text">
+              Navigate with
+            </SheetTitle>
+          </SheetHeader>
+          <div className="mt-4 flex flex-col gap-2 pb-2">
+            {NAV_APPS.map((app) => {
+              const active = app.id === current;
+              return (
+                <button
+                  key={app.id}
+                  type="button"
+                  onClick={() => onSelect(app.id)}
+                  aria-pressed={active}
+                  className={cn(
+                    "flex min-h-driver-control items-center justify-between rounded-2xl border-[1.5px] px-4 text-[15px] font-extrabold text-driver-text transition-all active:translate-y-px",
+                    active
+                      ? "border-driver-brand bg-driver-surface-alt"
+                      : "border-driver-border bg-driver-surface-alt",
+                  )}
+                >
+                  {app.label}
+                  {active ? (
+                    <Check className="h-4 w-4 text-driver-success" strokeWidth={3} />
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/Driver/ui/__tests__/NavigateButton.test.tsx
+++ b/src/components/Driver/ui/__tests__/NavigateButton.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { NavigateButton } from "../NavigateButton";
+import { DriverThemeProvider } from "../DriverThemeProvider";
+
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<DriverThemeProvider>{ui}</DriverThemeProvider>);
+}
+
+describe("NavigateButton", () => {
+  const openSpy = jest.fn();
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    openSpy.mockReset();
+    // jsdom has no real window.open
+    window.open = openSpy as unknown as typeof window.open;
+  });
+
+  it("opens the default app (Google) with a directions URL on tap", () => {
+    renderWithTheme(
+      <NavigateButton
+        target={{ lat: 37.79, lng: -122.45 }}
+        label="Directions to pickup"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Directions to pickup" }));
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    const url = String(openSpy.mock.calls[0][0]);
+    expect(url).toContain("google.com/maps/dir/");
+    expect(url).toContain(encodeURIComponent("37.79,-122.45"));
+  });
+
+  it("lets the driver switch maps app and remembers the choice", async () => {
+    renderWithTheme(
+      <NavigateButton target={{ lat: 37.79, lng: -122.45 }} label="Navigate" />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Choose navigation app" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Waze" }));
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(String(openSpy.mock.calls[0][0])).toContain("waze.com/ul");
+    expect(window.localStorage.getItem("rs:driverNavApp")).toBe("waze");
+  });
+});

--- a/src/lib/__tests__/driver-navigation.test.ts
+++ b/src/lib/__tests__/driver-navigation.test.ts
@@ -1,0 +1,81 @@
+import {
+  buildNavigationUrl,
+  getPreferredNavApp,
+  setPreferredNavApp,
+  isNavApp,
+  NAV_APPS,
+  DEFAULT_NAV_APP,
+} from "@/lib/driver-navigation";
+
+describe("buildNavigationUrl — coordinates", () => {
+  const target = { lat: 37.7879, lng: -122.4502 };
+  const ll = encodeURIComponent("37.7879,-122.4502");
+
+  it("builds a Google Maps directions URL", () => {
+    expect(buildNavigationUrl("google", target)).toBe(
+      `https://www.google.com/maps/dir/?api=1&destination=${ll}`,
+    );
+  });
+
+  it("builds an Apple Maps driving URL", () => {
+    expect(buildNavigationUrl("apple", target)).toBe(
+      `https://maps.apple.com/?daddr=${ll}&dirflg=d`,
+    );
+  });
+
+  it("builds a Waze URL that starts navigation", () => {
+    expect(buildNavigationUrl("waze", target)).toBe(
+      `https://waze.com/ul?ll=${ll}&navigate=yes`,
+    );
+  });
+
+  it("returns null for non-finite coordinates", () => {
+    expect(buildNavigationUrl("google", { lat: NaN, lng: 1 })).toBeNull();
+  });
+});
+
+describe("buildNavigationUrl — address", () => {
+  const target = { address: "390 Laurel St, San Francisco, CA" };
+  const q = encodeURIComponent("390 Laurel St, San Francisco, CA");
+
+  it("builds each app's URL from a free-text address", () => {
+    expect(buildNavigationUrl("google", target)).toBe(
+      `https://www.google.com/maps/dir/?api=1&destination=${q}`,
+    );
+    expect(buildNavigationUrl("apple", target)).toBe(
+      `https://maps.apple.com/?daddr=${q}&dirflg=d`,
+    );
+    expect(buildNavigationUrl("waze", target)).toBe(
+      `https://waze.com/ul?q=${q}&navigate=yes`,
+    );
+  });
+
+  it("returns null for a blank address", () => {
+    expect(buildNavigationUrl("google", { address: "   " })).toBeNull();
+  });
+});
+
+describe("navigation-app preference", () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it("defaults to Google when nothing is stored", () => {
+    expect(getPreferredNavApp()).toBe(DEFAULT_NAV_APP);
+    expect(DEFAULT_NAV_APP).toBe("google");
+  });
+
+  it("round-trips a stored choice", () => {
+    setPreferredNavApp("waze");
+    expect(getPreferredNavApp()).toBe("waze");
+  });
+
+  it("ignores an invalid stored value", () => {
+    window.localStorage.setItem("rs:driverNavApp", "bogus");
+    expect(getPreferredNavApp()).toBe("google");
+  });
+
+  it("guards values with isNavApp and exposes the three apps in order", () => {
+    expect(isNavApp("waze")).toBe(true);
+    expect(isNavApp("bogus")).toBe(false);
+    expect(NAV_APPS.map((a) => a.id)).toEqual(["google", "apple", "waze"]);
+  });
+});

--- a/src/lib/driver-navigation.ts
+++ b/src/lib/driver-navigation.ts
@@ -1,0 +1,96 @@
+/**
+ * Driver navigation helpers — build deep links to the driver's chosen maps app
+ * (Google Maps / Apple Maps / Waze) and remember the preference.
+ *
+ * Universal `https://` links are used on purpose (not custom schemes like
+ * `comgooglemaps://` or `waze://`): an https maps link opens the native app when
+ * it's installed and falls back to the web otherwise, and it sidesteps the iOS
+ * custom-scheme allowlist (`LSApplicationQueriesSchemes`) that would otherwise
+ * silently fail for an app the user doesn't have.
+ */
+
+export type NavApp = "google" | "apple" | "waze";
+
+export interface NavAppMeta {
+  id: NavApp;
+  label: string;
+}
+
+/** Ordered list for the chooser UI. Google first = the historical default. */
+export const NAV_APPS: readonly NavAppMeta[] = [
+  { id: "google", label: "Google Maps" },
+  { id: "apple", label: "Apple Maps" },
+  { id: "waze", label: "Waze" },
+] as const;
+
+/** A navigation destination — either a geocoded coordinate or a free-text address. */
+export type NavTarget = { lat: number; lng: number } | { address: string };
+
+const STORAGE_KEY = "rs:driverNavApp";
+export const DEFAULT_NAV_APP: NavApp = "google";
+
+export function isNavApp(value: unknown): value is NavApp {
+  return value === "google" || value === "apple" || value === "waze";
+}
+
+/** Read the driver's remembered maps app (defaults to Google). SSR-safe. */
+export function getPreferredNavApp(): NavApp {
+  if (typeof window === "undefined") return DEFAULT_NAV_APP;
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    return isNavApp(stored) ? stored : DEFAULT_NAV_APP;
+  } catch {
+    return DEFAULT_NAV_APP;
+  }
+}
+
+/** Persist the driver's maps-app choice. No-op on the server / on storage errors. */
+export function setPreferredNavApp(app: NavApp): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, app);
+  } catch {
+    /* private mode / disabled storage — ignore */
+  }
+}
+
+function hasCoords(t: NavTarget): t is { lat: number; lng: number } {
+  return (
+    typeof (t as { lat?: unknown }).lat === "number" &&
+    typeof (t as { lng?: unknown }).lng === "number"
+  );
+}
+
+/**
+ * Build a turn-by-turn navigation URL for the chosen app. Origin is the device's
+ * current location; destination is `target`. Returns `null` when the target is
+ * empty (no coords / blank address) so callers can hide the button.
+ */
+export function buildNavigationUrl(app: NavApp, target: NavTarget): string | null {
+  if (hasCoords(target)) {
+    const { lat, lng } = target;
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+    const ll = `${lat},${lng}`;
+    switch (app) {
+      case "waze":
+        return `https://waze.com/ul?ll=${encodeURIComponent(ll)}&navigate=yes`;
+      case "apple":
+        return `https://maps.apple.com/?daddr=${encodeURIComponent(ll)}&dirflg=d`;
+      case "google":
+      default:
+        return `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(ll)}`;
+    }
+  }
+
+  const query = target.address.trim();
+  if (!query) return null;
+  switch (app) {
+    case "waze":
+      return `https://waze.com/ul?q=${encodeURIComponent(query)}&navigate=yes`;
+    case "apple":
+      return `https://maps.apple.com/?daddr=${encodeURIComponent(query)}&dirflg=d`;
+    case "google":
+    default:
+      return `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(query)}`;
+  }
+}


### PR DESCRIPTION
## Why

From the **2026-06-22 live driver test with Gary** (`meetings/shared/2026-06-22-dev-team-meeting.md`):
1. The "Navigate"/"Directions" buttons were hard to find — low-contrast `bg-driver-surface-alt` links that blended into the card.
2. Tapping Navigate always opened Google Maps with no option to use Waze.

Board cards: `nav-button-visibility`, `nav-app-choice`.

## What

- **New `src/lib/driver-navigation.ts`** — `buildNavigationUrl(app, target)` for `google | apple | waze`, accepting either `{lat,lng}` or `{address}`. Uses **universal `https://` links** (deep-links to the native app when installed, falls back to web) to sidestep the iOS custom-scheme allowlist. Plus `getPreferredNavApp` / `setPreferredNavApp` (localStorage, default Google).
- **New `NavigateButton`** primitive — prominent `DriverButton` brand variant + a chevron that opens a chooser; remembers the driver's pick per device.
- **New `NavigationAppSheet`** — bottom-sheet chooser (mirrors `DriverPodSheet`), driver-theme scoped.
- **Wired** into `DriverDeliveryDetail` (pickup + drop-off) and `DriverTrackingPortal`; removed the inline `mapsHref`/hardcoded `maps.google.com` URLs.

No API / schema / request-response changes — pure driver UI.

## Testing

- `src/lib/__tests__/driver-navigation.test.ts` — URL builder per app × {coords, address}, null cases, preference round-trip (8 tests).
- `src/components/Driver/ui/__tests__/NavigateButton.test.tsx` — taps open the default app; switching to Waze opens Waze + persists the choice (2 tests).
- Existing `DriverDeliveryDetail` / `DriverTrackingPortal` suites still green.
- `pnpm pre-push-check` green (typecheck, prisma generate, lint, token guardrail — 0 violations in 406 added lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)