### PR TITLE
fix(driver): harden foreground GPS persistence (wake lock + re-arm + flush)

### DIFF
--- a/src/contexts/DriverTrackingContext.tsx
+++ b/src/contexts/DriverTrackingContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useContext, ReactNode } from 'react';
+import React, { createContext, useContext, useCallback, ReactNode } from 'react';
 import { useRealtimeLocationTracking } from '@/hooks/tracking/useRealtimeLocationTracking';
 import { useDriverShift } from '@/hooks/tracking/useDriverShift';
 import { useDriverDeliveries } from '@/hooks/tracking/useDriverDeliveries';
@@ -80,6 +80,7 @@ export function DriverTrackingProvider({ children }: DriverTrackingProviderProps
     stopTracking,
     requestLocationPermission,
     updateLocationManually,
+    syncOfflineLocations,
   } = useRealtimeLocationTracking();
 
   // Shift management
@@ -87,10 +88,25 @@ export function DriverTrackingProvider({ children }: DriverTrackingProviderProps
     currentShift,
     isShiftActive,
     startShift,
-    endShift,
+    endShift: endShiftBase,
     loading: shiftLoading,
     error: shiftError,
   } = useDriverShift();
+
+  // Flush any queued GPS points before ending the shift, so the server-side
+  // shift mileage (summed from driver_locations) reflects the full trail rather
+  // than dropping breadcrumbs that were only sitting in the offline queue.
+  const endShift = useCallback(
+    async (shiftId: string, location: LocationUpdate) => {
+      try {
+        await syncOfflineLocations();
+      } catch {
+        /* best-effort flush — never block ending the shift */
+      }
+      return endShiftBase(shiftId, location);
+    },
+    [syncOfflineLocations, endShiftBase],
+  );
 
   // Deliveries
   const {

--- a/src/hooks/tracking/__tests__/useLocationTracking.test.ts
+++ b/src/hooks/tracking/__tests__/useLocationTracking.test.ts
@@ -339,6 +339,66 @@ describe('useLocationTracking', () => {
     });
   });
 
