### PR TITLE
feat(driver): require a vendor-staff signature at pickup

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "sanity": "^4.22.0",
     "sanity-plugin-seo": "1.3.6",
     "server-only": "^0.0.1",
+    "signature_pad": "^5.1.3",
     "stripe": "^20.4.1",
     "styled-components": "^6.3.11",
     "tailgrids": "^2.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -421,6 +421,9 @@ importers:
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
+      signature_pad:
+        specifier: ^5.1.3
+        version: 5.1.3
       stripe:
         specifier: ^20.4.1
         version: 20.4.1(@types/node@25.5.0)
@@ -11027,6 +11030,9 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  signature_pad@5.1.3:
+    resolution: {integrity: sha512-zyxW5vuJVnQdGcU+kAj9FYl7WaAunY3kA5S7mPg0xJiujL9+sPAWfSQHS5tXaJXDUa4FuZeKhfdCDQ6K3wfkpQ==}
 
   simple-swizzle@0.2.4:
     resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
@@ -24700,6 +24706,8 @@ snapshots:
   signal-exit@4.0.2: {}
 
   signal-exit@4.1.0: {}
+
+  signature_pad@5.1.3: {}
 
   simple-swizzle@0.2.4:
     dependencies:

--- a/prisma/migrations/20260623000000_add_pickup_signature/migration.sql
+++ b/prisma/migrations/20260623000000_add_pickup_signature/migration.sql
@@ -1,0 +1,5 @@
+-- Add a pickup-stage signature URL to the standalone `deliveries` mirror row.
+-- Captured manually from the restaurant staff at vendor pickup (not DocuSign);
+-- mirrored from the canonical FileUpload (category = 'pickup_signature'), the
+-- same pattern as delivery_photo_url. Additive + nullable → safe no-op backfill.
+ALTER TABLE "public"."deliveries" ADD COLUMN IF NOT EXISTS "pickup_signature_url" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -930,6 +930,7 @@ model Delivery {
   signatureRequired      Boolean?  @default(false) @map("signature_required")
   photoRequired          Boolean?  @default(false) @map("photo_required")
   deliverySignatureUrl   String?   @map("delivery_signature_url")
+  pickupSignatureUrl     String?   @map("pickup_signature_url")
   deliveryPhotoUrl       String?   @map("delivery_photo_url")
   deliveryNotes          String?   @map("delivery_notes")
   createdAt              DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)

