### PR TITLE
fix(driver): walk-test UX batch — route trail, POD title, nav feedback, date filter

### DIFF
--- a/src/components/Driver/DriverLiveMap.tsx
+++ b/src/components/Driver/DriverLiveMap.tsx
@@ -17,7 +17,27 @@ if (typeof window !== 'undefined' && process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN
 interface DriverLiveMapProps {
   currentLocation: LocationUpdate | null;
   activeDeliveries: DeliveryTracking[];
+  /** When set (together with shiftStartedAt), the trail is seeded from the
+   *  server so it shows the full shift route — including stretches recorded
+   *  while the page was locked/backgrounded or before a reload — instead of
+   *  only the points this browser session happened to observe. */
+  driverId?: string | null;
+  shiftStartedAt?: string | Date | null;
   className?: string;
+}
+
+/** Hard cap on trail vertices kept in memory / handed to Mapbox. */
+const MAX_TRAIL_POINTS = 1000;
+
+/** Cap the trail without ever losing the route start: thin the OLDER half
+ *  (drop every other point) instead of shifting points off the head — the old
+ *  `length > 200 → shift()` behavior made the beginning of the route visibly
+ *  disappear ~20 min into a shift. */
+function capTrail(trail: [number, number][]): [number, number][] {
+  if (trail.length <= MAX_TRAIL_POINTS) return trail;
+  const half = Math.floor(trail.length / 2);
+  const olderThinned = trail.slice(0, half).filter((_, i) => i % 2 === 0);
+  return [...olderThinned, ...trail.slice(half)];
 }
 
 /**
@@ -34,6 +54,8 @@ interface DriverLiveMapProps {
 export default function DriverLiveMap({
   currentLocation,
   activeDeliveries,
+  driverId,
+  shiftStartedAt,
   className,
 }: DriverLiveMapProps) {
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
@@ -46,6 +68,65 @@ export default function DriverLiveMap({
   const trailRef = useRef<[number, number][]>([]);
   // Track last centered position to detect large jumps
   const lastCenteredRef = useRef<{ lng: number; lat: number } | null>(null);
+  // Which shift the trail was last seeded from (guards against re-fetching).
+  const seededShiftKeyRef = useRef<string | null>(null);
+
+  // Seed the trail from the server once per shift: the DB holds the full
+  // recorded route (offline queue + native watcher keep posting while the
+  // page is locked), while this component previously only accumulated points
+  // it saw live — producing straight-line shortcuts across locked periods
+  // and losing everything on reload.
+  useEffect(() => {
+    if (!mapLoaded || !driverId || !shiftStartedAt) return;
+    const shiftKey = `${driverId}:${new Date(shiftStartedAt).getTime()}`;
+    if (seededShiftKeyRef.current === shiftKey) return;
+    seededShiftKeyRef.current = shiftKey;
+
+    const startMs = new Date(shiftStartedAt).getTime();
+    const hours = Math.min(
+      Math.max(Math.ceil((Date.now() - startMs) / 3_600_000), 1),
+      24,
+    );
+    const controller = new AbortController();
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/tracking/locations?driver_id=${encodeURIComponent(driverId)}&hours=${hours}&limit=1000`,
+          { credentials: 'include', signal: controller.signal },
+        );
+        if (!res.ok) return; // best-effort: live accumulation still works
+        const data = await res.json();
+        const history: [number, number][] = (data?.data ?? [])
+          .filter((l: any) => new Date(l.recorded_at).getTime() >= startMs)
+          .reverse() // API returns DESC; the trail wants oldest -> newest
+          .map((l: any) => l?.location?.coordinates)
+          .filter(
+            (c: unknown): c is [number, number] =>
+              Array.isArray(c) && c.length === 2,
+          );
+        if (history.length === 0) return;
+        // History first, then whatever live points arrived while fetching.
+        trailRef.current = capTrail([...history, ...trailRef.current]);
+        const source = mapRef.current?.getSource('driver-trail') as
+          | mapboxgl.GeoJSONSource
+          | undefined;
+        source?.setData({
+          type: 'Feature',
+          properties: {},
+          geometry: { type: 'LineString', coordinates: trailRef.current },
+        });
+      } catch (error) {
+        if ((error as Error)?.name !== 'AbortError') {
+          captureException(error, {
+            action: 'trail-seed',
+            feature: 'driver-live-map',
+            component: 'DriverLiveMap',
+          });
+        }
+      }
+    })();
+    return () => controller.abort();
+  }, [mapLoaded, driverId, shiftStartedAt]);
 
   // Initialize the map
   useEffect(() => {
@@ -170,11 +251,9 @@ export default function DriverLiveMap({
           .addTo(mapRef.current);
       }
 
-      // Update the in-memory trail (cap length for performance)
+      // Update the in-memory trail (thinned, never truncated from the head)
       trailRef.current.push([lng, lat]);
-      if (trailRef.current.length > 200) {
-        trailRef.current.shift();
-      }
+      trailRef.current = capTrail(trailRef.current);
 
       const source = mapRef.current.getSource('driver-trail') as mapboxgl.GeoJSONSource | undefined;
       if (source) {

--- a/src/components/Driver/DriverTrackingPortal.tsx
+++ b/src/components/Driver/DriverTrackingPortal.tsx
@@ -45,6 +45,10 @@ export default function DriverTrackingPortal() {
   const [elapsed, setElapsed] = useState(0);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
   const [podTarget, setPodTarget] = useState<PodTarget | null>(null);
+  // Jul-3 walk feedback: multiple staged/real orders made "Active deliveries"
+  // confusing — filter by scheduled pickup date. `null` = no explicit choice,
+  // in which case we default to Today whenever today has at least one.
+  const [dayFilter, setDayFilter] = useState<"today" | "all" | null>(null);
 
   const {
     currentLocation,
@@ -190,6 +194,29 @@ export default function DriverTrackingPortal() {
     if (ok) setPodTarget(null);
   };
 
+  const isPickupToday = (d?: Date) =>
+    !!d && new Date(d).toDateString() === new Date().toDateString();
+  const todayCount = activeDeliveries.filter((d) =>
+    isPickupToday(d.scheduledPickupAt),
+  ).length;
+  const effectiveDayFilter =
+    dayFilter ?? (todayCount > 0 ? "today" : "all");
+  const visibleDeliveries =
+    effectiveDayFilter === "all"
+      ? activeDeliveries
+      : activeDeliveries.filter((d) => isPickupToday(d.scheduledPickupAt));
+
+  const formatPickup = (d: Date) =>
+    isPickupToday(d)
+      ? `today ${d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}`
+      : d.toLocaleDateString([], {
+          weekday: "short",
+          month: "short",
+          day: "numeric",
+        }) +
+        " " +
+        d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+
   const headerRight = useMemo(() => {
     if (!isShiftActive || !currentShift?.startTime) return null;
     return (
@@ -259,6 +286,8 @@ export default function DriverTrackingPortal() {
                   <DriverLiveMap
                     currentLocation={currentLocation}
                     activeDeliveries={activeDeliveries}
+                    driverId={currentShift?.driverId}
+                    shiftStartedAt={currentShift?.startTime}
                   />
                 </div>
               ) : (
@@ -317,14 +346,46 @@ export default function DriverTrackingPortal() {
                 {activeDeliveries.length > 0 ? ` — ${activeDeliveries.length} in progress` : ""}
               </h2>
 
+              {activeDeliveries.length > 0 ? (
+                <div className="flex gap-2" role="group" aria-label="Filter deliveries by date">
+                  {(
+                    [
+                      { key: "today", label: `Today (${todayCount})` },
+                      { key: "all", label: `All (${activeDeliveries.length})` },
+                    ] as const
+                  ).map((chip) => (
+                    <button
+                      key={chip.key}
+                      type="button"
+                      onClick={() => setDayFilter(chip.key)}
+                      aria-pressed={effectiveDayFilter === chip.key}
+                      className={cn(
+                        "rounded-full border px-4 py-1.5 text-[12.5px] font-semibold transition-colors",
+                        effectiveDayFilter === chip.key
+                          ? "border-transparent bg-driver-brand/15 text-driver-on-brand"
+                          : "border-driver-border bg-transparent text-driver-subtle",
+                      )}
+                    >
+                      {chip.label}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+
               {activeDeliveries.length === 0 ? (
                 <StateBlock
                   icon={CheckCircle2}
                   title="No active deliveries"
                   body="New assignments will appear here while you're on shift."
                 />
+              ) : visibleDeliveries.length === 0 ? (
+                <StateBlock
+                  icon={CheckCircle2}
+                  title="Nothing scheduled for today"
+                  body='Switch to "All" to see your other assignments.'
+                />
               ) : (
-                activeDeliveries.map((delivery, idx) => {
+                visibleDeliveries.map((delivery, idx) => {
                   const orderNumber =
                     delivery.cateringRequestId ||
                     delivery.onDemandId ||
@@ -358,6 +419,12 @@ export default function DriverTrackingPortal() {
                           <StatusPill status={delivery.status} size="sm" />
                         </div>
                       </div>
+
+                      {delivery.scheduledPickupAt ? (
+                        <div className="text-[12px] font-semibold text-driver-muted">
+                          Pickup {formatPickup(delivery.scheduledPickupAt)}
+                        </div>
+                      ) : null}
 
                       {delivery.estimatedArrival ? (
                         <div className="text-[12px] font-semibold text-driver-muted">

--- a/src/components/Driver/ProofOfDeliveryCapture.tsx
+++ b/src/components/Driver/ProofOfDeliveryCapture.tsx
@@ -58,6 +58,7 @@ export function ProofOfDeliveryCapture({
   onError,
   className,
   uploadEndpoint,
+  hideTitle = false,
 }: ProofOfDeliveryCaptureProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { permission, requestPermission, error: permissionError, isCameraSupported } = useCameraPermission();
@@ -510,7 +511,7 @@ export function ProofOfDeliveryCapture({
     <Card className={cn('w-full max-w-md', className)}>
       <CardHeader className="flex flex-row items-center justify-between pb-2">
         <div className="flex items-center gap-2">
-          <CardTitle className="text-lg">Proof of Delivery</CardTitle>
+          {!hideTitle && <CardTitle className="text-lg">Proof of Delivery</CardTitle>}
           {!offlineStatus.isOnline && (
             <Badge variant="secondary" className="gap-1 bg-amber-100 text-amber-700">
               <WifiOff className="h-3 w-3" />

--- a/src/components/Driver/__tests__/DriverTrackingPortal.test.tsx
+++ b/src/components/Driver/__tests__/DriverTrackingPortal.test.tsx
@@ -283,6 +283,46 @@ describe("DriverTrackingPortal (redesigned)", () => {
     expect(screen.getByTestId("pod-capture")).toBeInTheDocument();
   });
 
+  it("filters Active deliveries by scheduled pickup date via the Today/All chips", () => {
+    const today = new Date();
+    const nextWeek = new Date(Date.now() + 7 * 24 * 3600_000);
+    mockUseDriverTracking.mockReturnValue(
+      baseCtx({
+        isShiftActive: true,
+        currentShift: { id: "s1", driverId: "driver-1", startTime: new Date() },
+        currentLocation: sampleLocation,
+        activeDeliveries: [
+          {
+            id: "del-today",
+            cateringRequestId: "CR-TODAY",
+            driverId: "driver-1",
+            status: DriverStatus.ASSIGNED,
+            scheduledPickupAt: today,
+            deliveryLocation: { coordinates: [-122.41, 37.77] },
+          },
+          {
+            id: "del-later",
+            cateringRequestId: "CR-LATER",
+            driverId: "driver-1",
+            status: DriverStatus.ASSIGNED,
+            scheduledPickupAt: nextWeek,
+            deliveryLocation: { coordinates: [-122.41, 37.77] },
+          },
+        ],
+      }),
+    );
+    renderPortal();
+
+    // Today has an entry, so the filter defaults to Today: only CR-TODAY shows.
+    expect(screen.getByText(/#CR-TODAY/)).toBeInTheDocument();
+    expect(screen.queryByText(/#CR-LATER/)).not.toBeInTheDocument();
+
+    // Switching to All reveals both.
+    fireEvent.click(screen.getByRole("button", { name: /all \(2\)/i }));
+    expect(screen.getByText(/#CR-TODAY/)).toBeInTheDocument();
+    expect(screen.getByText(/#CR-LATER/)).toBeInTheDocument();
+  });
+
   it("shows an offline banner when offline", () => {
     mockUseDriverTracking.mockReturnValue(
       baseCtx({ isOnline: false, queuedItems: 3 }),

--- a/src/components/Driver/ui/BottomNav.tsx
+++ b/src/components/Driver/ui/BottomNav.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
 import { GraduationCap, History, Home, Navigation, type LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -39,6 +40,15 @@ const ITEMS: NavItem[] = [
  *  Detail view (which has its own back button). */
 export function BottomNav() {
   const pathname = usePathname() ?? "/driver";
+  // Route transitions can take seconds on a phone, and the active highlight
+  // only moves once the new route commits — so give the tapped tab immediate
+  // pending feedback (Jul-3 walk feedback: "bottom buttons take long to
+  // respond"). Cleared as soon as the pathname changes.
+  const [pendingHref, setPendingHref] = useState<string | null>(null);
+  useEffect(() => {
+    setPendingHref(null);
+  }, [pathname]);
+
   // Detail is a pushed view — no bottom nav there.
   if (pathname.startsWith("/driver/deliveries/")) return null;
 
@@ -51,26 +61,32 @@ export function BottomNav() {
       <div className="mx-auto flex max-w-2xl items-stretch justify-around px-2 py-1.5">
         {ITEMS.map((item) => {
           const active = item.match(pathname);
+          const pending = !active && pendingHref === item.href;
           const Icon = item.icon;
           return (
             <Link
               key={item.href}
               href={item.href}
               aria-current={active ? "page" : undefined}
+              onClick={() => {
+                if (!active) setPendingHref(item.href);
+              }}
               className="flex min-h-driver-control flex-1 flex-col items-center justify-center gap-1 rounded-xl"
             >
               <span
                 className={cn(
                   "flex h-8 w-12 items-center justify-center rounded-full transition-colors",
                   active ? "bg-driver-brand/15" : "bg-transparent",
+                  pending && "animate-driver-pulse bg-driver-brand/10",
                 )}
               >
                 <Icon
                   className={cn(
                     "h-driver-node w-driver-node",
                     active ? "text-driver-on-brand" : "text-driver-subtle",
+                    pending && "text-driver-on-brand",
                   )}
-                  strokeWidth={active ? 2.4 : 2}
+                  strokeWidth={active || pending ? 2.4 : 2}
                 />
               </span>
               <span

--- a/src/components/Driver/ui/DriverPodSheet.tsx
+++ b/src/components/Driver/ui/DriverPodSheet.tsx
@@ -53,6 +53,7 @@ export function DriverPodSheet({
               deliveryId={deliveryId}
               orderNumber={orderNumber}
               isRequired
+              hideTitle
               uploadEndpoint={uploadEndpoint}
               onUploadComplete={(url) => onComplete(url)}
               onCancel={() => onOpenChange(false)}

--- a/src/hooks/tracking/useDriverDeliveries.ts
+++ b/src/hooks/tracking/useDriverDeliveries.ts
@@ -99,6 +99,7 @@ export function useDriverDeliveries(): UseDriverDeliveriesReturn {
             pickupLocation: { coordinates: toCoords(pickup) },
             deliveryLocation: { coordinates: toCoords(dropoff) },
             estimatedArrival: o.arrivalDateTime ? new Date(o.arrivalDateTime) : undefined,
+            scheduledPickupAt: o.pickupDateTime ? new Date(o.pickupDateTime) : undefined,
             route: [],
             proofOfDelivery: pod,
             metadata: {},
@@ -106,7 +107,13 @@ export function useDriverDeliveries(): UseDriverDeliveriesReturn {
             createdAt: o.createdAt ? new Date(o.createdAt) : new Date(0),
             updatedAt: o.updatedAt ? new Date(o.updatedAt) : new Date(0),
           } as DeliveryTracking;
-        });
+        })
+        // Soonest scheduled pickup first so tonight's delivery leads the list.
+        .sort(
+          (a, b) =>
+            (a.scheduledPickupAt ?? a.estimatedArrival ?? a.createdAt).getTime() -
+            (b.scheduledPickupAt ?? b.estimatedArrival ?? b.createdAt).getTime(),
+        );
 
       setActiveDeliveries(mapped);
     } catch (err) {

--- a/src/types/proof-of-delivery.ts
+++ b/src/types/proof-of-delivery.ts
@@ -89,6 +89,9 @@ export interface ProofOfDeliveryCaptureProps {
   className?: string;
   /** Custom upload endpoint - defaults to tracking API if not provided */
   uploadEndpoint?: string;
+  /** Hide the card's own "Proof of Delivery" title — for hosts (sheets/dialogs)
+   *  that already render a title above this component. */
+  hideTitle?: boolean;
 }
 
 /**

--- a/src/types/tracking.ts
+++ b/src/types/tracking.ts
@@ -65,6 +65,8 @@ export interface DeliveryTracking {
   };
   estimatedArrival?: Date;
   actualArrival?: Date;
+  /** Scheduled pickup time from the order (drives the Today/All filter + card label). */
+  scheduledPickupAt?: Date;
   route: LocationUpdate[];
   proofOfDelivery?: string;
   actualDistanceMiles?: number;


### PR DESCRIPTION
Four of the six Jul-3 night-walk feedback items (tasks `driver-map-trail-straight-line`, `pod-sheet-duplicate-title`, `driver-action-buttons-loading-state`, `driver-active-deliveries-date-filter`). The critical signature bypass is separate in #475.

## 1. Map trail — straight lines + route disappearing (`DriverLiveMap`)

DB forensics showed the walk's data was nearly complete (285 pts / 28 min, two ~90 s lock gaps) — the bad rendering was client-side: the trail lived only in browser memory, and a 200-point cap `shift()`ed the route start away ~20 min in.

- Trail now **seeds from the server once per shift** (`GET /api/tracking/locations?driver_id=…&limit=1000`, cookie auth, filtered to the shift window) — locked-phone stretches and reloads no longer erase the route
- Cap raised to 1000 with **older-half thinning** instead of head truncation — the start of the route never disappears
- New optional `driverId`/`shiftStartedAt` props, wired from the tracking portal

## 2. POD sheet duplicate title

`DriverPodSheet` renders a SheetTitle and the inner `ProofOfDeliveryCapture` rendered its own CardTitle. New `hideTitle` prop, set by the sheet. Standalone usages unchanged.

## 3. Bottom-nav pending feedback

Tabs are plain `Link`s whose highlight only moves after the route commits — on a slow transition the tap felt dead. The tapped tab now pulses/highlights immediately; cleared when the pathname changes.

## 4. Active-deliveries date filter

- `useDriverDeliveries` now maps `scheduledPickupAt` (the API already returned `pickupDateTime`) and sorts soonest-first
- Each card shows its pickup time ("Pickup today 4:30 PM" / "Pickup Sat, Jul 5 …")
- **Today / All** chips (with counts) filter the list; defaults to Today when today has ≥1 delivery, with a dedicated empty state pointing at "All"

## Tests

- New: Today/All chip filtering (default-to-Today + switch to All)
- 100 tests across the touched suites green; typecheck/lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)