### PR TITLE
fix(driver): re-arm native background GPS when arming fails or the app relaunches mid-shift

### DIFF
--- a/src/contexts/DriverTrackingContext.tsx
+++ b/src/contexts/DriverTrackingContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useContext, useCallback, ReactNode } from 'react';
+import React, { createContext, useContext, useCallback, useEffect, ReactNode } from 'react';
 import { useRealtimeLocationTracking } from '@/hooks/tracking/useRealtimeLocationTracking';
 import { useDriverShift } from '@/hooks/tracking/useDriverShift';
 import { useDriverDeliveries } from '@/hooks/tracking/useDriverDeliveries';
@@ -91,7 +91,7 @@ export function DriverTrackingProvider({ children }: DriverTrackingProviderProps
   const {
     currentShift,
     isShiftActive,
-    startShift: startShiftBase,
+    startShift,
     endShift: endShiftBase,
     loading: shiftLoading,
     error: shiftError,
@@ -99,16 +99,15 @@ export function DriverTrackingProvider({ children }: DriverTrackingProviderProps
 
   // Supplement the foreground web tracker with native background GPS while the
   // /driver app runs inside the Capacitor shell — so the trail survives a locked
-  // screen or a switch to Waze. Both calls no-op in a normal browser (the native
-  // plugin is only dynamically imported inside the native shell).
-  const startShift = useCallback(
-    async (location: LocationUpdate): Promise<boolean> => {
-      const started = await startShiftBase(location);
-      if (started) void startNativeShiftTrackingForDriver();
-      return started;
-    },
-    [startShiftBase],
-  );
+  // screen or a switch to Waze. Keyed on shift state (not the startShift call)
+  // so the watcher also re-arms when the app is relaunched mid-shift and when
+  // arming failed at shift start. Both helpers no-op in a normal browser (the
+  // native plugin is only dynamically imported inside the native shell) and are
+  // idempotent inside it.
+  useEffect(() => {
+    if (isShiftActive) void startNativeShiftTrackingForDriver();
+    else void stopNativeShiftTrackingForDriver();
+  }, [isShiftActive]);
 
   // Flush any queued GPS points before ending the shift, so the server-side
   // shift mileage (summed from driver_locations) reflects the full trail rather

--- a/src/lib/tracking/__tests__/capacitor-tracking.test.ts
+++ b/src/lib/tracking/__tests__/capacitor-tracking.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for the Capacitor background-GPS bridge — specifically the lazy,
+ * self-healing driver-id resolution: a failed lookup at shift start (e.g. an
+ * expired server session returning 401) must not disable background tracking
+ * for the whole shift.
+ */
+
+let mockIsNative = true;
+const mockAddWatcher = jest.fn();
+const mockRemoveWatcher = jest.fn();
+const mockOpenSettings = jest.fn();
+
+jest.mock('@capacitor/core', () => ({
+  Capacitor: { isNativePlatform: () => mockIsNative },
+  registerPlugin: () => ({
+    addWatcher: (...args: unknown[]) => mockAddWatcher(...args),
+    removeWatcher: (...args: unknown[]) => mockRemoveWatcher(...args),
+    openSettings: (...args: unknown[]) => mockOpenSettings(...args),
+  }),
+}));
+
+type Bridge = typeof import('../capacitor-tracking');
+type WatcherCallback = (
+  location?: Record<string, unknown>,
+  error?: { code?: string },
+) => Promise<void>;
+
+describe('capacitor-tracking', () => {
+  let bridge: Bridge;
+  let nowMs: number;
+  let watcherCallback: WatcherCallback;
+
+  const fetchMock = jest.fn();
+
+  const fix = {
+    latitude: 19.41,
+    longitude: -99.19,
+    accuracy: 5,
+    speed: 0,
+    bearing: null,
+    altitude: null,
+  };
+
+  function session(overrides: Record<string, unknown> = {}) {
+    return {
+      getDriverId: jest.fn().mockResolvedValue('driver-1'),
+      getAccessToken: jest.fn().mockResolvedValue('token-1'),
+      ...overrides,
+    };
+  }
+
+  /** Fire one watcher fix with the 5s post throttle already cleared. */
+  async function emitFix() {
+    nowMs += 5_001;
+    await watcherCallback(fix, undefined);
+  }
+
+  function postedBody(callIndex = 0): Record<string, unknown> {
+    return JSON.parse(fetchMock.mock.calls[callIndex]![1].body as string);
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    mockIsNative = true;
+    nowMs = 1_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => nowMs);
+    global.fetch = fetchMock as unknown as typeof fetch;
+    fetchMock.mockResolvedValue({ ok: true });
+    mockAddWatcher.mockImplementation((_opts: unknown, cb: WatcherCallback) => {
+      watcherCallback = cb;
+      return Promise.resolve('watcher-1');
+    });
+    mockRemoveWatcher.mockResolvedValue(undefined);
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    bridge = require('../capacitor-tracking');
+  });
+
+  afterEach(() => {
+    (Date.now as jest.Mock).mockRestore();
+  });
+
+  it('arms the watcher even when the driver id cannot resolve yet', async () => {
+    const s = session({ getDriverId: jest.fn().mockResolvedValue(null) });
+    await bridge.startNativeShiftTracking(s);
+    expect(mockAddWatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('posts a fix with the resolved driver id and bearer token', async () => {
+    await bridge.startNativeShiftTracking(session());
+    await emitFix();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/tracking/locations',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({ Authorization: 'Bearer token-1' }),
+      }),
+    );
+    expect(postedBody().driver_id).toBe('driver-1');
+  });
+
+  it('retries the driver-id lookup on later fixes until it succeeds, then caches it', async () => {
+    const getDriverId = jest
+      .fn()
+      .mockResolvedValueOnce(null) // shift started with a broken session
+      .mockResolvedValueOnce('driver-1'); // session healed
+    await bridge.startNativeShiftTracking(session({ getDriverId }));
+
+    await emitFix(); // unresolved → skipped, no post
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await emitFix(); // resolves now → posts
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await emitFix(); // cached → no further lookups
+    expect(getDriverId).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips the fix without a driver-id lookup when signed out', async () => {
+    const s = session({ getAccessToken: jest.fn().mockResolvedValue(null) });
+    await bridge.startNativeShiftTracking(s);
+    await emitFix();
+
+    expect(s.getDriverId).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent while running and clears the cached driver id on stop', async () => {
+    const s = session();
+    await bridge.startNativeShiftTracking(s);
+    await bridge.startNativeShiftTracking(s);
+    expect(mockAddWatcher).toHaveBeenCalledTimes(1);
+
+    await bridge.stopNativeShiftTracking();
+    expect(mockRemoveWatcher).toHaveBeenCalledWith({ id: 'watcher-1' });
+
+    const s2 = session({ getDriverId: jest.fn().mockResolvedValue('driver-2') });
+    await bridge.startNativeShiftTracking(s2);
+    await emitFix();
+    expect(postedBody().driver_id).toBe('driver-2');
+  });
+});

--- a/src/lib/tracking/__tests__/native-shift-tracking.test.ts
+++ b/src/lib/tracking/__tests__/native-shift-tracking.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for the native-shift-tracking adapter. The regression under test: the
+ * adapter used to resolve the driver id up-front and silently bail when
+ * /api/auth/session failed (expired server session at shift start), leaving
+ * the native watcher unarmed for the whole shift. It must now always arm and
+ * hand the bridge a lazy resolver instead.
+ */
+
+const mockStartBridge = jest.fn();
+const mockStopBridge = jest.fn();
+
+jest.mock('../capacitor-tracking', () => ({
+  startNativeShiftTracking: (...args: unknown[]) => mockStartBridge(...args),
+  stopNativeShiftTracking: (...args: unknown[]) => mockStopBridge(...args),
+}));
+
+jest.mock('@/utils/supabase/client', () => ({
+  createClient: () => ({
+    auth: {
+      getSession: jest
+        .fn()
+        .mockResolvedValue({ data: { session: { access_token: 'tok-1' } } }),
+    },
+  }),
+}));
+
+import {
+  isCapacitorNative,
+  startNativeShiftTrackingForDriver,
+  stopNativeShiftTrackingForDriver,
+} from '../native-shift-tracking';
+
+type CapacitorWindow = Window & {
+  Capacitor?: { isNativePlatform?: () => boolean };
+};
+
+const fetchMock = jest.fn();
+
+describe('native-shift-tracking', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    delete (window as CapacitorWindow).Capacitor;
+  });
+
+  function enterNativeShell() {
+    (window as CapacitorWindow).Capacitor = { isNativePlatform: () => true };
+  }
+
+  it('no-ops entirely in a plain browser', async () => {
+    expect(isCapacitorNative()).toBe(false);
+    await startNativeShiftTrackingForDriver();
+    await stopNativeShiftTrackingForDriver();
+    expect(mockStartBridge).not.toHaveBeenCalled();
+    expect(mockStopBridge).not.toHaveBeenCalled();
+  });
+
+  it('arms the bridge even when the driver-id lookup is failing (401)', async () => {
+    enterNativeShell();
+    fetchMock.mockResolvedValue({ ok: false, status: 401 });
+
+    await startNativeShiftTrackingForDriver();
+
+    expect(mockStartBridge).toHaveBeenCalledTimes(1);
+    const passed = mockStartBridge.mock.calls[0]![0];
+    // The lazy resolver reflects the current session state on each call.
+    await expect(passed.getDriverId()).resolves.toBeNull();
+    await expect(passed.getAccessToken()).resolves.toBe('tok-1');
+  });
+
+  it('hands the bridge a resolver that returns the driver id once the session heals', async () => {
+    enterNativeShell();
+    fetchMock
+      .mockResolvedValueOnce({ ok: false, status: 401 })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ user: { driverId: 'driver-9' } }),
+      });
+
+    await startNativeShiftTrackingForDriver();
+    const passed = mockStartBridge.mock.calls[0]![0];
+
+    await expect(passed.getDriverId()).resolves.toBeNull(); // still broken
+    await expect(passed.getDriverId()).resolves.toBe('driver-9'); // healed
+  });
+
+  it('stops the bridge inside the native shell', async () => {
+    enterNativeShell();
+    await stopNativeShiftTrackingForDriver();
+    expect(mockStopBridge).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/tracking/capacitor-tracking.ts
+++ b/src/lib/tracking/capacitor-tracking.ts
@@ -32,7 +32,13 @@ const BackgroundGeolocation =
   registerPlugin<BackgroundGeolocationPlugin>('BackgroundGeolocation');
 
 export interface NativeTrackingSession {
-  driverId: string;
+  /**
+   * Resolves the driver id. Called lazily on each fix until it succeeds (then
+   * cached), so a failed lookup at shift start — e.g. an expired server session
+   * returning 401 — heals on its own once auth recovers, instead of silently
+   * disabling background tracking for the whole shift.
+   */
+  getDriverId: () => Promise<string | null>;
   /** Returns a fresh Supabase access token (refresh-aware); null if signed out. */
   getAccessToken: () => Promise<string | null>;
 }
@@ -42,6 +48,7 @@ const POST_THROTTLE_MS = 5000;
 
 let watcherId: string | null = null;
 let lastPostAt = 0;
+let cachedDriverId: string | null = null;
 
 /** True only inside the Capacitor native shell — false in any web browser. */
 export function isNativeTrackingAvailable(): boolean {
@@ -87,7 +94,12 @@ export async function startNativeShiftTracking(
 
       const token = await session.getAccessToken();
       if (!token) return; // signed out / token unavailable — skip this fix
-      await postLocation(location, session.driverId, token);
+
+      if (!cachedDriverId) {
+        cachedDriverId = await session.getDriverId();
+        if (!cachedDriverId) return; // auth not healed yet — next fix retries
+      }
+      await postLocation(location, cachedDriverId, token);
     },
   );
 }
@@ -100,6 +112,7 @@ export async function stopNativeShiftTracking(): Promise<void> {
   } finally {
     watcherId = null;
     lastPostAt = 0;
+    cachedDriverId = null;
   }
 }
 

