### PR TITLE
fix(partners): emit CaterCow lifecycle webhooks from the driver order PATCH

### DIFF
--- a/src/app/api/orders/[order_number]/__tests__/route.test.ts
+++ b/src/app/api/orders/[order_number]/__tests__/route.test.ts
@@ -14,6 +14,25 @@ jest.mock('@/utils/supabase/server');
 jest.mock('@/services/notifications/delivery-status', () => ({
   sendDispatchStatusNotification: jest.fn().mockResolvedValue(undefined),
 }));
+// Mock the partner webhook dispatcher so we can assert the orders PATCH wires
+// it on driver-status transitions (the bug this guards: the #447 unification
+// moved the driver flow onto this route and left the lifecycle emit orphaned
+// on /api/catering-requests/[id]/status). The status map is hardcoded here to
+// keep the route's `partnerLifecycle` lookup working without importing the real
+// module's DB deps; its values are independently locked by
+// src/__tests__/services/partnerWebhookService.test.ts.
+jest.mock('@/lib/services/partnerWebhookService', () => ({
+  recordAndDispatchLifecycleEvent: jest.fn().mockResolvedValue(undefined),
+  DRIVER_STATUS_TO_PARTNER_LIFECYCLE: {
+    ASSIGNED: 'ASSIGNED',
+    EN_ROUTE_TO_VENDOR: null,
+    ARRIVED_AT_VENDOR: null,
+    PICKED_UP: 'PICKED_UP',
+    EN_ROUTE_TO_CLIENT: 'ON_THE_WAY',
+    ARRIVED_TO_CLIENT: 'ARRIVED',
+    COMPLETED: 'DELIVERED',
+  },
+}));
 
 import { NextRequest } from 'next/server';
 
@@ -21,12 +40,14 @@ import { NextRequest } from 'next/server';
 import { prisma } from '@/utils/prismaDB';
 import { createClient, createAdminClient } from '@/utils/supabase/server';
 import { sendDispatchStatusNotification } from '@/services/notifications/delivery-status';
+import { recordAndDispatchLifecycleEvent } from '@/lib/services/partnerWebhookService';
 
 // Get mocked versions
 const mockedPrisma = jest.mocked(prisma);
 const mockedCreateClient = jest.mocked(createClient);
 const mockedCreateAdminClient = jest.mocked(createAdminClient);
 const mockedSendDispatchStatusNotification = jest.mocked(sendDispatchStatusNotification);
+const mockedRecordLifecycle = jest.mocked(recordAndDispatchLifecycleEvent);
 
 // Track calls to channel methods
 let channelSendCalls: any[] = [];
