### PR TITLE
feat(admin): staff can correct driver status (undo an accidental start)

### DIFF
--- a/src/app/api/orders/[order_number]/__tests__/route.test.ts
+++ b/src/app/api/orders/[order_number]/__tests__/route.test.ts
@@ -469,6 +469,64 @@ describe('Orders API Route - Delivery Status Broadcast', () => {
     });
   });
 
+  describe('Privileged driver-status repair (undo accidental start)', () => {
+    const mockCaller = (userId: string, type: string) => {
+      mockedCreateClient.mockResolvedValue({
+        auth: {
+          getUser: jest.fn().mockResolvedValue({
+            data: { user: { id: userId } },
+            error: null,
+          }),
+        },
+        from: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({
+            data: { type },
+            error: null,
+          }),
+        }),
+      } as any);
+    };
+
+    it('lets HELPDESK move driverStatus backwards (PICKED_UP -> ASSIGNED) with the order status', async () => {
+      // The Jul-3 walk: a driver accidentally started a delivery and nothing
+      // could undo it — the forward-only graph 422'd even privileged callers.
+      setupMocks({ status: 'IN_PROGRESS', driverStatus: 'PICKED_UP' });
+      mockCaller('helpdesk-user', 'HELPDESK');
+
+      const { PATCH } = await importRoute();
+      const response = await PATCH(
+        createPatchRequest({ driverStatus: 'ASSIGNED', status: 'ASSIGNED' }),
+        { params: Promise.resolve({ order_number: 'CAT-001' }) },
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockedPrisma.cateringRequest.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            driverStatus: 'ASSIGNED',
+            status: 'ASSIGNED',
+          }),
+        }),
+      );
+    });
+
+    it('still rejects a backward driverStatus move from the assigned driver (graph binds drivers)', async () => {
+      setupMocks({ status: 'IN_PROGRESS', driverStatus: 'PICKED_UP' });
+      mockCaller('driver-456', 'DRIVER');
+
+      const { PATCH } = await importRoute();
+      const response = await PATCH(
+        createPatchRequest({ driverStatus: 'ASSIGNED' }),
+        { params: Promise.resolve({ order_number: 'CAT-001' }) },
+      );
+
+      expect(response.status).toBe(422);
+      expect(mockedPrisma.cateringRequest.update).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Pickup-signature enforcement on PICKED_UP', () => {
     // Same caller-mock shape as the IDOR block above: `userId` is the
     // authenticated user, `type` drives the privileged check.

--- a/src/app/api/orders/[order_number]/__tests__/route.test.ts
+++ b/src/app/api/orders/[order_number]/__tests__/route.test.ts
@@ -468,4 +468,82 @@ describe('Orders API Route - Delivery Status Broadcast', () => {
       expect(response.status).toBe(400);
     });
   });