--- a/src/app/api/orders/[order_number]/signature/__tests__/route.test.ts
+++ b/src/app/api/orders/[order_number]/signature/__tests__/route.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for the pickup-signature POST route. Mirrors the POD route: auth + role
+ * + driver-assignment gating, FileUpload (category = 'pickup_signature'), and a
+ * non-fatal mirror of the URL onto the standalone `deliveries` row.
+ */
+
+jest.mock('@/utils/prismaDB');
+jest.mock('@/utils/supabase/server');
+jest.mock('@/utils/supabase/storage', () => ({
+  uploadPickupSignatureImage: jest.fn(),
+}));
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn(), captureMessage: jest.fn() }));
+
+import { NextRequest } from 'next/server';
+import { prisma } from '@/utils/prismaDB';
+import { createClient } from '@/utils/supabase/server';
+import { uploadPickupSignatureImage } from '@/utils/supabase/storage';
+import * as Sentry from '@sentry/nextjs';
+
+const mockedPrisma = jest.mocked(prisma);
+const mockedCreateClient = jest.mocked(createClient);
+const mockedUpload = uploadPickupSignatureImage as jest.Mock;
+const mockedSentry = Sentry as unknown as { captureException: jest.Mock };
+
+const SIG_URL = 'https://cdn.example.com/signatures/sig.png';
+
+const makeFile = () =>
+  ({ name: 'pickup-signature.png', type: 'image/png', size: 512 } as unknown as File);
+
+const createPostRequest = (orderNumber = 'CAT-001', file: File | null = makeFile()) => {
+  const req = new NextRequest(
+    `http://localhost:3000/api/orders/${orderNumber}/signature`,
+    { method: 'POST' },
+  );
+  (req as any).formData = jest.fn().mockResolvedValue({
+    get: (k: string) => (k === 'file' ? file : null),
+  });
+  return req;
+};
+
+const setupMocks = (opts: { role?: string; user?: any } = {}) => {
+  const role = opts.role ?? 'ADMIN';
+  const user = opts.user === undefined ? { id: 'user-1' } : opts.user;
+
+  mockedCreateClient.mockResolvedValue({
+    auth: {
+      getUser: jest.fn().mockResolvedValue({ data: { user }, error: null }),
+    },
+  } as any);
+
+  (mockedPrisma.profile.findUnique as jest.Mock).mockResolvedValue({ id: 'user-1', type: role });
+  (mockedPrisma.cateringRequest.findFirst as jest.Mock).mockResolvedValue({
+    id: 'order-123',
+    orderNumber: 'CAT-001',
+  });
+  (mockedPrisma.onDemand.findFirst as jest.Mock).mockResolvedValue(null);
+  (mockedPrisma.dispatch.findFirst as jest.Mock).mockResolvedValue({ id: 'dispatch-1' });
+  (mockedPrisma.fileUpload.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
+  (mockedPrisma.fileUpload.create as jest.Mock).mockResolvedValue({ id: 'file-1' });
+  (mockedPrisma.$executeRawUnsafe as jest.Mock).mockResolvedValue(1);
+
+  mockedUpload.mockResolvedValue({ url: SIG_URL, path: 'signatures/sig.png', error: null });
+};
+
+const importRoute = async () => import('../route');
+const params = (order_number: string) => ({ params: Promise.resolve({ order_number }) });
+
+describe('pickup signature POST', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupMocks();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    setupMocks({ user: null });
+    const { POST } = await importRoute();
+    const res = await POST(createPostRequest(), params('CAT-001'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for a non-driver/admin role', async () => {
+    setupMocks({ role: 'CLIENT' });
+    const { POST } = await importRoute();
+    const res = await POST(createPostRequest(), params('CAT-001'));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when the order does not exist', async () => {
+    setupMocks();
+    (mockedPrisma.cateringRequest.findFirst as jest.Mock).mockResolvedValue(null);
+    (mockedPrisma.onDemand.findFirst as jest.Mock).mockResolvedValue(null);
+    const { POST } = await importRoute();
+    const res = await POST(createPostRequest('NOPE'), params('NOPE'));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 for a driver not assigned to the order', async () => {
+    setupMocks({ role: 'DRIVER' });
+    (mockedPrisma.dispatch.findFirst as jest.Mock).mockResolvedValue(null);
+    const { POST } = await importRoute();
+    const res = await POST(createPostRequest(), params('CAT-001'));
+    expect(res.status).toBe(403);
+  });
+
+  it('uploads + mirrors the signature URL onto the deliveries row', async () => {
+    const { POST } = await importRoute();
+    const res = await POST(createPostRequest('CAT-001'), params('CAT-001'));
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(data.url).toBe(SIG_URL);
+
+    expect(mockedPrisma.fileUpload.create as jest.Mock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          category: 'pickup_signature',
+          cateringRequestId: 'order-123',
+        }),
+      }),
+    );
+
+    const [sql, urlArg, orderArg] = (mockedPrisma.$executeRawUnsafe as jest.Mock).mock.calls[0];
+    expect(sql).toContain('UPDATE deliveries');
+    expect(sql).toContain('pickup_signature_url');
+    expect(sql).toContain('LOWER(order_number) = LOWER($2)');
+    expect(sql).toContain('deleted_at IS NULL');
+    expect(urlArg).toBe(SIG_URL);
+    expect(orderArg).toBe('CAT-001');
+  });
+
+  it('still succeeds when the deliveries mirror throws (non-fatal)', async () => {
+    setupMocks();
+    (mockedPrisma.$executeRawUnsafe as jest.Mock).mockRejectedValue(new Error('no deliveries row'));
+    const { POST } = await importRoute();
+    const res = await POST(createPostRequest('CAT-001'), params('CAT-001'));
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+    expect(mockedSentry.captureException).toHaveBeenCalled();
+  });
+
+  it('returns 500 and skips the mirror when the upload fails', async () => {
+    setupMocks();
+    mockedUpload.mockResolvedValue({ url: null, path: null, error: 'storage down' });
+    const { POST } = await importRoute();
+    const res = await POST(createPostRequest('CAT-001'), params('CAT-001'));
+
+    expect(res.status).toBe(500);
+    expect(mockedPrisma.$executeRawUnsafe as jest.Mock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/orders/[order_number]/signature/route.ts
+++ b/src/app/api/orders/[order_number]/signature/route.ts
@@ -1,0 +1,220 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/utils/supabase/server';
+import { prisma } from '@/utils/prismaDB';
+import { uploadPickupSignatureImage } from '@/utils/supabase/storage';
+import * as Sentry from '@sentry/nextjs';
+
+/**
+ * POST - Upload a pickup-stage signature for an order.
+ *
+ * Mirrors the POD route (`../pod/route.ts`): a manual capture of the restaurant
+ * staff member's signature when the driver picks up the food (NOT DocuSign).
+ * Creates a FileUpload (category = 'pickup_signature') linked to the catering /
+ * on-demand order, then mirrors the URL onto the standalone `deliveries` row.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ order_number: string }> }
+) {
+  try {
+    const { order_number: encodedOrderNumber } = await params;
+    const orderNumber = decodeURIComponent(encodedOrderNumber);
+
+    // Authenticate user
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user?.id) {
+      return NextResponse.json(
+        { success: false, error: 'Unauthorized' },
+        { status: 401 }
+      );
+    }
+
+    // Get user profile to check role
+    const userProfile = await prisma.profile.findUnique({
+      where: { id: user.id },
+      select: { id: true, type: true },
+    });
+
+    if (!userProfile) {
+      return NextResponse.json(
+        { success: false, error: 'User profile not found' },
+        { status: 404 }
+      );
+    }
+
+    // Only DRIVER, ADMIN, or SUPER_ADMIN can capture a pickup signature
+    const allowedRoles = ['DRIVER', 'ADMIN', 'SUPER_ADMIN'];
+    if (!allowedRoles.includes(userProfile.type)) {
+      return NextResponse.json(
+        { success: false, error: 'Access denied' },
+        { status: 403 }
+      );
+    }
+
+    // Find the order (try catering first, then on-demand)
+    let orderId: string | null = null;
+    let orderType: 'catering' | 'on_demand' | null = null;
+
+    const cateringRequest = await prisma.cateringRequest.findFirst({
+      where: {
+        orderNumber: { equals: orderNumber, mode: 'insensitive' },
+        deletedAt: null,
+      },
+      select: { id: true, orderNumber: true },
+    });
+
+    if (cateringRequest) {
+      orderId = cateringRequest.id;
+      orderType = 'catering';
+    } else {
+      const onDemandOrder = await prisma.onDemand.findFirst({
+        where: {
+          orderNumber: { equals: orderNumber, mode: 'insensitive' },
+          deletedAt: null,
+        },
+        select: { id: true, orderNumber: true },
+      });
+
+      if (onDemandOrder) {
+        orderId = onDemandOrder.id;
+        orderType = 'on_demand';
+      }
+    }
+
+    if (!orderId || !orderType) {
+      return NextResponse.json(
+        { success: false, error: 'Order not found' },
+        { status: 404 }
+      );
+    }
+
+    // If user is DRIVER, verify they are assigned to this order
+    if (userProfile.type === 'DRIVER') {
+      const dispatch = await prisma.dispatch.findFirst({
+        where: {
+          driverId: user.id,
+          ...(orderType === 'catering'
+            ? { cateringRequestId: orderId }
+            : { onDemandId: orderId }),
+        },
+      });
+
+      if (!dispatch) {
+        return NextResponse.json(
+          { success: false, error: 'Access denied - not assigned to this order' },
+          { status: 403 }
+        );
+      }
+    }
+
+    // Parse form data
+    const formData = await request.formData();
+    const file = formData.get('file') as File | null;
+
+    if (!file) {
+      return NextResponse.json(
+        { success: false, error: 'No file provided' },
+        { status: 400 }
+      );
+    }
+
+    // Validate file type (signature pad exports PNG)
+    const allowedTypes = ['image/png', 'image/jpeg', 'image/webp'];
+    if (!allowedTypes.includes(file.type)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Invalid file type. Only PNG, JPEG, and WebP images are allowed.',
+        },
+        { status: 400 }
+      );
+    }
+
+    // Validate file size (max 2MB — a signature PNG is tiny)
+    const maxSize = 2 * 1024 * 1024;
+    if (file.size > maxSize) {
+      return NextResponse.json(
+        { success: false, error: 'File too large. Maximum size is 2MB.' },
+        { status: 400 }
+      );
+    }
+
+    // Upload to Supabase Storage
+    const uploadResult = await uploadPickupSignatureImage(file, orderId);
+
+    if (uploadResult.error) {
+      return NextResponse.json(
+        { success: false, error: uploadResult.error },
+        { status: 500 }
+      );
+    }
+
+    // Replace any existing pickup signature for this order
+    await prisma.fileUpload.deleteMany({
+      where: {
+        category: 'pickup_signature',
+        ...(orderType === 'catering'
+          ? { cateringRequestId: orderId }
+          : { onDemandId: orderId }),
+      },
+    });
+
+    // Create FileUpload record (the canonical store)
+    const fileUpload = await prisma.fileUpload.create({
+      data: {
+        userId: user.id,
+        fileName: file.name || 'pickup-signature.png',
+        fileType: file.type,
+        fileSize: file.size,
+        fileUrl: uploadResult.url,
+        filePath: uploadResult.path,
+        category: 'pickup_signature',
+        isTemporary: false,
+        ...(orderType === 'catering'
+          ? { cateringRequestId: orderId }
+          : { onDemandId: orderId }),
+      },
+    });
+
+    // Mirror the signature URL onto the standalone `deliveries` row so the admin
+    // tracking surface (which reads pickup_signature_url) sees it too. Non-fatal:
+    // a missing deliveries row (created on the first stage advance) must not fail
+    // the capture — the FileUpload above is the source of truth.
+    try {
+      await prisma.$executeRawUnsafe(
+        `UPDATE deliveries
+           SET pickup_signature_url = $1, updated_at = NOW()
+         WHERE LOWER(order_number) = LOWER($2) AND deleted_at IS NULL`,
+        uploadResult.url,
+        orderNumber,
+      );
+    } catch (mirrorErr) {
+      Sentry.captureException(mirrorErr, {
+        tags: { operation: 'pickup_signature_mirror_deliveries', route: 'orders' },
+        extra: { orderNumber },
+      });
+    }
+
+    return NextResponse.json({
+      success: true,
+      url: uploadResult.url,
+      path: uploadResult.path,
+      fileUploadId: fileUpload.id,
+      message: 'Pickup signature uploaded successfully',
+    });
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: { operation: 'pickup_signature_upload', route: 'orders' },
+    });
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to upload pickup signature',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/Driver/DriverDeliveryDetail.tsx
+++ b/src/components/Driver/DriverDeliveryDetail.tsx
@@ -31,6 +31,7 @@ import {
   resolveDriverStatus,
 } from "@/components/Driver/ui";
 import { DriverPodSheet } from "@/components/Driver/ui/DriverPodSheet";
+import { DriverSignatureSheet } from "@/components/Driver/ui/DriverSignatureSheet";
 
 /**
  * Driver-specific Delivery Detail.
@@ -141,6 +142,7 @@ export function DriverDeliveryDetail({ orderNumber }: DriverDeliveryDetailProps)
   const [notFound, setNotFound] = useState(false);
   const [isAdvancing, setIsAdvancing] = useState(false);
   const [podOpen, setPodOpen] = useState(false);
+  const [signatureOpen, setSignatureOpen] = useState(false);
 
   // Cache the session per mount cycle to reduce auth-lock contention (same
   // pattern SingleOrder uses).
@@ -280,12 +282,18 @@ export function DriverDeliveryDetail({ orderNumber }: DriverDeliveryDetailProps)
     [order, getValidSession, router],
   );
 
-  /** Next-Action handler: POD-gate the final step, otherwise advance. */
+  /** Next-Action handler: gate the signature (pickup) + POD (delivery) steps,
+   *  otherwise advance. */
   const handleNextAction = useCallback(() => {
     if (!order) return;
     const current = order.driverStatus as DriverStatus | undefined;
     const next = current ? getNextStatus(current) : DriverStatus.ASSIGNED;
     if (!next) return;
+    // Require a vendor-staff signature before marking the pickup done.
+    if (current === DriverStatus.ARRIVED_AT_VENDOR && next === DriverStatus.PICKED_UP) {
+      setSignatureOpen(true);
+      return;
+    }
     // Require proof of delivery before completing.
     if (current === DriverStatus.ARRIVED_TO_CLIENT && next === DriverStatus.COMPLETED) {
       setPodOpen(true);
@@ -293,6 +301,11 @@ export function DriverDeliveryDetail({ orderNumber }: DriverDeliveryDetailProps)
     }
     void advanceStatus(next);
   }, [order, advanceStatus]);
+
+  const onSignatureComplete = useCallback(async () => {
+    setSignatureOpen(false);
+    await advanceStatus(DriverStatus.PICKED_UP);
+  }, [advanceStatus]);
 
   const onPodComplete = useCallback(async () => {
     setPodOpen(false);
@@ -521,6 +534,15 @@ export function DriverDeliveryDetail({ orderNumber }: DriverDeliveryDetailProps)
           )}
         </div>
       </div>
+
+      {signatureOpen ? (
+        <DriverSignatureSheet
+          open={signatureOpen}
+          onOpenChange={setSignatureOpen}
+          orderNumber={order.orderNumber}
+          onComplete={onSignatureComplete}
+        />
+      ) : null}
 
       {podOpen ? (
         <DriverPodSheet

--- a/src/components/Driver/SignatureCapture.tsx
+++ b/src/components/Driver/SignatureCapture.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import SignaturePad from "signature_pad";
+import { AlertCircle, Check, Eraser } from "lucide-react";
+import toast from "react-hot-toast";
+import { cn } from "@/lib/utils";
+import { DriverButton } from "./ui/DriverButton";
+
+interface SignatureCaptureProps {
+  orderNumber: string;
+  /** Endpoint override (defaults to /api/orders/[order_number]/signature). */
+  uploadEndpoint?: string;
+  /** Called with the stored signature URL once capture + upload succeeds. */
+  onUploadComplete: (url: string) => void;
+  onCancel: () => void;
+  className?: string;
+}
+
+/** Decode a `data:` URL into a Blob (no fetch — works offline / in jsdom). */
+function dataURLToBlob(dataURL: string): Blob {
+  const [head, body] = dataURL.split(",");
+  const mime = head?.match(/:(.*?);/)?.[1] ?? "image/png";
+  const binary = atob(body ?? "");
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return new Blob([bytes], { type: mime });
+}
+
+/**
+ * In-app signature pad for the vendor pickup step. Captures a manual signature
+ * from the restaurant staff (not DocuSign), exports a PNG, and uploads it to the
+ * orders signature endpoint. Mandatory before a driver can mark a pickup done.
+ */
+export function SignatureCapture({
+  orderNumber,
+  uploadEndpoint,
+  onUploadComplete,
+  onCancel,
+  className,
+}: SignatureCaptureProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const padRef = useRef<SignaturePad | null>(null);
+  const [hasInk, setHasInk] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Initialise the pad and keep the canvas crisp on high-DPI screens.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const pad = new SignaturePad(canvas, {
+      penColor: "#15202e",
+      backgroundColor: "rgba(0,0,0,0)",
+      minWidth: 0.8,
+      maxWidth: 2.4,
+    });
+    padRef.current = pad;
+
+    const resize = () => {
+      const ratio = Math.max(window.devicePixelRatio || 1, 1);
+      canvas.width = canvas.offsetWidth * ratio;
+      canvas.height = canvas.offsetHeight * ratio;
+      canvas.getContext("2d")?.scale(ratio, ratio);
+      pad.clear(); // resizing wipes the canvas — reset pad state too
+      setHasInk(false);
+    };
+    resize();
+
+    const onEnd = () => setHasInk(!pad.isEmpty());
+    pad.addEventListener("endStroke", onEnd);
+    window.addEventListener("resize", resize);
+
+    return () => {
+      pad.removeEventListener("endStroke", onEnd);
+      window.removeEventListener("resize", resize);
+      pad.off();
+      padRef.current = null;
+    };
+  }, []);
+
+  const handleClear = useCallback(() => {
+    padRef.current?.clear();
+    setHasInk(false);
+    setError(null);
+  }, []);
+
+  const handleConfirm = useCallback(async () => {
+    const pad = padRef.current;
+    if (!pad || pad.isEmpty()) {
+      setError("Please capture a signature first.");
+      return;
+    }
+    setUploading(true);
+    setError(null);
+    try {
+      const blob = dataURLToBlob(pad.toDataURL("image/png"));
+      const file = new File([blob], "pickup-signature.png", {
+        type: "image/png",
+      });
+      const formData = new FormData();
+      formData.append("file", file, file.name);
+
+      const endpoint =
+        uploadEndpoint ??
+        `/api/orders/${encodeURIComponent(orderNumber)}/signature`;
+      const res = await fetch(endpoint, { method: "POST", body: formData });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || "Upload failed");
+      }
+      const result = await res.json();
+      toast.success("Signature captured");
+      onUploadComplete(result.url);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Upload failed";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setUploading(false);
+    }
+  }, [orderNumber, uploadEndpoint, onUploadComplete]);
+
+  return (
+    <div className={cn("flex flex-col gap-3", className)}>
+      <p className="text-[13.5px] font-semibold text-driver-muted">
+        Ask the restaurant staff to sign below to confirm pickup.
+      </p>
+
+      <div className="relative overflow-hidden rounded-2xl border-[1.5px] border-driver-border bg-driver-surface-alt">
+        <canvas
+          ref={canvasRef}
+          className="h-48 w-full touch-none"
+          aria-label="Signature pad"
+        />
+        {!hasInk ? (
+          <span className="pointer-events-none absolute inset-0 flex items-center justify-center text-[13px] font-semibold text-driver-subtle">
+            Sign here
+          </span>
+        ) : null}
+      </div>
+
+      {error ? (
+        <div className="flex items-center gap-2 text-[12.5px] font-semibold text-driver-error">
+          <AlertCircle className="h-4 w-4" />
+          {error}
+        </div>
+      ) : null}
+
+      <div className="flex items-center gap-2">
+        <DriverButton
+          variant="outline"
+          onClick={handleClear}
+          disabled={uploading || !hasInk}
+        >
+          <Eraser className="h-4 w-4" strokeWidth={2.4} />
+          Clear
+        </DriverButton>
+        <DriverButton
+          variant="brand"
+          full
+          loading={uploading}
+          disabled={uploading || !hasInk}
+          onClick={handleConfirm}
+          className="flex-1"
+        >
+          {!uploading ? <Check className="h-4 w-4" strokeWidth={2.6} /> : null}
+          Confirm signature
+        </DriverButton>
+      </div>
+
+      <button
+        type="button"
+        onClick={onCancel}
+        disabled={uploading}
+        className="text-[12.5px] font-bold text-driver-muted disabled:opacity-50"
+      >
+        Cancel
+      </button>
+    </div>
+  );
+}

--- a/src/components/Driver/__tests__/SignatureCapture.test.tsx
+++ b/src/components/Driver/__tests__/SignatureCapture.test.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// Mock signature_pad — jsdom has no real 2d canvas context. The mock captures
+// the endStroke handler so a test can simulate the driver drawing.
+const mockPad = {
+  _handlers: {} as Record<string, () => void>,
+  clear: jest.fn(),
+  isEmpty: jest.fn(() => false),
+  toDataURL: jest.fn(() => "data:image/png;base64,iVBORw0KGgo="),
+  addEventListener: jest.fn((evt: string, cb: () => void) => {
+    mockPad._handlers[evt] = cb;
+  }),
+  removeEventListener: jest.fn(),
+  off: jest.fn(),
+};
+jest.mock("signature_pad", () => ({
+  __esModule: true,
+  default: jest.fn(() => mockPad),
+}));
+jest.mock("react-hot-toast", () => ({
+  __esModule: true,
+  default: { success: jest.fn(), error: jest.fn() },
+}));
+
+import { SignatureCapture } from "../SignatureCapture";
+
+const SIG_URL = "https://cdn.example.com/signatures/sig.png";
+
+describe("SignatureCapture", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPad._handlers = {};
+    mockPad.isEmpty.mockReturnValue(false);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, url: SIG_URL }),
+    }) as unknown as typeof fetch;
+  });
+
+  it("disables Confirm until a stroke is drawn", () => {
+    render(
+      <SignatureCapture orderNumber="CAT-001" onUploadComplete={jest.fn()} onCancel={jest.fn()} />,
+    );
+    expect(screen.getByRole("button", { name: /confirm signature/i })).toBeDisabled();
+  });
+
+  it("uploads the signature and reports the stored URL", async () => {
+    const onComplete = jest.fn();
+    render(
+      <SignatureCapture orderNumber="CAT-001" onUploadComplete={onComplete} onCancel={jest.fn()} />,
+    );
+
+    // Simulate the driver completing a stroke.
+    act(() => mockPad._handlers["endStroke"]?.());
+
+    fireEvent.click(screen.getByRole("button", { name: /confirm signature/i }));
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledWith(SIG_URL));
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/orders/CAT-001/signature",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});

--- a/src/components/Driver/ui/DriverSignatureSheet.tsx
+++ b/src/components/Driver/ui/DriverSignatureSheet.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+import { SignatureCapture } from "@/components/Driver/SignatureCapture";
+import { useDriverTheme } from "./DriverThemeProvider";
+
+interface DriverSignatureSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  orderNumber: string;
+  /** Endpoint override (defaults to /api/orders/[order_number]/signature). */
+  uploadEndpoint?: string;
+  /** Called with the stored signature URL once capture + upload succeeds. */
+  onComplete: (url: string) => void;
+}
+
+/** Bottom-sheet wrapper around the pickup SignatureCapture flow. Mirrors
+ *  DriverPodSheet (driver-theme scoped bottom sheet). */
+export function DriverSignatureSheet({
+  open,
+  onOpenChange,
+  orderNumber,
+  uploadEndpoint,
+  onComplete,
+}: DriverSignatureSheetProps) {
+  const { resolved } = useDriverTheme();
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="bottom"
+        className={cn(
+          "driver-theme max-h-[90dvh] overflow-auto rounded-t-3xl border-driver-border bg-driver-surface",
+          resolved === "dark" && "dark",
+        )}
+      >
+        <div className="mx-auto w-full max-w-2xl">
+          <SheetHeader className="items-start">
+            <SheetTitle className="text-[18px] font-extrabold text-driver-text">
+              Vendor pickup signature
+            </SheetTitle>
+          </SheetHeader>
+          <div className="mt-4">
+            <SignatureCapture
+              orderNumber={orderNumber}
+              uploadEndpoint={uploadEndpoint}
+              onUploadComplete={(url) => onComplete(url)}
+              onCancel={() => onOpenChange(false)}
+            />
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/utils/supabase/storage.ts
+++ b/src/utils/supabase/storage.ts
@@ -123,6 +123,70 @@ export async function uploadPODImage(
 }
 
 /**
+ * Upload a pickup-stage signature image (a PNG from the in-app signature pad).
+ *
+ * Reuses the delivery-proofs bucket but a distinct `signatures/` path prefix so
+ * pickup signatures are easy to tell apart from POD photos in storage.
+ *
+ * @param file - The signature image (File or Blob)
+ * @param orderId - The order UUID (catering or on-demand)
+ * @returns Object with url, path, and optional error message
+ */
+export async function uploadPickupSignatureImage(
+  file: File | Blob,
+  orderId: string
+): Promise<{ url: string; path?: string; error?: string }> {
+  try {
+    const supabase = await createClient();
+
+    // Validate file size (max 2MB — signature PNGs are tiny)
+    const maxSize = 2 * 1024 * 1024;
+    if (file.size > maxSize) {
+      return { url: '', error: 'File too large (max 2MB)' };
+    }
+
+    // Validate file type
+    const allowedTypes = ['image/png', 'image/jpeg', 'image/webp'];
+    const fileType = file.type || 'image/png';
+    if (!allowedTypes.includes(fileType)) {
+      return { url: '', error: 'Invalid file type. Only PNG, JPEG, and WebP images are allowed.' };
+    }
+
+    const timestamp = Date.now();
+    const filename = `signatures/${orderId}/pickup-signature-${orderId}-${timestamp}.png`;
+
+    const { data, error } = await supabase.storage
+      .from(POD_BUCKET_NAME)
+      .upload(filename, file, {
+        cacheControl: '3600',
+        upsert: false,
+        contentType: fileType,
+      });
+
+    if (error) {
+      Sentry.captureException(error, {
+        tags: { operation: 'pickup_signature_upload', component: 'storage' },
+      });
+      return { url: '', error: error.message || 'Upload failed' };
+    }
+
+    const { data: { publicUrl } } = supabase.storage
+      .from(POD_BUCKET_NAME)
+      .getPublicUrl(data.path);
+
+    return { url: publicUrl, path: data.path };
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: { operation: 'pickup_signature_upload', component: 'storage' },
+    });
+    return {
+      url: '',
+      error: error instanceof Error ? error.message : 'Upload failed',
+    };
+  }
+}
+
+/**
  * Delete a Proof of Delivery image
  *
  * @param path - The storage path of the image to delete


### PR DESCRIPTION
## Why

The **2026-06-22 live driver test with Gary** confirmed the driver app's only major missing feature: there's no signature/photo requirement at **vendor pickup** (only at final delivery). The meeting finalized the decision to **mandate a manual signature from the restaurant staff** when the driver picks up the food — explicitly **not** DocuSign.

Board card: `driver-pickup-signature` (split from `driver-photo-signature-required`).

## What

Gates `ARRIVED_AT_VENDOR → PICKED_UP` on an in-app signature, mirroring the existing POD gate at `ARRIVED_TO_CLIENT → COMPLETED`.

- **Schema**: add `Delivery.pickupSignatureUrl` (`pickup_signature_url`) + migration `20260623000000_add_pickup_signature` — the `deliveries` mirror column, alongside `delivery_photo_url` / the pre-existing unused `delivery_signature_url`.
- **`SignatureCapture`** — a `signature_pad` canvas pad (Clear / Confirm), driver-themed, exports a PNG. **`DriverSignatureSheet`** — bottom-sheet wrapper mirroring `DriverPodSheet`.
- **`POST /api/orders/[order_number]/signature`** — mirrors the orders POD route: same auth (DRIVER/ADMIN/SUPER_ADMIN) + driver-assignment check, writes a `FileUpload` (`category='pickup_signature'`), then a **non-fatal** raw mirror onto the `deliveries` row. New `uploadPickupSignatureImage` storage helper (`signatures/` path prefix in the existing `delivery-proofs` bucket).
- **Integration**: `DriverDeliveryDetail.handleNextAction` opens the signature sheet at the pickup step; on success it advances to `PICKED_UP`.

## ⚠️ Deploy / ops note

The migration must be **applied to the dev Supabase DB** (and recorded on prod at promotion via the established `_prisma_migrations` + sha256 procedure). The feature **degrades gracefully** without it — the `FileUpload` is the source of truth and the `deliveries` mirror is wrapped in try/catch (Sentry, non-fatal) — but the mirror column won't populate until the migration lands.

## Notes / follow-ups

- **Mandatory + online** for this MVP: on upload failure the sheet stays open with an error (the driver isn't advanced without a captured signature). An offline queue (like `usePODOfflineQueue`) is a sensible fast-follow if vendors have poor signal.
- Pairs with the still-open photo/completion-signature scope on `driver-photo-signature-required`.

## Testing

- `signature/__tests__/route.test.ts` — 7 cases: 401 / 403 (role) / 404 / 403 (unassigned driver) / 200 + `pickup_signature` FileUpload + `deliveries` mirror / non-fatal mirror failure / 500 + mirror skipped on upload failure.
- `SignatureCapture.test.tsx` — Confirm disabled until a stroke; uploads + reports the stored URL (2 cases).
- Existing `DriverDeliveryDetail` suite still green (POD gate unaffected).
- `pnpm pre-push-check` green (typecheck, prisma generate, lint, token guardrail — 0 violations in 769 added lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)