@@ -213,6 +234,81 @@ describe('Orders API Route - Delivery Status Broadcast', () => {
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data.orderNumber).toBe('CAT-001');
+    });
+  });
+
+  describe('Partner lifecycle webhook (registry partners, e.g. CaterCow)', () => {
+    it('dispatches the partner lifecycle event on a client-leg driver transition', async () => {
+      // CC- order, ARRIVED_AT_VENDOR → EN_ROUTE_TO_CLIENT (maps to ON_THE_WAY).
+      setupMocks({
+        orderNumber: 'CC-12345',
+        status: 'IN_PROGRESS',
+        driverStatus: 'ARRIVED_AT_VENDOR',
+      });
+      const { PATCH } = await importRoute();
+
+      const request = createPatchRequest({ driverStatus: 'EN_ROUTE_TO_CLIENT' }, 'CC-12345');
+      const params = Promise.resolve({ order_number: 'CC-12345' });
+
+      const response = await PATCH(request, { params });
+      expect(response.status).toBe(200);
+
+      expect(mockedRecordLifecycle).toHaveBeenCalledTimes(1);
+      expect(mockedRecordLifecycle).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderNumber: 'CC-12345',
+          partnerStatus: 'ON_THE_WAY',
+          driverStatus: 'EN_ROUTE_TO_CLIENT',
+          driver: { name: 'John Driver', phone: '555-1234' },
+        }),
+      );
+    });
+
+    it('does NOT dispatch on a vendor-leg transition (no partner-facing event)', async () => {
+      // ASSIGNED → EN_ROUTE_TO_VENDOR maps to null — vendor-leg detail isn't
+      // surfaced to partners, so no webhook should fire.
+      setupMocks({ orderNumber: 'CC-12345', status: 'ACTIVE', driverStatus: 'ASSIGNED' });
+      const { PATCH } = await importRoute();
+
+      const request = createPatchRequest({ driverStatus: 'EN_ROUTE_TO_VENDOR' }, 'CC-12345');
+      const params = Promise.resolve({ order_number: 'CC-12345' });
+
+      await PATCH(request, { params });
+
+      expect(mockedRecordLifecycle).not.toHaveBeenCalled();
+    });
+
+    it('does NOT dispatch on a status-only PATCH (no driverStatus)', async () => {
+      setupMocks({ orderNumber: 'CC-12345', status: 'ACTIVE', driverStatus: 'ASSIGNED' });
+      const { PATCH } = await importRoute();
+
+      const request = createPatchRequest({ status: 'IN_PROGRESS' }, 'CC-12345');
+      const params = Promise.resolve({ order_number: 'CC-12345' });
+
+      await PATCH(request, { params });
+
+      expect(mockedRecordLifecycle).not.toHaveBeenCalled();
+    });
+
+    it('does not fail the driver request if the partner dispatch rejects', async () => {
+      // Fire-and-forget: even a thrown dispatch must not break the PATCH.
+      setupMocks({
+        orderNumber: 'CC-12345',
+        status: 'IN_PROGRESS',
+        driverStatus: 'ARRIVED_TO_CLIENT',
+      });
+      mockedRecordLifecycle.mockRejectedValueOnce(new Error('partner down'));
+      const { PATCH } = await importRoute();
+
+      const request = createPatchRequest({ driverStatus: 'COMPLETED' }, 'CC-12345');
+      const params = Promise.resolve({ order_number: 'CC-12345' });
+
+      const response = await PATCH(request, { params });
+
+      expect(response.status).toBe(200);
+      expect(mockedRecordLifecycle).toHaveBeenCalledWith(
+        expect.objectContaining({ partnerStatus: 'DELIVERED' }),
+      );
     });
   });
 

--- a/src/app/api/orders/[order_number]/route.ts
+++ b/src/app/api/orders/[order_number]/route.ts
@@ -25,6 +25,10 @@ import {
   deriveOrderStatusFromDriver,
 } from '@/lib/state-machine/transition';
 import type { OrderStatus } from '@/lib/state-machine/transition';
