### PR TITLE
feat(partners): emit ASSIGNED lifecycle webhook on driver assignment

### DIFF
--- a/src/app/api/orders/[order_number]/route.ts
+++ b/src/app/api/orders/[order_number]/route.ts
@@ -1,5 +1,5 @@
 // src/app/api/orders/[order_number]/route.ts
-import { NextRequest, NextResponse, after } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { createClient, createAdminClient } from "@/utils/supabase/server";
 import { prisma } from "@/utils/prismaDB";
 import { Prisma } from "@prisma/client";
@@ -29,6 +29,7 @@ import {
   recordAndDispatchLifecycleEvent,
   DRIVER_STATUS_TO_PARTNER_LIFECYCLE,
 } from '@/lib/services/partnerWebhookService';
+import { runAfterResponse } from '@/lib/api/after-response';
 
 // Map DriverStatus to dispatch notification status
 const DRIVER_STATUS_TO_DISPATCH_STATUS: Record<string, string> = {
@@ -317,29 +318,6 @@ function isStatusOnlyUpdate(body: Record<string, unknown>): boolean {
   const statusFields = ['status', 'driverStatus'];
   const providedFields = Object.keys(body).filter(key => body[key] !== undefined);
   return providedFields.every(field => statusFields.includes(field));
-}
-
-/**
- * Run best-effort work *after* the response is sent — reliably.
- *
- * On Vercel the serverless function is frozen once the response returns, so a
- * bare `fn().catch()` started during the request is dropped intermittently
- * (observed live: ~half of partner-webhook emits, and by the same mechanism the
- * realtime broadcast + status notifications below, were silently lost). `after()`
- * keeps the function alive until the work finishes, without blocking the
- * response. `after()` throws outside a request scope (e.g. a unit test calling
- * the handler directly), so fall back to running inline there.
- */
-function runAfterResponse(label: string, work: () => Promise<unknown>): void {
-  const safe = () =>
-    Promise.resolve()
-      .then(work)
-      .catch((err) => console.error(label, err));
-  try {
-    after(safe);
-  } catch {
-    void safe();
-  }
 }
 
 export async function PATCH(

--- a/src/app/api/orders/assignDriver/__tests__/route.test.ts
+++ b/src/app/api/orders/assignDriver/__tests__/route.test.ts
@@ -18,6 +18,7 @@ import { POST } from "../route";
 import { createClient } from "@/utils/supabase/server";
 import { prisma } from "@/utils/prismaDB";
 import { validateUserNotSoftDeleted } from "@/lib/soft-delete-handlers";
+import { recordAndDispatchLifecycleEvent } from "@/lib/services/partnerWebhookService";
 import {
   createPostRequest,
   expectSuccessResponse,
@@ -43,10 +44,17 @@ jest.mock("@/lib/soft-delete-handlers", () => ({
   getActiveDriversForDispatch: jest.fn(),
 }));
 
+jest.mock("@/lib/services/partnerWebhookService", () => ({
+  recordAndDispatchLifecycleEvent: jest.fn().mockResolvedValue(undefined),
+}));
+
 const mockCreateClient = createClient as jest.MockedFunction<typeof createClient>;
 const mockPrisma = prisma as any;
 const mockValidateUserNotSoftDeleted = validateUserNotSoftDeleted as jest.MockedFunction<
   typeof validateUserNotSoftDeleted
+>;
+const mockRecordLifecycle = recordAndDispatchLifecycleEvent as jest.MockedFunction<
+  typeof recordAndDispatchLifecycleEvent
 >;
 
 describe("/api/orders/assignDriver", () => {
@@ -411,6 +419,73 @@ describe("/api/orders/assignDriver", () => {
             data: expect.objectContaining({ status: "ASSIGNED" }),
           })
         );
+      });
+    });
+
+    describe("Partner ASSIGNED webhook", () => {
+      it("emits the ASSIGNED lifecycle event for a catering assignment", async () => {
+        mockPrisma.$transaction.mockImplementation(async (callback: any) => {
+          return callback({
+            cateringRequest: {
+              findUnique: jest.fn().mockResolvedValue(mockCateringOrder),
+              update: jest.fn().mockResolvedValue({ ...mockCateringOrder, status: "ASSIGNED" }),
+              findUniqueOrThrow: jest
+                .fn()
+                .mockResolvedValue({ ...mockCateringOrder, status: "ASSIGNED" }),
+            },
+            dispatch: {
+              findFirst: jest.fn().mockResolvedValue(null),
+              create: jest.fn().mockResolvedValue(mockDispatch),
+            },
+          });
+        });
+
+        const request = createPostRequest("http://localhost:3000/api/orders/assignDriver", {
+          orderId: mockCateringOrder.id,
+          driverId: mockDriver.id,
+          orderType: "catering",
+        });
+
+        await POST(request);
+
+        expect(mockRecordLifecycle).toHaveBeenCalledTimes(1);
+        expect(mockRecordLifecycle).toHaveBeenCalledWith(
+          expect.objectContaining({
+            orderId: mockCateringOrder.id,
+            orderNumber: mockCateringOrder.orderNumber,
+            partnerStatus: "ASSIGNED",
+            driverStatus: "ASSIGNED",
+            driver: { name: mockDriver.name, phone: mockDriver.contactNumber },
+          })
+        );
+      });
+
+      it("does NOT emit for an on_demand assignment (partner orders are catering)", async () => {
+        mockPrisma.$transaction.mockImplementation(async (callback: any) => {
+          return callback({
+            onDemand: {
+              findUnique: jest.fn().mockResolvedValue(mockOnDemandOrder),
+              update: jest.fn().mockResolvedValue({ ...mockOnDemandOrder, status: "ASSIGNED" }),
+              findUniqueOrThrow: jest
+                .fn()
+                .mockResolvedValue({ ...mockOnDemandOrder, status: "ASSIGNED" }),
+            },
+            dispatch: {
+              findFirst: jest.fn().mockResolvedValue(null),
+              create: jest.fn().mockResolvedValue(mockDispatch),
+            },
+          });
+        });
+
+        const request = createPostRequest("http://localhost:3000/api/orders/assignDriver", {
+          orderId: mockOnDemandOrder.id,
+          driverId: mockDriver.id,
+          orderType: "on_demand",
+        });
+
+        await POST(request);
+
+        expect(mockRecordLifecycle).not.toHaveBeenCalled();
       });
     });
 