+  describe('wake lock + foreground re-arm (Track C)', () => {
+    it('acquires a screen wake lock on start and releases it on stop', async () => {
+      const release = jest.fn().mockResolvedValue(undefined);
+      const request = jest.fn().mockResolvedValue({ release });
+      mockNavigatorProperty('wakeLock', { request });
+
+      const { result } = renderHook(() => useLocationTracking());
+
+      await act(async () => {
+        result.current.startTracking();
+        await Promise.resolve();
+      });
+      await waitFor(() => expect(request).toHaveBeenCalledWith('screen'));
+
+      // Let the wakeLockRef assignment settle before tearing down.
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        result.current.stopTracking();
+        await Promise.resolve();
+      });
+      await waitFor(() => expect(release).toHaveBeenCalled());
+    });
+
+    it('re-arms watchPosition when returning to the foreground while tracking', async () => {
+      const { result } = renderHook(() => useLocationTracking());
+
+      await act(async () => {
+        result.current.startTracking();
+      });
+
+      (navigator.geolocation.clearWatch as jest.Mock).mockClear();
+      const watchCallsBefore = (navigator.geolocation.watchPosition as jest.Mock).mock.calls.length;
+
+      await act(async () => {
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+
+      // Stale watch cleared + a fresh watch armed.
+      expect(navigator.geolocation.clearWatch).toHaveBeenCalled();
+      expect(
+        (navigator.geolocation.watchPosition as jest.Mock).mock.calls.length,
+      ).toBeGreaterThan(watchCallsBefore);
+    });
+
+    it('does not re-arm on a visibility change when not tracking', async () => {
+      renderHook(() => useLocationTracking());
+
+      (navigator.geolocation.clearWatch as jest.Mock).mockClear();
+
+      await act(async () => {
+        document.dispatchEvent(new Event('visibilitychange'));
+      });
+
+      expect(navigator.geolocation.clearWatch).not.toHaveBeenCalled();
+    });
+  });
+
   describe('stopTracking', () => {
     it('should stop watching position when stopTracking is called', async () => {
       const { result } = renderHook(() => useLocationTracking());

--- a/src/hooks/tracking/useLocationTracking.ts
+++ b/src/hooks/tracking/useLocationTracking.ts
@@ -102,6 +102,10 @@ export function useLocationTracking(): UseLocationTrackingReturn {
   // painted the dot but never POSTed. Bit iOS Safari specifically (Android's
   // render/callback timing happened to resolve the gate open).
   const isTrackingRef = useRef(false);
+  // Screen wake lock held while a shift is actively tracking, so the device
+  // doesn't sleep mid-delivery (sleeping suspends watchPosition). The browser
+  // auto-releases it when the page is hidden; we re-acquire it on the way back.
+  const wakeLockRef = useRef<{ release: () => Promise<void> } | null>(null);
 
   // Get driver ID from session, cached to avoid repeated /api/auth/session fetches
   const getDriverId = useCallback(async (): Promise<string | null> => {
@@ -435,6 +439,48 @@ export function useLocationTracking(): UseLocationTrackingReturn {
     }
   }, []);
 
+  // Acquire a screen wake lock so the device doesn't sleep mid-shift (sleeping
+  // suspends watchPosition). Best-effort: unsupported/denied is non-fatal.
+  const requestWakeLock = useCallback(async () => {
+    try {
+      const nav = navigator as any;
+      if (
+        typeof document !== 'undefined' &&
+        document.visibilityState === 'visible' &&
+        nav?.wakeLock?.request
+      ) {
+        wakeLockRef.current = await nav.wakeLock.request('screen');
+      }
+    } catch {
+      /* wake lock denied or unsupported — non-fatal */
+    }
+  }, []);
+
+  const releaseWakeLock = useCallback(async () => {
+    try {
+      await wakeLockRef.current?.release();
+    } catch {
+      /* already released — ignore */
+    }
+    wakeLockRef.current = null;
+  }, []);
+
+  // Tear down any existing watch and start a fresh one. Used on return to the
+  // foreground: the OS may have suspended or killed the long-lived watch while
+  // backgrounded (notably iOS Safari), leaving a stale watchId that never fires.
+  const reArmWatch = useCallback(() => {
+    if (!navigator.geolocation) return;
+    if (watchIdRef.current !== null) {
+      navigator.geolocation.clearWatch(watchIdRef.current);
+      watchIdRef.current = null;
+    }
+    watchIdRef.current = navigator.geolocation.watchPosition(
+      handlePositionUpdate,
+      handleGeolocationError,
+      HIGH_ACCURACY_OPTIONS,
+    );
+  }, [handlePositionUpdate, handleGeolocationError]);
+
   // Start continuous location tracking
   const startTracking = useCallback(() => {
     if (!navigator.geolocation) {
@@ -462,7 +508,9 @@ export function useLocationTracking(): UseLocationTrackingReturn {
     // Trigger initial sync on start
     syncOfflineLocations();
 
-      }, [handlePositionUpdate, handleGeolocationError, syncOfflineLocations]);
+    // Keep the screen awake for the active shift (best-effort).
+    void requestWakeLock();
+  }, [handlePositionUpdate, handleGeolocationError, syncOfflineLocations, requestWakeLock]);
 
   // Stop location tracking
   const stopTracking = useCallback(() => {
@@ -488,7 +536,9 @@ export function useLocationTracking(): UseLocationTrackingReturn {
     cachedDriverIdRef.current = null;
     lastSyncTimeRef.current = 0;
 
-      }, []);
+    // Release the screen wake lock.
+    void releaseWakeLock();
+  }, [releaseWakeLock]);
 
   // Manually update location once
   const updateLocationManually = useCallback(async () => {
@@ -689,52 +739,25 @@ export function useLocationTracking(): UseLocationTrackingReturn {
     loadUnsyncedCount();
   }, []);
 
-  // Handle page visibility changes (pause tracking when hidden)
+  // Re-arm tracking when returning to the foreground. While backgrounded the OS
+  // can suspend or kill the long-lived watchPosition (notably iOS Safari), and the
+  // browser auto-releases the screen wake lock. On the way back we re-arm the
+  // watch, grab an immediate fix, and re-acquire the wake lock so the breadcrumb
+  // trail (and shift mileage) doesn't silently stall after a tab switch.
+  //
+  // NOTE: this does NOT give true background tracking — web JS is suspended while
+  // backgrounded, so points aren't captured until the app is foregrounded again.
+  // Continuous background capture requires the native wrapper (see the
+  // 2026-06-17 native-driver-app spec).
   useEffect(() => {
     const handleVisibilityChange = () => {
-      // Skip if component is unmounting or not tracking
-      if (!isMountedRef.current || !isTracking) return;
-
-      if (document.hidden) {
-        // Reduce update frequency when app is in background
-        if (intervalIdRef.current) {
-          clearInterval(intervalIdRef.current);
-          intervalIdRef.current = setInterval(async () => {
-            // Check mounted state before async operations
-            if (!isMountedRef.current) return;
-            try {
-              const position = await getCurrentPosition();
-              if (isMountedRef.current) {
-                await handlePositionUpdate(position);
-              }
-            } catch (error) {
-              // Only log if still mounted (ignore errors during navigation)
-              if (isMountedRef.current) {
-                console.debug('Background location update skipped:', error);
-              }
-            }
-          }, TRACKING_INTERVAL * 2); // Double the interval when in background
-        }
-      } else {
-        // Resume normal frequency when app is visible
-        if (intervalIdRef.current) {
-          clearInterval(intervalIdRef.current);
-          intervalIdRef.current = setInterval(async () => {
-            // Check mounted state before async operations
-            if (!isMountedRef.current) return;
-            try {
-              const position = await getCurrentPosition();
-              if (isMountedRef.current) {
-                await handlePositionUpdate(position);
-              }
-            } catch (error) {
-              // Only log if still mounted (ignore errors during navigation)
-              if (isMountedRef.current) {
-                console.debug('Foreground location update skipped:', error);
-              }
-            }
-          }, TRACKING_INTERVAL);
-        }
+      // Read the live ref, not the captured `isTracking` state, so a tab return
+      // is honored even when the effect closed over a stale value.
+      if (!isMountedRef.current || !isTrackingRef.current) return;
+      if (!document.hidden) {
+        reArmWatch();
+        void updateLocationManually();
+        void requestWakeLock();
       }
     };
 
@@ -742,7 +765,7 @@ export function useLocationTracking(): UseLocationTrackingReturn {
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [isTracking, getCurrentPosition, handlePositionUpdate]);
+  }, [reArmWatch, updateLocationManually, requestWakeLock]);
 
   // Listen for geolocation mock state changes (development only)
   // When the location simulator enables/disables the mock, we need to restart our watch


### PR DESCRIPTION
## Why

The `walk-test-pr2` persistence slice. Web GPS **can't** track in the true background (that's the native wrapper — Track D / `persistent-gps-background`), but it was also silently dropping the **foreground** trail on tab switches. Root cause: the visibility handler in `useLocationTracking` was effectively **dead code** — it only acted `if (intervalIdRef.current)`, but `startTracking` never sets `intervalIdRef`, so the long-lived `watchPosition` was never re-armed after the OS suspended it on a tab switch (notably iOS Safari).

Board card: `persistent-gps-background` (web slice; the native POC remains the gated Track D).

## What

- **Re-arm on return to foreground** — replaced the dead handler: on `visibilitychange → visible` while tracking, tear down the stale watch + start a fresh `watchPosition` + grab an immediate fix. Reads `isTrackingRef` (not a stale `isTracking` closure).
- **Screen wake lock** — held during an active shift (re-acquired on foreground, released on stop), so the device doesn't sleep mid-delivery and suspend the watch. Best-effort; unsupported/denied is non-fatal.
- **Flush before mileage** — `DriverTrackingContext.endShift` now flushes the offline location queue (`syncOfflineLocations`) **before** calling the server end-shift, so the server-side shift mileage (summed from `driver_locations`) includes the full trail instead of breadcrumbs stuck in the IndexedDB queue.

**Not changed:** persistence + realtime broadcast already both fire — `useRealtimeLocationTracking` wraps `useLocationTracking` (which does the REST persist) and adds broadcasting. The earlier zero-writes were the `uuid::text` bugs already fixed in #451/#452.

## ⚠️ Verification needs a real device

The unit tests cover the wiring, but the real proof is a **`WALK-TEST-SF` re-walk on `development`**: start a shift, walk + switch to Maps/Waze and back, confirm `driver_locations` keeps gaining rows on each foreground return, and that shift-end mileage > 0 with the full trail. I can't run an on-device walk from here.

## Testing

- `useLocationTracking.test.ts` — 3 new cases: wake-lock acquire-on-start / release-on-stop, watch re-arm on foreground return, and no-op when not tracking. Full hook + realtime-wrapper suites green (86 tests).
- `pnpm pre-push-check` green (typecheck, prisma generate, lint, token guardrail — 0 violations in 148 added lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)