+import {
+  recordAndDispatchLifecycleEvent,
+  DRIVER_STATUS_TO_PARTNER_LIFECYCLE,
+} from '@/lib/services/partnerWebhookService';
 
 // Map DriverStatus to dispatch notification status
 const DRIVER_STATUS_TO_DISPATCH_STATUS: Record<string, string> = {
@@ -803,6 +807,37 @@ export async function PATCH(
         broadcastDeliveryStatus().catch((err) => {
           console.error('Failed to broadcast delivery status update:', err);
         });
+
+        // Registry-driven partner status webhook (e.g. CaterCow). The driver
+        // app advances order status through THIS route, so the outbound
+        // lifecycle callback (ASSIGNED → PICKED_UP → ON_THE_WAY → ARRIVED →
+        // DELIVERED) must be emitted here. recordAndDispatchLifecycleEvent
+        // records to order_status_history then POSTs an HMAC-signed webhook;
+        // it self-guards against legacy carriers (CaterValley/ezCater own their
+        // outbound path) and non-partner orders, never throws, and no-ops when
+        // the partner has no webhook URL/secret configured. Fire-and-forget so
+        // partner delivery (up to 3 retries) never blocks the driver's response.
+        const partnerLifecycle =
+          DRIVER_STATUS_TO_PARTNER_LIFECYCLE[
+            driverStatus as keyof typeof DRIVER_STATUS_TO_PARTNER_LIFECYCLE
+          ];
+        if (partnerLifecycle) {
+          const driverProfile = (updatedOrder as any).dispatches?.[0]?.driver;
+          const driver =
+            driverProfile?.name && driverProfile?.contactNumber
+              ? { name: driverProfile.name, phone: driverProfile.contactNumber }
+              : undefined;
+          recordAndDispatchLifecycleEvent({
+            orderId: (updatedOrder as any).id,
+            orderNumber: (updatedOrder as any).orderNumber,
+            partnerStatus: partnerLifecycle,
+            driverStatus,
+            changedBy: user.id ?? driverProfile?.id ?? null,
+            driver,
+          }).catch((err) => {
+            console.error('Failed to dispatch partner lifecycle webhook:', err);
+          });
+        }
       }
 
       // Send customer notification for significant field changes (non-blocking)


### PR DESCRIPTION
## Problem

Outbound **partner status webhooks never fired for a real CaterCow delivery.**

The registry-driven dispatcher `recordAndDispatchLifecycleEvent` (built in #432) was only wired into `POST /api/catering-requests/[orderId]/status`. But the #447 *"unify on the orders system"* refactor moved the driver app's status-advance flow onto `PATCH /api/orders/[order_number]` — and nothing re-wired the emit. The catering-requests status route now has **zero callers** in the app.

Net effect for a CaterCow (`CC-`) order driven end-to-end by a driver:
- **No** outbound lifecycle callbacks (`ASSIGNED → PICKED_UP → ON_THE_WAY → ARRIVED → DELIVERED`) reached the partner.
- **Nothing** was written to `order_status_history`, so `GET /orders/{id}` (the resync endpoint) returned `lifecycleStatus: null, events: []` too.

## Fix

Emit the partner lifecycle event from the orders PATCH handler, right after the status-update transaction commits — fire-and-forget, matching the realtime broadcast + notification dispatches already in that handler, so partner delivery (up to 3 retries) never blocks the driver's response.

`recordAndDispatchLifecycleEvent` is **self-guarding**, so this is safe and narrow:
- no-op for non-partner orders,
- skips legacy carriers (CaterValley / ezCater own their outbound path via `CARRIER_CONFIGS`),
- never throws,
- logs `[partner-webhook] skipped` when the partner has no `webhook_url`/`webhook_secret` set.

→ **Safe to merge before the staging webhook is configured** — it simply no-ops until the CaterCow partner row gets a URL + secret.

## Blast radius

- Only registry partners (currently **CaterCow**) are affected. CaterValley/ezCater are untouched (skipped by the guard).
- The vendor-leg statuses (`EN_ROUTE_TO_VENDOR`, `ARRIVED_AT_VENDOR`) map to `null` and emit nothing — partners only see the client-leg lifecycle, unchanged from the contract.

## Testing

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- Orders route + partner-webhook suites: **56/56 ✅**
- New regression tests on `PATCH /api/orders/[order_number]` assert it: emits on a client-leg transition (with the right `partnerStatus`/`driver`), stays silent on vendor-leg and status-only updates, and survives a dispatch rejection without failing the driver request — locking the wiring so a future refactor can't silently re-orphan it.

## Follow-up (ops, not in this PR)

1. Set the CaterCow **staging** webhook URL + secret on rs-dev (`scripts/set-partner-webhook.ts`, URL `https://api.staging.steerdelivery.com/webhooks/ready_set`) — currently `webhook_url`/`webhook_secret` are NULL.
2. Deliver the signing secret to CaterCow securely; reply to their open thread.
3. Production: issue prod key + set prod webhook URL/secret after CaterCow signs off on staging.

## Out of scope (flagged)

CaterValley emits via a separate, **admin-driven** path (`SingleOrder.tsx → brokerSyncService → syncCaterValleyOrderStatusAction`), not the driver flow. Whether CaterValley *should* also fire on driver transitions is a pre-existing question, not addressed here.