+
+  describe('Pickup-signature enforcement on PICKED_UP', () => {
+    // Same caller-mock shape as the IDOR block above: `userId` is the
+    // authenticated user, `type` drives the privileged check.
+    const mockCaller = (userId: string, type: string) => {
+      mockedCreateClient.mockResolvedValue({
+        auth: {
+          getUser: jest.fn().mockResolvedValue({
+            data: { user: { id: userId } },
+            error: null,
+          }),
+        },
+        from: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          single: jest.fn().mockResolvedValue({
+            data: { type },
+            error: null,
+          }),
+        }),
+      } as any);
+    };
+
+    it('rejects a driver PICKED_UP with 422 when no pickup_signature upload exists', async () => {
+      // The Jul-3 walk-test bug: the Live-Tracking tab advanced
+      // ARRIVED_AT_VENDOR -> PICKED_UP without the signature sheet. The server
+      // must be the backstop regardless of which client surface forgot the gate.
+      setupMocks({ status: 'IN_PROGRESS', driverStatus: 'ARRIVED_AT_VENDOR' });
+      mockCaller('driver-456', 'DRIVER');
+      (mockedPrisma.fileUpload.findFirst as jest.Mock).mockResolvedValue(null);
+
+      const { PATCH } = await importRoute();
+      const response = await PATCH(createPatchRequest({ driverStatus: 'PICKED_UP' }), {
+        params: Promise.resolve({ order_number: 'CAT-001' }),
+      });
+
+      expect(response.status).toBe(422);
+      const data = await response.json();
+      expect(data.code).toBe('PICKUP_SIGNATURE_REQUIRED');
+      expect(mockedPrisma.cateringRequest.update).not.toHaveBeenCalled();
+    });
+
+    it('allows a driver PICKED_UP once the pickup_signature upload exists', async () => {
+      setupMocks({ status: 'IN_PROGRESS', driverStatus: 'ARRIVED_AT_VENDOR' });
+      mockCaller('driver-456', 'DRIVER');
+      (mockedPrisma.fileUpload.findFirst as jest.Mock).mockResolvedValue({ id: 'sig-1' });
+
+      const { PATCH } = await importRoute();
+      const response = await PATCH(createPatchRequest({ driverStatus: 'PICKED_UP' }), {
+        params: Promise.resolve({ order_number: 'CAT-001' }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(mockedPrisma.fileUpload.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            category: 'pickup_signature',
+            cateringRequestId: 'order-123',
+          }),
+        }),
+      );
+      expect(mockedPrisma.cateringRequest.update).toHaveBeenCalled();
+    });
+
+    it('lets a privileged (HELPDESK) caller set PICKED_UP without a signature (data repair)', async () => {
+      setupMocks({ status: 'IN_PROGRESS', driverStatus: 'ARRIVED_AT_VENDOR' });
+      mockCaller('helpdesk-user', 'HELPDESK');
+      (mockedPrisma.fileUpload.findFirst as jest.Mock).mockResolvedValue(null);
+
+      const { PATCH } = await importRoute();
+      const response = await PATCH(createPatchRequest({ driverStatus: 'PICKED_UP' }), {
+        params: Promise.resolve({ order_number: 'CAT-001' }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(mockedPrisma.cateringRequest.update).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/app/api/orders/[order_number]/route.ts
+++ b/src/app/api/orders/[order_number]/route.ts
@@ -423,6 +423,7 @@ export async function PATCH(
     // status-only PATCH (`{ status }`) — the driver client sends the latter on
     // completion, and without this any authenticated user could drive any order's
     // status by order number (the role check below only runs for field updates).
+    let callerIsPrivileged = false;
     if (driverStatus || status) {
       const { data: callerProfile } = await supabase
         .from('profiles')
@@ -434,6 +435,7 @@ export async function PATCH(
         callerType === 'ADMIN' ||
         callerType === 'SUPER_ADMIN' ||
         callerType === 'HELPDESK';
+      callerIsPrivileged = privileged;
 
       if (!privileged) {
         const dispatches = (existingOrder as any).dispatches;
@@ -524,6 +526,36 @@ export async function PATCH(
         { status: 422 },
       );
     }
+    // The vendor-pickup signature is mandatory (2026-06-22 decision), and the
+    // sheet is client-side — so back it up here: a driver cannot mark PICKED_UP
+    // until a pickup_signature upload exists for the order. Admin/helpdesk are
+    // exempt so they can repair stuck orders.
+    if (
+      driverStatus === DriverStatus.PICKED_UP &&
+      currentDriverStatus !== DriverStatus.PICKED_UP &&
+      !callerIsPrivileged
+    ) {
+      const pickupSignature = await prisma.fileUpload.findFirst({
+        where: {
+          category: 'pickup_signature',
+          ...(orderType === 'catering'
+            ? { cateringRequestId: (existingOrder as any).id }
+            : { onDemandId: (existingOrder as any).id }),
+        },
+        select: { id: true },
+      });
+      if (!pickupSignature) {
+        return NextResponse.json(
+          {
+            message:
+              'A vendor pickup signature is required before marking this order as picked up',
+            code: 'PICKUP_SIGNATURE_REQUIRED',
+          },
+          { status: 422 },
+        );
+      }
+    }
+
     if (
       status &&
       status !== currentStatus &&

--- a/src/app/api/orders/[order_number]/route.ts
+++ b/src/app/api/orders/[order_number]/route.ts
@@ -514,9 +514,13 @@ export async function PATCH(
       }
     }
 
+    // The forward-only driver graph binds DRIVERS; admin/helpdesk may move
+    // driverStatus freely — the repair path for an accidentally-started
+    // delivery (Jul-3 walk) is resetting it back to ASSIGNED.
     if (
       driverStatus &&
       driverStatus !== currentDriverStatus &&
+      !callerIsPrivileged &&
       !canTransitionDriver(currentDriverStatus, driverStatus as DriverStatus)
     ) {
       return NextResponse.json(
@@ -559,6 +563,7 @@ export async function PATCH(
     if (
       status &&
       status !== currentStatus &&
+      !callerIsPrivileged &&
       !canTransitionOrder(currentStatus, status as OrderStatus)
     ) {
       return NextResponse.json(

--- a/src/components/Driver/DriverTrackingPortal.tsx
+++ b/src/components/Driver/DriverTrackingPortal.tsx
@@ -32,6 +32,7 @@ import {
   getStatusProgress,
 } from "@/components/Driver/ui";
 import { DriverPodSheet } from "@/components/Driver/ui/DriverPodSheet";
+import { DriverSignatureSheet } from "@/components/Driver/ui/DriverSignatureSheet";
 import { NavigateButton } from "@/components/Driver/ui/NavigateButton";
 
 interface PodTarget {
@@ -45,6 +46,7 @@ export default function DriverTrackingPortal() {
   const [elapsed, setElapsed] = useState(0);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
   const [podTarget, setPodTarget] = useState<PodTarget | null>(null);
+  const [sigTarget, setSigTarget] = useState<PodTarget | null>(null);
 
   const {
     currentLocation,
@@ -174,6 +176,13 @@ export default function DriverTrackingPortal() {
     if (!next) return;
     const orderNumber =
       delivery.cateringRequestId || delivery.onDemandId || delivery.id;
+    // The pickup step routes through vendor-signature capture (mandatory per
+    // the 2026-06-22 decision — mirrors the gate in DriverDeliveryDetail; the
+    // server also rejects an unsigned PICKED_UP).
+    if (next === DriverStatus.PICKED_UP) {
+      setSigTarget({ deliveryId: delivery.id, orderNumber });
+      return;
+    }
     // The final step routes through proof-of-delivery capture.
     if (next === DriverStatus.COMPLETED) {
       setPodTarget({ deliveryId: delivery.id, orderNumber });
@@ -188,6 +197,13 @@ export default function DriverTrackingPortal() {
     // having to re-capture the proof after only seeing the error toast.
     const ok = await advanceStatus(podTarget.deliveryId, DriverStatus.COMPLETED);
     if (ok) setPodTarget(null);
+  };
+
+  const onSignatureComplete = async () => {
+    if (!sigTarget) return;
+    // Same retry semantics as POD: keep the sheet open if the advance fails.
+    const ok = await advanceStatus(sigTarget.deliveryId, DriverStatus.PICKED_UP);
+    if (ok) setSigTarget(null);
   };
 
   const headerRight = useMemo(() => {
@@ -462,6 +478,15 @@ export default function DriverTrackingPortal() {
           </DriverCard>
         )}
       </div>
+
+      {sigTarget ? (
+        <DriverSignatureSheet
+          open={!!sigTarget}
+          onOpenChange={(o) => !o && setSigTarget(null)}
+          orderNumber={sigTarget.orderNumber}
+          onComplete={() => void onSignatureComplete()}
+        />
+      ) : null}
 
       {podTarget ? (
         <DriverPodSheet

--- a/src/components/Driver/__tests__/DriverTrackingPortal.test.tsx
+++ b/src/components/Driver/__tests__/DriverTrackingPortal.test.tsx
@@ -39,6 +39,16 @@ jest.mock("@/components/Driver/ProofOfDeliveryCapture", () => ({
   ),
 }));
 
+jest.mock("@/components/Driver/SignatureCapture", () => ({
+  SignatureCapture: ({ onUploadComplete }: any) => (
+    <div data-testid="signature-capture">
+      <button onClick={() => onUploadComplete("https://pod.example/signature.png")}>
+        finish signature upload
+      </button>
+    </div>
+  ),
+}));
+
 const mockUseDriverTracking = useDriverTracking as jest.MockedFunction<
   typeof useDriverTracking
 >;
@@ -281,6 +291,47 @@ describe("DriverTrackingPortal (redesigned)", () => {
     // podTarget is only cleared on success — the sheet must stay open so the
     // driver can retry without re-capturing the proof.
     expect(screen.getByTestId("pod-capture")).toBeInTheDocument();
+  });
+
+  it("routes the pickup step through the signature sheet instead of advancing directly", async () => {
+    // Jul-3 walk-test regression: this surface advanced ARRIVED_AT_VENDOR ->
+    // PICKED_UP with no vendor signature (the gate only existed in
+    // DriverDeliveryDetail). The pickup mandate applies on every surface.
+    mockUseDriverTracking.mockReturnValue(
+      baseCtx({
+        isShiftActive: true,
+        currentShift: { id: "s1", driverId: "driver-1", startTime: new Date() },
+        currentLocation: sampleLocation,
+        activeDeliveries: [
+          {
+            id: "del-1",
+            cateringRequestId: "cr-1",
+            driverId: "driver-1",
+            status: DriverStatus.ARRIVED_AT_VENDOR,
+            deliveryLocation: { coordinates: [-122.41, 37.77] },
+          },
+        ],
+      }),
+    );
+    renderPortal();
+
+    fireEvent.click(screen.getByText(/picked up the order/i));
+
+    // The signature sheet opens and NO status update happens yet.
+    expect(await screen.findByTestId("signature-capture")).toBeInTheDocument();
+    expect(updateDeliveryStatus).not.toHaveBeenCalled();
+
+    // Completing the signature advances to PICKED_UP.
+    fireEvent.click(
+      screen.getByRole("button", { name: /finish signature upload/i }),
+    );
+    await waitFor(() =>
+      expect(updateDeliveryStatus).toHaveBeenCalledWith(
+        "del-1",
+        DriverStatus.PICKED_UP,
+        sampleLocation,
+      ),
+    );
   });
 
   it("shows an offline banner when offline", () => {

--- a/src/components/Orders/DriverStatus.tsx
+++ b/src/components/Orders/DriverStatus.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 // src/components/Orders/DriverStatus.tsx
 
+import React from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
@@ -89,6 +92,17 @@ export const DriverStatusCard: React.FC<DriverStatusCardProps> = ({
   onAssignDriver,
   showAssignDriverButton = true,
 }) => {
+  const [isUpdatingStatus, setIsUpdatingStatus] = React.useState(false);
+
+  const handleStatusSelect = async (statusOption: DriverStatus) => {
+    setIsUpdatingStatus(true);
+    try {
+      await updateDriverStatus(statusOption);
+    } finally {
+      setIsUpdatingStatus(false);
+    }
+  };
+
   const getProgressValue = (status: DriverStatus | null | undefined) => {
     return status ? driverStatusProgress[status] : 0;
   };
@@ -229,6 +243,40 @@ export const DriverStatusCard: React.FC<DriverStatusCardProps> = ({
                       <Clock className="h-3.5 w-3.5" />
                       {getEstimatedTimeRemaining(order.driver_status)}
                     </span>
+                  )}
+
+                  {/* Staff correction: set any driver status (incl. backwards —
+                      "Assigned" undoes an accidentally started delivery). */}
+                  {canUpdateDriverStatus && (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          disabled={isUpdatingStatus}
+                        >
+                          {isUpdatingStatus ? "Updating…" : "Change status"}
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        {(Object.keys(driverStatusMap) as DriverStatus[]).map(
+                          (statusOption) => (
+                            <DropdownMenuItem
+                              key={statusOption}
+                              disabled={statusOption === order.driver_status}
+                              onClick={() => handleStatusSelect(statusOption)}
+                            >
+                              {driverStatusMap[statusOption]}
+                              {statusOption === DriverStatus.ASSIGNED &&
+                              order.driver_status &&
+                              order.driver_status !== DriverStatus.ASSIGNED
+                                ? " (reset progress)"
+                                : ""}
+                            </DropdownMenuItem>
+                          ),
+                        )}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
                   )}
                 </div>
               </div>

--- a/src/components/Orders/SingleOrder.tsx
+++ b/src/components/Orders/SingleOrder.tsx
@@ -674,7 +674,14 @@ const SingleOrder: React.FC<SingleOrderProps> = ({
             "Content-Type": "application/json",
           },
           credentials: "include",
-          body: JSON.stringify({ driverStatus: newStatus }),
+          // Resetting to ASSIGNED is the staff "undo an accidental start"
+          // path — roll the order status back with it so the whole order
+          // returns to its pre-start state.
+          body: JSON.stringify(
+            newStatus === DriverStatus.ASSIGNED
+              ? { driverStatus: newStatus, status: "ASSIGNED" }
+              : { driverStatus: newStatus },
+          ),
         },
       );
 


### PR DESCRIPTION
**Stacked on #475** — merge that first (this branch includes its commit; the diff shown here will shrink to just this change once #475 lands).

## Problem (Jul-3 walk, task `helpdesk-undo-accidental-drive-start`)

A driver accidentally started a delivery and had no way back:
- The forward-only driver graph returned 422 on any backward move **for every caller**, privileged or not
- The admin `DriverStatusCard` never rendered a status-change control at all (`updateDriverStatus` was a dead prop), so even legal changes had no UI
- Only escape hatch was cancelling the whole order

## Change

**Policy:** state-machine guards bind non-privileged callers. ADMIN/SUPER_ADMIN/HELPDESK may set any `driverStatus`/`status` on the orders PATCH (the repair path); drivers remain on the forward-only rails.

**UI:** `DriverStatusCard` gains a **Change status** dropdown (visible only with `canUpdateDriverStatus`, i.e. the admin order pages). Selecting **Assigned** is labeled "(reset progress)" and also rolls the order `status` back to `ASSIGNED`, returning the order to its pre-start state so the driver can redo the flow properly.

## Tests

- HELPDESK moves `PICKED_UP → ASSIGNED` (with order status) → 200, exact update payload asserted
- The assigned driver attempting the same backward move → still 422
- 119 tests across touched suites green; typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)