### PR TITLE
fix(driver): enforce the pickup signature on every surface

### DIFF
--- a/src/app/api/orders/[order_number]/__tests__/route.test.ts
+++ b/src/app/api/orders/[order_number]/__tests__/route.test.ts
@@ -468,4 +468,82 @@ describe('Orders API Route - Delivery Status Broadcast', () => {
       expect(response.status).toBe(400);
     });
   });
+
+  describe('Pickup-signature enforcement on PICKED_UP', () => {
+    // Same caller-mock shape as the IDOR block above: `userId` is the
+    // authenticated user, `type` drives the privileged check.
+    const mockCaller = (userId: string, type: string) => {
+      mockedCreateClient.mockResolvedValue({
+        auth: {
+          getUser: jest.fn().mockResolvedValue({
+            data: { user: { id: userId } },
+            error: null,
+          }),
+        },
+        from: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({
+            data: { type },
+            error: null,
+          }),
+        }),
+      } as any);
+    };
+
+    it('rejects a driver PICKED_UP with 422 when no pickup_signature upload exists', async () => {
+      // The Jul-3 walk-test bug: the Live-Tracking tab advanced
+      // ARRIVED_AT_VENDOR -> PICKED_UP without the signature sheet. The server
+      // must be the backstop regardless of which client surface forgot the gate.
+      setupMocks({ status: 'IN_PROGRESS', driverStatus: 'ARRIVED_AT_VENDOR' });
+      mockCaller('driver-456', 'DRIVER');
+      (mockedPrisma.fileUpload.findFirst as jest.Mock).mockResolvedValue(null);
+
+      const { PATCH } = await importRoute();
+      const response = await PATCH(createPatchRequest({ driverStatus: 'PICKED_UP' }), {
+        params: Promise.resolve({ order_number: 'CAT-001' }),
+      });
+
+      expect(response.status).toBe(422);
+      const data = await response.json();
+      expect(data.code).toBe('PICKUP_SIGNATURE_REQUIRED');
+      expect(mockedPrisma.cateringRequest.update).not.toHaveBeenCalled();
+    });
+
+    it('allows a driver PICKED_UP once the pickup_signature upload exists', async () => {
+      setupMocks({ status: 'IN_PROGRESS', driverStatus: 'ARRIVED_AT_VENDOR' });
+      mockCaller('driver-456', 'DRIVER');
+      (mockedPrisma.fileUpload.findFirst as jest.Mock).mockResolvedValue({ id: 'sig-1' });
+
+      const { PATCH } = await importRoute();
+      const response = await PATCH(createPatchRequest({ driverStatus: 'PICKED_UP' }), {
+        params: Promise.resolve({ order_number: 'CAT-001' }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(mockedPrisma.fileUpload.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            category: 'pickup_signature',
+            cateringRequestId: 'order-123',
+          }),
+        }),
+      );
+      expect(mockedPrisma.cateringRequest.update).toHaveBeenCalled();
+    });
+
+    it('lets a privileged (HELPDESK) caller set PICKED_UP without a signature (data repair)', async () => {
+      setupMocks({ status: 'IN_PROGRESS', driverStatus: 'ARRIVED_AT_VENDOR' });
+      mockCaller('helpdesk-user', 'HELPDESK');
+      (mockedPrisma.fileUpload.findFirst as jest.Mock).mockResolvedValue(null);
+
+      const { PATCH } = await importRoute();
+      const response = await PATCH(createPatchRequest({ driverStatus: 'PICKED_UP' }), {
+        params: Promise.resolve({ order_number: 'CAT-001' }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(mockedPrisma.cateringRequest.update).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/app/api/orders/[order_number]/route.ts
+++ b/src/app/api/orders/[order_number]/route.ts
@@ -423,6 +423,7 @@ export async function PATCH(
     // status-only PATCH (`{ status }`) — the driver client sends the latter on
     // completion, and without this any authenticated user could drive any order's
     // status by order number (the role check below only runs for field updates).
+    let callerIsPrivileged = false;
     if (driverStatus || status) {
       const { data: callerProfile } = await supabase
         .from('profiles')
@@ -434,6 +435,7 @@ export async function PATCH(
         callerType === 'ADMIN' ||
         callerType === 'SUPER_ADMIN' ||
         callerType === 'HELPDESK';
+      callerIsPrivileged = privileged;
 
       if (!privileged) {
         const dispatches = (existingOrder as any).dispatches;
@@ -524,6 +526,36 @@ export async function PATCH(
         { status: 422 },
       );
     }
+    // The vendor-pickup signature is mandatory (2026-06-22 decision), and the
+    // sheet is client-side — so back it up here: a driver cannot mark PICKED_UP
+    // until a pickup_signature upload exists for the order. Admin/helpdesk are
+    // exempt so they can repair stuck orders.
+    if (
+      driverStatus === DriverStatus.PICKED_UP &&
+      currentDriverStatus !== DriverStatus.PICKED_UP &&
+      !callerIsPrivileged
+    ) {
+      const pickupSignature = await prisma.fileUpload.findFirst({
+        where: {
+          category: 'pickup_signature',
+          ...(orderType === 'catering'
+            ? { cateringRequestId: (existingOrder as any).id }
+            : { onDemandId: (existingOrder as any).id }),
+        },
+        select: { id: true },
+      });
+      if (!pickupSignature) {
+        return NextResponse.json(
+          {
+            message:
+              'A vendor pickup signature is required before marking this order as picked up',
+            code: 'PICKUP_SIGNATURE_REQUIRED',
+          },
+          { status: 422 },
+        );
+      }
+    }
+
     if (
       status &&
       status !== currentStatus &&

--- a/src/components/Driver/DriverTrackingPortal.tsx
+++ b/src/components/Driver/DriverTrackingPortal.tsx
@@ -32,6 +32,7 @@ import {
   getStatusProgress,
 } from "@/components/Driver/ui";
 import { DriverPodSheet } from "@/components/Driver/ui/DriverPodSheet";
+import { DriverSignatureSheet } from "@/components/Driver/ui/DriverSignatureSheet";
 import { NavigateButton } from "@/components/Driver/ui/NavigateButton";
 
 interface PodTarget {
@@ -45,6 +46,7 @@ export default function DriverTrackingPortal() {
   const [elapsed, setElapsed] = useState(0);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
   const [podTarget, setPodTarget] = useState<PodTarget | null>(null);
+  const [sigTarget, setSigTarget] = useState<PodTarget | null>(null);
 
   const {
     currentLocation,
@@ -174,6 +176,13 @@ export default function DriverTrackingPortal() {
     if (!next) return;
     const orderNumber =
       delivery.cateringRequestId || delivery.onDemandId || delivery.id;
+    // The pickup step routes through vendor-signature capture (mandatory per
+    // the 2026-06-22 decision — mirrors the gate in DriverDeliveryDetail; the
+    // server also rejects an unsigned PICKED_UP).
+    if (next === DriverStatus.PICKED_UP) {
+      setSigTarget({ deliveryId: delivery.id, orderNumber });
+      return;
+    }
     // The final step routes through proof-of-delivery capture.
     if (next === DriverStatus.COMPLETED) {
       setPodTarget({ deliveryId: delivery.id, orderNumber });
@@ -188,6 +197,13 @@ export default function DriverTrackingPortal() {
     // having to re-capture the proof after only seeing the error toast.
     const ok = await advanceStatus(podTarget.deliveryId, DriverStatus.COMPLETED);
     if (ok) setPodTarget(null);
+  };
+
+  const onSignatureComplete = async () => {
+    if (!sigTarget) return;
+    // Same retry semantics as POD: keep the sheet open if the advance fails.
+    const ok = await advanceStatus(sigTarget.deliveryId, DriverStatus.PICKED_UP);
+    if (ok) setSigTarget(null);
   };
 
   const headerRight = useMemo(() => {
@@ -462,6 +478,15 @@ export default function DriverTrackingPortal() {
           </DriverCard>
         )}
       </div>
+
+      {sigTarget ? (
+        <DriverSignatureSheet
+          open={!!sigTarget}
+          onOpenChange={(o) => !o && setSigTarget(null)}
+          orderNumber={sigTarget.orderNumber}
+          onComplete={() => void onSignatureComplete()}
+        />
+      ) : null}
 
       {podTarget ? (
         <DriverPodSheet

--- a/src/components/Driver/__tests__/DriverTrackingPortal.test.tsx
+++ b/src/components/Driver/__tests__/DriverTrackingPortal.test.tsx
@@ -39,6 +39,16 @@ jest.mock("@/components/Driver/ProofOfDeliveryCapture", () => ({
   ),
 }));
 
+jest.mock("@/components/Driver/SignatureCapture", () => ({
+  SignatureCapture: ({ onUploadComplete }: any) => (
+    <div data-testid="signature-capture">
+      <button onClick={() => onUploadComplete("https://pod.example/signature.png")}>
+        finish signature upload
+      </button>
+    </div>
+  ),
+}));
+
 const mockUseDriverTracking = useDriverTracking as jest.MockedFunction<
   typeof useDriverTracking
 >;
@@ -281,6 +291,47 @@ describe("DriverTrackingPortal (redesigned)", () => {
     // podTarget is only cleared on success — the sheet must stay open so the
     // driver can retry without re-capturing the proof.
     expect(screen.getByTestId("pod-capture")).toBeInTheDocument();
+  });
+
+  it("routes the pickup step through the signature sheet instead of advancing directly", async () => {
+    // Jul-3 walk-test regression: this surface advanced ARRIVED_AT_VENDOR ->
+    // PICKED_UP with no vendor signature (the gate only existed in
+    // DriverDeliveryDetail). The pickup mandate applies on every surface.
+    mockUseDriverTracking.mockReturnValue(
+      baseCtx({
+        isShiftActive: true,
+        currentShift: { id: "s1", driverId: "driver-1", startTime: new Date() },
+        currentLocation: sampleLocation,
+        activeDeliveries: [
+          {
+            id: "del-1",
+            cateringRequestId: "cr-1",
+            driverId: "driver-1",
+            status: DriverStatus.ARRIVED_AT_VENDOR,
+            deliveryLocation: { coordinates: [-122.41, 37.77] },
+          },
+        ],
+      }),
+    );
+    renderPortal();
+
+    fireEvent.click(screen.getByText(/picked up the order/i));
+
+    // The signature sheet opens and NO status update happens yet.
+    expect(await screen.findByTestId("signature-capture")).toBeInTheDocument();
+    expect(updateDeliveryStatus).not.toHaveBeenCalled();
+
+    // Completing the signature advances to PICKED_UP.
+    fireEvent.click(
+      screen.getByRole("button", { name: /finish signature upload/i }),
+    );
+    await waitFor(() =>
+      expect(updateDeliveryStatus).toHaveBeenCalledWith(
+        "del-1",
+        DriverStatus.PICKED_UP,
+        sampleLocation,
+      ),
+    );
   });
 
   it("shows an offline banner when offline", () => {


### PR DESCRIPTION
## Bug (Jul-3 night walk, task `pickup-signature-gate-bypassed-tracking-portal`)

WALK-TEST-NIGHT completed with **0 signature uploads** despite the mandatory vendor-pickup-signature decision (2026-06-22, Gary). Root cause: #459 added the signature gate only to `DriverDeliveryDetail`; the Live-Tracking tab (`DriverTrackingPortal.handleAdvance`) gates POD but advanced `ARRIVED_AT_VENDOR → PICKED_UP` directly. Nothing server-side enforced the mandate.

## Fix

1. **Portal gate** — the pickup step now opens `DriverSignatureSheet` (mirrors the detail screen; sheet stays open on a failed advance so the driver can retry, same as POD).
2. **Server backstop** — `PATCH /api/orders/[order_number]` returns **422 `PICKUP_SIGNATURE_REQUIRED`** for a driver-initiated `PICKED_UP` when no `pickup_signature` FileUpload exists (catering + on-demand). ADMIN/SUPER_ADMIN/HELPDESK bypass so they can repair stuck orders. Any future surface that forgets the sheet now fails loudly instead of silently skipping the mandate.

## Tests

- Route: 422 without signature (+ no DB update), 200 once the upload exists (asserts the exact lookup), HELPDESK bypass — 3 new
- Portal: pickup click opens the sheet with **no** status update, completing the signature advances to `PICKED_UP` — 1 new
- `typecheck` / `lint` / 81 tests across the touched areas green

🤖 Generated with [Claude Code](https://claude.com/claude-code)