--- a/src/lib/tracking/native-shift-tracking.ts
+++ b/src/lib/tracking/native-shift-tracking.ts
@@ -52,12 +52,14 @@ async function resolveDriverId(): Promise<string | null> {
 export async function startNativeShiftTrackingForDriver(): Promise<void> {
   if (!isCapacitorNative()) return;
   try {
-    const driverId = await resolveDriverId();
-    if (!driverId) return;
     const supabase = createClient();
     const { startNativeShiftTracking } = await import('./capacitor-tracking');
+    // The watcher always arms; the driver id resolves lazily per fix (and is
+    // then cached by the bridge). A 401 from /api/auth/session at shift start
+    // must not permanently disable background tracking — it retries on the
+    // next fix once the session heals.
     await startNativeShiftTracking({
-      driverId,
+      getDriverId: resolveDriverId,
       getAccessToken: async () =>
         (await supabase.auth.getSession()).data.session?.access_token ?? null,
     });


### PR DESCRIPTION
## Problem

In today's Android walk test (Cap-8 debug APK, real Redmi device), the entire walk recorded only foreground GPS points — a 14-minute screen-locked gap with zero fixes — even though the whole point of the native shell is background tracking.

Root cause chain:

1. The shift started while the WebView's server session was expired (every API call returned 401 `Auth session missing`).
2. `startNativeShiftTrackingForDriver()` resolved the driver id up-front via `/api/auth/session`, got `null`, and **silently returned without arming the watcher** — no retry, ever.
3. The watcher is only armed inside the `startShift` call, so nothing re-armed after the driver re-logged in. Background tracking stayed dead for the whole shift.

## Fix

- **`DriverTrackingContext`**: arm/stop the native watcher keyed on `isShiftActive` (effect) instead of the `startShift` call — re-arms when the app is relaunched mid-shift and after a failed arm. Both helpers no-op on web and are idempotent in the shell.
- **`native-shift-tracking`**: always arm; pass the driver-id lookup to the bridge as a lazy resolver instead of gating the arm on it.
- **`capacitor-tracking`**: resolve the driver id per fix until it succeeds, then cache it (cleared on stop). A broken session at shift start now self-heals on the next fix once auth recovers.

## Tests

- 9 new unit tests across two suites (`capacitor-tracking`, `native-shift-tracking`) covering: arms with unresolved driver id, lazy retry-then-cache, signed-out skip, idempotency, stop-clears-cache, web no-op, and the exact 401-at-shift-start regression.
- Existing tracking hook suites: 304 pass. `pre-push-check` green.

## Out of scope (follow-ups from the same walk test)

- WebView session divergence (client session alive, server cookies dead → the 401s that triggered this). Under investigation.
- `CAMERA` permission missing in the Android shell manifest (POD photo blocked) — native-shell change, PR #461 territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)