### PR TITLE
fix(driver): reserve the iOS safe-area top inset in the native WebView

### DIFF
--- a/src/app/(site)/(users)/driver/tracking/page.tsx
+++ b/src/app/(site)/(users)/driver/tracking/page.tsx
@@ -18,6 +18,7 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
+  viewportFit: 'cover', // resolve env(safe-area-inset-*) so the native WebView clears the status bar
   themeColor: '#1f2937',
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { CONSTANTS } from "@/constants";
 import UmamiAnalytics from "@/components/Analytics/UmamiAnalytics";
 import QueryProvider from "@/providers/QueryProvider";
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { getCloudinaryUrl } from "@/lib/cloudinary";
 import JsonLd from "@/components/SEO/JsonLd";
 
@@ -65,6 +65,21 @@ export const metadata: Metadata = {
       "max-snippet": -1,
     },
   },
+};
+
+// `viewport-fit=cover` lets the page extend into the iOS safe-area regions
+// (status bar / notch / home indicator) and, crucially, makes the
+// `env(safe-area-inset-*)` CSS variables resolve to real values instead of 0.
+// The driver UI already pads its sticky header + bottom nav with those insets
+// (see DriverScreen / BottomNav); without cover mode they collapsed to 0, so in
+// the native Capacitor WebView (no browser chrome) the header rendered under the
+// status bar. This only has a visible effect in standalone/native contexts
+// (the PWA `start_url` and the native shell are driver-only) — normal browser
+// tabs are unaffected. Kept zoom enabled site-wide for accessibility.
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
 };
 
 const montserrat = Montserrat({


### PR DESCRIPTION
## Problem

In the native Capacitor driver app (and any iOS standalone/PWA context), the driver **home header** (`Monday … · Good evening, <name>`) rendered **underneath the iOS status bar / Dynamic Island** — overlapping the clock and battery.

![before](status-bar-overlap)

## Root cause

`viewport-fit=cover` was set **nowhere** in the app. Without it, iOS reports every `env(safe-area-inset-*)` as **`0`**. The driver UI already pads for the insets — `DriverScreen`'s sticky header uses `paddingTop: env(safe-area-inset-top)` and `BottomNav` uses the bottom inset — but those collapsed to 0. In a normal browser the page sits below the browser chrome so it's never noticed; in Capacitor's chrome-less WKWebView the header slides up under the status bar.

## Change

- `src/app/layout.tsx` — add a root `viewport` export with `viewportFit: 'cover'` (zoom kept enabled for a11y).
- `src/app/(site)/(users)/driver/tracking/page.tsx` — add `viewportFit: 'cover'` to its existing `viewport` export (it defines its own, so it wouldn't inherit the root otherwise).

No new CSS — this just **activates** the safe-area padding the app already ships.

## Scope / blast radius

`viewport-fit=cover` only has a visible effect in **standalone/native** contexts. Per `public/manifest.json` the PWA is **driver-only** (`start_url: /driver/tracking`) and the manifest is not linked site-wide, so:

- ✅ Driver app / native shell: header now clears the status bar.
- ✅ Normal browser tabs (marketing site, admin, etc.): **unchanged** (cover mode is inert with browser chrome present).

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` (next lint, both files) ✅
- Manual: confirmed on a real iPhone 14 Pro Max (iOS 26.5.2) via the Capacitor shell that the home header was overlapping the status bar; this enables the existing inset padding. Will re-confirm on-device once this is live on `development.readysetllc.com`.

## Notes

- This is the cosmetic follow-up to the native-driver-app POC (the Cap 8 WebView now loads the live site on-device). It does not touch any API/data path.