### PR TITLE
fix(auth): redirect to /sign-in (not the 404 /auth/login) on session expiry

### DIFF
--- a/src/components/Driver/DriverDeliveryDetail.tsx
+++ b/src/components/Driver/DriverDeliveryDetail.tsx
@@ -172,7 +172,7 @@ export function DriverDeliveryDetail({ orderNumber }: DriverDeliveryDetailProps)
       const session = await getValidSession();
       if (!session) {
         toast.error("Authentication error. Please log in again.");
-        router.push("/auth/login");
+        router.push("/sign-in");
         return;
       }
       const res = await fetch(
@@ -187,7 +187,7 @@ export function DriverDeliveryDetail({ orderNumber }: DriverDeliveryDetailProps)
       );
       if (res.status === 401) {
         toast.error("Session expired. Please log in again.");
-        router.push("/auth/login");
+        router.push("/sign-in");
         return;
       }
       if (res.status === 404) {
@@ -221,7 +221,7 @@ export function DriverDeliveryDetail({ orderNumber }: DriverDeliveryDetailProps)
         const session = await getValidSession();
         if (!session) {
           toast.error("Authentication error. Please log in again.");
-          router.push("/auth/login");
+          router.push("/sign-in");
           return;
         }
         const res = await fetch(

--- a/src/components/Orders/OnDemand/SingleOnDemandOrder.tsx
+++ b/src/components/Orders/OnDemand/SingleOnDemandOrder.tsx
@@ -263,7 +263,7 @@ const SingleOnDemandOrder: React.FC<SingleOnDemandOrderProps> = ({
       if (sessionError || !session) {
         console.error("Authentication error:", sessionError?.message);
         toast.error("Authentication error. Please try logging in again.");
-        router.push("/auth/login"); // Redirect to login if session is invalid
+        router.push("/sign-in"); // Redirect to login if session is invalid
         return;
       }
 
@@ -289,7 +289,7 @@ const SingleOnDemandOrder: React.FC<SingleOnDemandOrderProps> = ({
           // If unauthorized, redirect to login
           if (orderResponse.status === 401) {
             toast.error("Session expired. Please log in again.");
-            router.push("/auth/login");
+            router.push("/sign-in");
             return;
           }
         } catch (parseError) {
@@ -429,7 +429,7 @@ const SingleOnDemandOrder: React.FC<SingleOnDemandOrderProps> = ({
         if (sessionError || !session) {
           console.error("Authentication error:", sessionError?.message);
           toast.error("Authentication error. Please try logging in again.");
-          router.push("/auth/login");
+          router.push("/sign-in");
           return;
         }
 
@@ -446,7 +446,7 @@ const SingleOnDemandOrder: React.FC<SingleOnDemandOrderProps> = ({
         } else {
           if (response.status === 401) {
             toast.error("Session expired. Please log in again.");
-            router.push("/auth/login");
+            router.push("/sign-in");
             return;
           }
           if (response.status === 403) {
@@ -484,7 +484,7 @@ const SingleOnDemandOrder: React.FC<SingleOnDemandOrderProps> = ({
       if (sessionError || !session) {
         console.error("Authentication error:", sessionError?.message);
         toast.error("Authentication error. Please try logging in again.");
-        router.push("/auth/login");
+        router.push("/sign-in");
         return;
       }
 
@@ -506,7 +506,7 @@ const SingleOnDemandOrder: React.FC<SingleOnDemandOrderProps> = ({
       if (!response.ok) {
         if (response.status === 401) {
           toast.error("Session expired. Please log in again.");
-          router.push("/auth/login");
+          router.push("/sign-in");
           return;
         }
 
@@ -566,7 +566,7 @@ const SingleOnDemandOrder: React.FC<SingleOnDemandOrderProps> = ({
       if (sessionError || !session) {
         console.error("Authentication error:", sessionError?.message);
         toast.error("Authentication error. Please try logging in again.");
-        router.push("/auth/login");
+        router.push("/sign-in");
         return;
       }
 
@@ -586,7 +586,7 @@ const SingleOnDemandOrder: React.FC<SingleOnDemandOrderProps> = ({
       if (!response.ok) {
         if (response.status === 401) {
           toast.error("Session expired. Please log in again.");
-          router.push("/auth/login");
+          router.push("/sign-in");
           return;
         }
 
@@ -634,7 +634,7 @@ const SingleOnDemandOrder: React.FC<SingleOnDemandOrderProps> = ({
       if (sessionError || !session) {
         console.error("Authentication error:", sessionError?.message);
         toast.error("Authentication error. Please try logging in again.");
-        router.push("/auth/login");
+        router.push("/sign-in");
         return;
       }
 
@@ -654,7 +654,7 @@ const SingleOnDemandOrder: React.FC<SingleOnDemandOrderProps> = ({
       if (!response.ok) {
         if (response.status === 401) {
           toast.error("Session expired. Please log in again.");
-          router.push("/auth/login");
+          router.push("/sign-in");
           return;
         }
 

--- a/src/components/Orders/SingleOrder.tsx
+++ b/src/components/Orders/SingleOrder.tsx
@@ -338,7 +338,7 @@ const SingleOrder: React.FC<SingleOrderProps> = ({
 
       if (!session) {
         toast.error("Authentication error. Please try logging in again.");
-        router.push("/auth/login");
+        router.push("/sign-in");
         return;
       }
 
@@ -364,7 +364,7 @@ const SingleOrder: React.FC<SingleOrderProps> = ({
           // If unauthorized, redirect to login
           if (orderResponse.status === 401) {
             toast.error("Session expired. Please log in again.");
-            router.push("/auth/login");
+            router.push("/sign-in");
             return;
           }
         } catch (parseError) {
@@ -507,7 +507,7 @@ const SingleOrder: React.FC<SingleOrderProps> = ({
 
         if (!session) {
           toast.error("Authentication error. Please try logging in again.");
-          router.push("/auth/login");
+          router.push("/sign-in");
           return;
         }
 
@@ -524,7 +524,7 @@ const SingleOrder: React.FC<SingleOrderProps> = ({
         } else {
           if (response.status === 401) {
             toast.error("Session expired. Please log in again.");
-            router.push("/auth/login");
+            router.push("/sign-in");
             return;
           }
           if (response.status === 403) {
@@ -561,7 +561,7 @@ const SingleOrder: React.FC<SingleOrderProps> = ({
 
       if (!session) {
         toast.error("Authentication error. Please try logging in again.");
-        router.push("/auth/login");
+        router.push("/sign-in");
         return;
       }
 
@@ -585,7 +585,7 @@ const SingleOrder: React.FC<SingleOrderProps> = ({
         console.error("❌ API call failed with status:", response.status);
         if (response.status === 401) {
           toast.error("Session expired. Please log in again.");
-          router.push("/auth/login");
+          router.push("/sign-in");
           return;
         }
 
@@ -661,7 +661,7 @@ const SingleOrder: React.FC<SingleOrderProps> = ({
 
       if (!session) {
         toast.error("Authentication error. Please try logging in again.");
-        router.push("/auth/login");
+        router.push("/sign-in");
         return;
       }
 
@@ -681,7 +681,7 @@ const SingleOrder: React.FC<SingleOrderProps> = ({
       if (!response.ok) {
         if (response.status === 401) {
           toast.error("Session expired. Please log in again.");
-          router.push("/auth/login");
+          router.push("/sign-in");
           return;
         }
 
@@ -738,7 +738,7 @@ const SingleOrder: React.FC<SingleOrderProps> = ({
 
       if (!session) {
         toast.error("Authentication error. Please try logging in again.");
-        router.push("/auth/login");
+        router.push("/sign-in");
         return;
       }
 
@@ -758,7 +758,7 @@ const SingleOrder: React.FC<SingleOrderProps> = ({
       if (!response.ok) {
         if (response.status === 401) {
           toast.error("Session expired. Please log in again.");
-          router.push("/auth/login");
+          router.push("/sign-in");
           return;
         }
 


### PR DESCRIPTION
## Why

Found during QA of the merged driver work on `development.readysetllc.com`: the driver + order detail views redirect to **`/auth/login`** on auth failure / session expiry, but **no such route exists** — the sign-in page is **`/sign-in`** (`src/app/(site)/(auth)/sign-in`). So a user whose session expires mid-delivery (or mid-order) lands on a **404** instead of the login screen.

## What

Replaced all **23** `router.push("/auth/login")` → `router.push("/sign-in")` across the three components that have this dead redirect:
- `src/components/Driver/DriverDeliveryDetail.tsx` (3)
- `src/components/Orders/SingleOrder.tsx` (10)
- `src/components/Orders/OnDemand/SingleOnDemandOrder.tsx` (10)

Left untouched: test request-path references to `/auth/login` / `/api/auth/login` in `api-security-qa.test.ts` and `security-headers.test.ts` (those are HTTP request fixtures, not client redirects).

No behavior change beyond the corrected destination — the redirects already passed no return param, so this just sends users to the real sign-in page.

## Testing

- `pnpm pre-push-check` green (typecheck, prisma generate, lint, token guardrail — 0 violations in 23 lines).
- `DriverDeliveryDetail` suite green; no test asserted the old `/auth/login` target.
- Verified zero `router.push("/auth/login")` remain in non-test code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)