--- a/src/app/api/orders/assignDriver/route.ts
+++ b/src/app/api/orders/assignDriver/route.ts
@@ -10,6 +10,8 @@ import {
   StateTransitionError,
 } from "@/lib/state-machine/transition";
 import type { OrderStatus, OrderType } from "@/lib/state-machine/transition";
+import { recordAndDispatchLifecycleEvent } from "@/lib/services/partnerWebhookService";
+import { runAfterResponse } from "@/lib/api/after-response";
 
 function serializeData(obj: unknown): number | string | Date | Record<string, unknown> | unknown {
   if (typeof obj === "bigint") {
@@ -198,6 +200,32 @@ export async function POST(request: Request) {
         });
       } catch (deliveryErr) {
         console.error('Failed to upsert delivery assignedAt:', deliveryErr);
+      }
+
+      // Registry-driven partner ASSIGNED webhook (e.g. CaterCow). Driver
+      // assignment happens here, NOT via the driver order PATCH, so the ASSIGNED
+      // lifecycle event has to be emitted from this route — otherwise partners
+      // never see it. Catering-only: partner orders are catering_requests, and
+      // order_status_history.cateringRequestId FKs to that table. The helper
+      // additionally no-ops for non-partner orders and legacy carriers, never
+      // throws, and skips when no webhook is configured. Deferred via
+      // runAfterResponse so it survives the Vercel post-response freeze.
+      if (orderType === "catering") {
+        const driverProfile = (result.dispatch as any)?.driver;
+        const driver =
+          driverProfile?.name && driverProfile?.contactNumber
+            ? { name: driverProfile.name, phone: driverProfile.contactNumber }
+            : undefined;
+        runAfterResponse('Failed to dispatch partner ASSIGNED webhook:', () =>
+          recordAndDispatchLifecycleEvent({
+            orderId: (result.updatedOrder as any).id,
+            orderNumber: (result.updatedOrder as any).orderNumber,
+            partnerStatus: 'ASSIGNED',
+            driverStatus: 'ASSIGNED',
+            changedBy: user.id ?? null,
+            driver,
+          }),
+        );
       }
 
       // Serialize the result before sending the response

--- a/src/lib/api/after-response.ts
+++ b/src/lib/api/after-response.ts
@@ -1,0 +1,23 @@
+import { after } from 'next/server';
+
+/**
+ * Run best-effort work *after* the response is sent — reliably.
+ *
+ * On Vercel the serverless function is frozen once the response returns, so a
+ * bare `fn().catch()` started during the request is dropped intermittently
+ * (observed live: ~half of the driver-PATCH partner-webhook emits, and by the
+ * same mechanism the realtime broadcast + status notifications, were silently
+ * lost). `after()` keeps the function alive until the work finishes, without
+ * blocking the response. `after()` throws outside a request scope (e.g. a unit
+ * test calling a route handler directly), so fall back to running inline there.
+ */
+export function runAfterResponse(label: string, work: () => Promise<unknown>): void {
+  // `work` is always an async fn / promise-returning thunk, so it never throws
+  // synchronously — `.catch` captures every rejection.
+  const safe = () => work().catch((err) => console.error(label, err));
+  try {
+    after(safe);
+  } catch {
+    void safe();
+  }
+}


### PR DESCRIPTION
## Why

Driver assignment goes through `POST /api/orders/assignDriver`, which sets the order to ASSIGNED but **never emitted the partner `ASSIGNED` webhook** — only the driver-advanced transitions through the orders PATCH do (#467/#468). So CaterCow's lifecycle effectively started at `PICKED_UP`, missing the `ASSIGNED` event the v0.1 contract promises. (Caught while reviewing the partner email before sending.)

## What

- **`assignDriver`** now emits the `ASSIGNED` lifecycle event after the assignment commits, **catering-only** (partner orders are `catering_requests`, and `order_status_history.cateringRequestId` FKs to that table). The dispatcher helper additionally no-ops for non-partner orders + legacy carriers and never throws.
- Deferred via **`after()`** (same reliability fix as #468) so it survives the Vercel post-response freeze.
- Extracted the `after()`-with-inline-fallback pattern into a shared **`runAfterResponse()`** (`src/lib/api/after-response.ts`); the driver order PATCH now imports it instead of keeping a local copy.

## Testing

- `pnpm typecheck` ✅, `pnpm lint` ✅, orders + assignDriver + partner suites **84/84** ✅.
- +2 `assignDriver` tests: a catering assignment emits `ASSIGNED` (with the right order number + driver); an `on_demand` assignment does not.

After this lands, the full contract lifecycle fires end-to-end: **`ASSIGNED → PICKED_UP → ON_THE_WAY → ARRIVED → DELIVERED`** (+ `CANCELLED`).
