### PR TITLE
feat(driver): native background-GPS bridge (shift lifecycle)

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,8 @@
     "unrs-resolver"
   ],
   "dependencies": {
+    "@capacitor-community/background-geolocation": "^1.2.26",
+    "@capacitor/core": "^6.2.1",
     "@faker-js/faker": "^10.3.0",
     "@hookform/resolvers": "^5.2.2",
     "@next/mdx": "^15.5.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,12 @@ importers:
 
   .:
     dependencies:
+      '@capacitor-community/background-geolocation':
+        specifier: ^1.2.26
+        version: 1.2.26(@capacitor/core@6.2.1)
+      '@capacitor/core':
+        specifier: ^6.2.1
+        version: 6.2.1
       '@faker-js/faker':
         specifier: ^10.3.0
         version: 10.3.0
@@ -1383,6 +1389,14 @@ packages:
 
   '@bytecodealliance/preview2-shim@0.17.6':
     resolution: {integrity: sha512-n3cM88gTen5980UOBAD6xDcNNL3ocTK8keab21bpx1ONdA+ARj7uD1qoFxOWCyKlkpSi195FH+GeAut7Oc6zZw==}
+
+  '@capacitor-community/background-geolocation@1.2.26':
+    resolution: {integrity: sha512-kuva8VQ6zM+uIKgHUJTP87IYbmGKhX7DZw62JYfGZ888h4Xr5zeN+UTR6KBRHQVrGBpzSfbv+6/HQVuHYa7W5A==}
+    peerDependencies:
+      '@capacitor/core': '>=3.0.0'
+
+  '@capacitor/core@6.2.1':
+    resolution: {integrity: sha512-urZwxa7hVE/BnA18oCFAdizXPse6fCKanQyEqpmz6cBJ2vObwMpyJDG5jBeoSsgocS9+Ax+9vb4ducWJn0y2qQ==}
 
   '@codemirror/autocomplete@6.20.1':
     resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
@@ -13294,6 +13308,14 @@ snapshots:
       css-tree: 3.2.1
 
   '@bytecodealliance/preview2-shim@0.17.6': {}
+
+  '@capacitor-community/background-geolocation@1.2.26(@capacitor/core@6.2.1)':
+    dependencies:
+      '@capacitor/core': 6.2.1
+
+  '@capacitor/core@6.2.1':
+    dependencies:
+      tslib: 2.8.1
 
   '@codemirror/autocomplete@6.20.1':
     dependencies:

--- a/src/contexts/DriverTrackingContext.tsx
+++ b/src/contexts/DriverTrackingContext.tsx
@@ -7,6 +7,10 @@ import { useDriverDeliveries } from '@/hooks/tracking/useDriverDeliveries';
 import { useOfflineQueue } from '@/hooks/tracking/useOfflineQueue';
 import { DriverStatus } from '@/types/user';
 import type { LocationUpdate, DriverShift, DeliveryTracking } from '@/types/tracking';
+import {
+  startNativeShiftTrackingForDriver,
+  stopNativeShiftTrackingForDriver,
+} from '@/lib/tracking/native-shift-tracking';
 
 interface DriverTrackingContextValue {
   // Location tracking
@@ -87,17 +91,32 @@ export function DriverTrackingProvider({ children }: DriverTrackingProviderProps
   const {
     currentShift,
     isShiftActive,
-    startShift,
+    startShift: startShiftBase,
     endShift: endShiftBase,
     loading: shiftLoading,
     error: shiftError,
   } = useDriverShift();
 
+  // Supplement the foreground web tracker with native background GPS while the
+  // /driver app runs inside the Capacitor shell — so the trail survives a locked
+  // screen or a switch to Waze. Both calls no-op in a normal browser (the native
+  // plugin is only dynamically imported inside the native shell).
+  const startShift = useCallback(
+    async (location: LocationUpdate): Promise<boolean> => {
+      const started = await startShiftBase(location);
+      if (started) void startNativeShiftTrackingForDriver();
+      return started;
+    },
+    [startShiftBase],
+  );
+
   // Flush any queued GPS points before ending the shift, so the server-side
   // shift mileage (summed from driver_locations) reflects the full trail rather
   // than dropping breadcrumbs that were only sitting in the offline queue.
+  // Also stop the native background watcher (no-op on web).
   const endShift = useCallback(
     async (shiftId: string, location: LocationUpdate) => {
+      void stopNativeShiftTrackingForDriver();
       try {
         await syncOfflineLocations();
       } catch {

--- a/src/lib/tracking/capacitor-tracking.ts
+++ b/src/lib/tracking/capacitor-tracking.ts
@@ -1,0 +1,137 @@
+/**
+ * Capacitor background-GPS bridge — the native-shell side of driver tracking.
+ *
+ * When the /driver web app runs inside the native shell (native/driver-app),
+ * Capacitor injects its runtime + the background-geolocation plugin into this
+ * page. This module drives that plugin so location keeps posting to the existing
+ * `POST /api/tracking/locations` route even when the screen is locked or the
+ * driver opens Waze — the gap web-only tracking can't close (web JS is suspended
+ * in the background).
+ *
+ * This module is **only ever loaded via a dynamic import from
+ * native-shift-tracking.ts, gated on `window.Capacitor`**, so the @capacitor
+ * plugin code never lands in the web build / SSR. On a plain browser the dynamic
+ * import never runs.
+ *
+ * No backend change: `withAuth` already accepts `Authorization: Bearer`
+ * (src/lib/auth-middleware.ts), and the POST body matches the web client
+ * (src/hooks/tracking/useLocationTracking.ts).
+ */
+
+import { Capacitor, registerPlugin } from '@capacitor/core';
+import type {
+  BackgroundGeolocationPlugin,
+  Location,
+  CallbackError,
+} from '@capacitor-community/background-geolocation';
+
+// v1.x exposes only the plugin TYPE; the runtime object is obtained via
+// Capacitor's registerPlugin, which binds to the native implementation inside
+// the Capacitor shell (and is a harmless proxy on web — we never call it there).
+const BackgroundGeolocation =
+  registerPlugin<BackgroundGeolocationPlugin>('BackgroundGeolocation');
+
+export interface NativeTrackingSession {
+  driverId: string;
+  /** Returns a fresh Supabase access token (refresh-aware); null if signed out. */
+  getAccessToken: () => Promise<string | null>;
+}
+
+/** Match the server rate limit (~12/min) and the web client's throttle. */
+const POST_THROTTLE_MS = 5000;
+
+let watcherId: string | null = null;
+let lastPostAt = 0;
+
+/** True only inside the Capacitor native shell — false in any web browser. */
+export function isNativeTrackingAvailable(): boolean {
+  try {
+    return Capacitor.isNativePlatform();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Start native background location tracking for the active shift. Idempotent:
+ * a second call while already running is a no-op.
+ */
+export async function startNativeShiftTracking(
+  session: NativeTrackingSession,
+): Promise<void> {
+  if (!isNativeTrackingAvailable() || watcherId) return;
+
+  watcherId = await BackgroundGeolocation.addWatcher(
+    {
+      backgroundTitle: 'Delivery in progress',
+      backgroundMessage: 'Ready Set is tracking your delivery location.',
+      requestPermissions: true,
+      // Keep firing in the background (don't drop stale-but-recent fixes).
+      stale: false,
+      // Metres of movement between callbacks — caps battery + post volume.
+      distanceFilter: 10,
+    },
+    async (location?: Location, error?: CallbackError) => {
+      if (error) {
+        // The OS denied "Always" permission — bounce the driver to Settings.
+        if (error.code === 'NOT_AUTHORIZED') {
+          void BackgroundGeolocation.openSettings();
+        }
+        return;
+      }
+      if (!location) return;
+
+      const now = Date.now();
+      if (now - lastPostAt < POST_THROTTLE_MS) return;
+      lastPostAt = now;
+
+      const token = await session.getAccessToken();
+      if (!token) return; // signed out / token unavailable — skip this fix
+      await postLocation(location, session.driverId, token);
+    },
+  );
+}
+
+/** Stop native tracking (call on shift end). Idempotent. */
+export async function stopNativeShiftTracking(): Promise<void> {
+  if (!watcherId) return;
+  try {
+    await BackgroundGeolocation.removeWatcher({ id: watcherId });
+  } finally {
+    watcherId = null;
+    lastPostAt = 0;
+  }
+}
+
+/**
+ * POST one fix to the existing ingest route. The relative URL resolves against
+ * the loaded origin (the deployed site), so no base URL is needed. Failures are
+ * swallowed — the next fix retries; durable buffering is a Phase-1 item.
+ */
+async function postLocation(
+  location: Location,
+  driverId: string,
+  token: string,
+): Promise<void> {
+  try {
+    await fetch('/api/tracking/locations', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        driver_id: driverId,
+        latitude: location.latitude,
+        longitude: location.longitude,
+        accuracy: location.accuracy ?? undefined,
+        speed: location.speed ?? undefined,
+        heading: location.bearing ?? undefined,
+        altitude: location.altitude ?? undefined,
+        is_moving: (location.speed ?? 0) > 1,
+      }),
+    });
+  } catch {
+    /* background network blip — next fix retries */
+  }
+}

--- a/src/lib/tracking/native-shift-tracking.ts
+++ b/src/lib/tracking/native-shift-tracking.ts
@@ -1,0 +1,78 @@
+'use client';
+
+/**
+ * App-side adapter that drives the native background-GPS bridge for the active
+ * shift. It is imported by DriverTrackingContext and called from the shift
+ * start/end flow, but **every export no-ops in a normal browser**: the heavy
+ * `@capacitor-community/background-geolocation` plugin is only reached through a
+ * dynamic `import('./capacitor-tracking')` that runs solely when the page is
+ * inside the Capacitor native shell (native/driver-app). So the web build and
+ * SSR never bundle the plugin into the main chunk, and a plain browser never
+ * loads it.
+ *
+ * Why this exists: web JS is suspended when the screen locks or the driver
+ * switches to Waze, so the foreground web tracker (useLocationTracking) loses
+ * the trail. Inside the native shell the OS keeps a background-location service
+ * alive; this adapter feeds those fixes to the existing
+ * `POST /api/tracking/locations` with a Bearer token (withAuth already accepts
+ * Bearer — no backend change). It SUPPLEMENTS the foreground tracker, it does
+ * not replace it.
+ */
+
+import { createClient } from '@/utils/supabase/client';
+
+/** True only inside the Capacitor native shell — false in every web browser. */
+export function isCapacitorNative(): boolean {
+  if (typeof window === 'undefined') return false;
+  const cap = (window as { Capacitor?: { isNativePlatform?: () => boolean } })
+    .Capacitor;
+  try {
+    return Boolean(cap?.isNativePlatform?.());
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve the driver id the same way the web tracking hooks do. */
+async function resolveDriverId(): Promise<string | null> {
+  try {
+    const res = await fetch('/api/auth/session');
+    if (!res.ok) return null;
+    const session = await res.json();
+    return session?.user?.driverId ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Start native background GPS for the active shift. No-op on web; safe to call
+ * unconditionally from the shift-start flow.
+ */
+export async function startNativeShiftTrackingForDriver(): Promise<void> {
+  if (!isCapacitorNative()) return;
+  try {
+    const driverId = await resolveDriverId();
+    if (!driverId) return;
+    const supabase = createClient();
+    const { startNativeShiftTracking } = await import('./capacitor-tracking');
+    await startNativeShiftTracking({
+      driverId,
+      getAccessToken: async () =>
+        (await supabase.auth.getSession()).data.session?.access_token ?? null,
+    });
+  } catch {
+    /* native bridge unavailable — foreground web tracking still runs */
+  }
+}
+
+/** Stop native background GPS (call on shift end). No-op on web. */
+export async function stopNativeShiftTrackingForDriver(): Promise<void> {
+  if (!isCapacitorNative()) return;
+  try {
+    const { stopNativeShiftTracking } = await import('./capacitor-tracking');
+    await stopNativeShiftTracking();
+  } catch {
+    /* ignore */
+  }
+}


### PR DESCRIPTION
## What

Wires the **web side** of the native background-GPS work (Track D / `persistent-gps-background`). When the `/driver` app runs inside the Capacitor native shell (`native/driver-app`, draft #461), this keeps GPS posting to the **existing** `POST /api/tracking/locations` even when the screen is locked or the driver switches to Waze — the gap web-only tracking physically can't close (the OS suspends background JS).

## Why now

The native shell loads the **deployed** `/driver` UI in a WebView, so for the shell to drive the background-location plugin, the driving code has to live in the deployed web bundle. This PR adds exactly that, gated so it's inert everywhere except inside the native app.

## Safety — no-op on the live site

- `src/lib/tracking/native-shift-tracking.ts` reaches the `@capacitor` plugin **only through a dynamic `import()` gated on `window.Capacitor`**. In a normal browser `isCapacitorNative()` is `false`, so the plugin is **never loaded**, never bundled into the main chunk, and never touches SSR.
- `DriverTrackingContext` calls `startNativeShiftTrackingForDriver()` / `stopNativeShiftTrackingForDriver()` on shift start/end — both **no-op on web**. It **supplements** the existing foreground tracker, doesn't replace it.
- **Zero backend change**: posts use the same body as the web client + a Bearer token, which `withAuth` already accepts (`src/lib/auth-middleware.ts`).

So on `development.readysetllc.com` in a browser, **behavior is unchanged**.

## Files

- `src/lib/tracking/capacitor-tracking.ts` — registers the background-geolocation plugin via `registerPlugin`, starts/stops a watcher tied to the shift, throttles posts ≥5s. *(Also fixes the `registerPlugin` import the #461 scaffolding got wrong.)*
- `src/lib/tracking/native-shift-tracking.ts` — the dynamic-import adapter (driver id via `/api/auth/session`, fresh Supabase token).
- `src/contexts/DriverTrackingContext.tsx` — start/stop on shift start/end.
- `package.json` / `pnpm-lock.yaml` — `@capacitor/core` + `@capacitor-community/background-geolocation`.

## Validation

- `pnpm typecheck` ✅
- `pnpm lint` ✅ (no new errors)
- 62 tracking tests pass (`useDriverShift`, `DriverTrackingPortal`, `tracking-system`, driver `page`)

## Follow-up

Real validation is an on-device background walk (`WALK-TEST-SF`) once the native shell is built — tracked under `persistent-gps-background` / #461.

🤖 Generated with [Claude Code](https://claude.com/claude-code)