### PR TITLE
fix(driver): unblock pickup confirmation — storage path + optional signature with received-by name

### DIFF
--- a/prisma/migrations/20260709000000_add_pickup_received_by/migration.sql
+++ b/prisma/migrations/20260709000000_add_pickup_received_by/migration.sql
@@ -1,0 +1,5 @@
+-- Name of the vendor-side person who handed over / confirmed the pickup.
+-- Replaces the mandatory-signature policy (2026-07-09 live-drive decision):
+-- PICKED_UP now requires this name OR a pickup_signature upload.
+-- Additive + nullable -> safe no-op backfill.
+ALTER TABLE "public"."deliveries" ADD COLUMN IF NOT EXISTS "pickup_received_by" VARCHAR(255);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -931,6 +931,7 @@ model Delivery {
   photoRequired          Boolean?  @default(false) @map("photo_required")
   deliverySignatureUrl   String?   @map("delivery_signature_url")
   pickupSignatureUrl     String?   @map("pickup_signature_url")
+  pickupReceivedBy       String?   @map("pickup_received_by") @db.VarChar(255)
   deliveryPhotoUrl       String?   @map("delivery_photo_url")
   deliveryNotes          String?   @map("delivery_notes")
   createdAt              DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)

--- a/src/app/api/orders/[order_number]/__tests__/route.test.ts
+++ b/src/app/api/orders/[order_number]/__tests__/route.test.ts
@@ -549,13 +549,15 @@ describe('Orders API Route - Delivery Status Broadcast', () => {
       } as any);
     };
 
-    it('rejects a driver PICKED_UP with 422 when no pickup_signature upload exists', async () => {
+    it('rejects a driver PICKED_UP with 422 when neither a signature nor a receiver name exists', async () => {
       // The Jul-3 walk-test bug: the Live-Tracking tab advanced
       // ARRIVED_AT_VENDOR -> PICKED_UP without the signature sheet. The server
       // must be the backstop regardless of which client surface forgot the gate.
+      // Since 2026-07-09 the gate accepts a receiver NAME or a signature.
       setupMocks({ status: 'IN_PROGRESS', driverStatus: 'ARRIVED_AT_VENDOR' });
       mockCaller('driver-456', 'DRIVER');
       (mockedPrisma.fileUpload.findFirst as jest.Mock).mockResolvedValue(null);
+      (mockedPrisma.delivery.findUnique as jest.Mock).mockResolvedValue(null);
 
       const { PATCH } = await importRoute();
       const response = await PATCH(createPatchRequest({ driverStatus: 'PICKED_UP' }), {
@@ -564,14 +566,55 @@ describe('Orders API Route - Delivery Status Broadcast', () => {
 
       expect(response.status).toBe(422);
       const data = await response.json();
-      expect(data.code).toBe('PICKUP_SIGNATURE_REQUIRED');
+      expect(data.code).toBe('PICKUP_CONFIRMATION_REQUIRED');
       expect(mockedPrisma.cateringRequest.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects a driver PICKED_UP when the recorded receiver name is whitespace-only', async () => {
+      setupMocks({ status: 'IN_PROGRESS', driverStatus: 'ARRIVED_AT_VENDOR' });
+      mockCaller('driver-456', 'DRIVER');
+      (mockedPrisma.fileUpload.findFirst as jest.Mock).mockResolvedValue(null);
+      (mockedPrisma.delivery.findUnique as jest.Mock).mockResolvedValue({
+        pickupReceivedBy: '   ',
+      });
+
+      const { PATCH } = await importRoute();
+      const response = await PATCH(createPatchRequest({ driverStatus: 'PICKED_UP' }), {
+        params: Promise.resolve({ order_number: 'CAT-001' }),
+      });
+
+      expect(response.status).toBe(422);
+      expect((await response.json()).code).toBe('PICKUP_CONFIRMATION_REQUIRED');
+    });
+
+    it('allows a driver PICKED_UP with a receiver name only (no signature upload)', async () => {
+      setupMocks({ status: 'IN_PROGRESS', driverStatus: 'ARRIVED_AT_VENDOR' });
+      mockCaller('driver-456', 'DRIVER');
+      (mockedPrisma.fileUpload.findFirst as jest.Mock).mockResolvedValue(null);
+      (mockedPrisma.delivery.findUnique as jest.Mock).mockResolvedValue({
+        pickupReceivedBy: 'Maria Lopez',
+      });
+
+      const { PATCH } = await importRoute();
+      const response = await PATCH(createPatchRequest({ driverStatus: 'PICKED_UP' }), {
+        params: Promise.resolve({ order_number: 'CAT-001' }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(mockedPrisma.delivery.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { orderNumber: 'CAT-001' },
+          select: { pickupReceivedBy: true },
+        }),
+      );
+      expect(mockedPrisma.cateringRequest.update).toHaveBeenCalled();
     });
 
     it('allows a driver PICKED_UP once the pickup_signature upload exists', async () => {
       setupMocks({ status: 'IN_PROGRESS', driverStatus: 'ARRIVED_AT_VENDOR' });
       mockCaller('driver-456', 'DRIVER');
       (mockedPrisma.fileUpload.findFirst as jest.Mock).mockResolvedValue({ id: 'sig-1' });
+      (mockedPrisma.delivery.findUnique as jest.Mock).mockResolvedValue(null);
 
       const { PATCH } = await importRoute();
       const response = await PATCH(createPatchRequest({ driverStatus: 'PICKED_UP' }), {

--- a/src/app/api/orders/[order_number]/route.ts
+++ b/src/app/api/orders/[order_number]/route.ts
@@ -530,30 +530,39 @@ export async function PATCH(
         { status: 422 },
       );
     }
-    // The vendor-pickup signature is mandatory (2026-06-22 decision), and the
-    // sheet is client-side — so back it up here: a driver cannot mark PICKED_UP
-    // until a pickup_signature upload exists for the order. Admin/helpdesk are
-    // exempt so they can repair stuck orders.
+    // Pickup confirmation is mandatory (2026-07-09 policy: receiver NAME is the
+    // required artifact, signature optional — supersedes the 2026-06-22
+    // signature-only mandate), and the sheet is client-side — so back it up
+    // here: a driver cannot mark PICKED_UP until a receiver name is recorded on
+    // the deliveries row OR a pickup_signature upload exists. Admin/helpdesk
+    // are exempt so they can repair stuck orders.
     if (
       driverStatus === DriverStatus.PICKED_UP &&
       currentDriverStatus !== DriverStatus.PICKED_UP &&
       !callerIsPrivileged
     ) {
-      const pickupSignature = await prisma.fileUpload.findFirst({
-        where: {
-          category: 'pickup_signature',
-          ...(orderType === 'catering'
-            ? { cateringRequestId: (existingOrder as any).id }
-            : { onDemandId: (existingOrder as any).id }),
-        },
-        select: { id: true },
-      });
-      if (!pickupSignature) {
+      const [pickupSignature, deliveryRow] = await Promise.all([
+        prisma.fileUpload.findFirst({
+          where: {
+            category: 'pickup_signature',
+            ...(orderType === 'catering'
+              ? { cateringRequestId: (existingOrder as any).id }
+              : { onDemandId: (existingOrder as any).id }),
+          },
+          select: { id: true },
+        }),
+        prisma.delivery.findUnique({
+          where: { orderNumber: (existingOrder as any).orderNumber },
+          select: { pickupReceivedBy: true },
+        }),
+      ]);
+      const hasReceiverName = !!deliveryRow?.pickupReceivedBy?.trim();
+      if (!pickupSignature && !hasReceiverName) {
         return NextResponse.json(
           {
             message:
-              'A vendor pickup signature is required before marking this order as picked up',
-            code: 'PICKUP_SIGNATURE_REQUIRED',
+              'Record who handed over the order (name) or capture a signature before marking picked up',
+            code: 'PICKUP_CONFIRMATION_REQUIRED',
           },
           { status: 422 },
         );

--- a/src/app/api/orders/[order_number]/signature/__tests__/route.test.ts
+++ b/src/app/api/orders/[order_number]/signature/__tests__/route.test.ts
@@ -1,7 +1,9 @@
 /**
- * Tests for the pickup-signature POST route. Mirrors the POD route: auth + role
- * + driver-assignment gating, FileUpload (category = 'pickup_signature'), and a
- * non-fatal mirror of the URL onto the standalone `deliveries` row.
+ * Tests for the pickup-confirmation POST route (formerly signature-only).
+ * Policy since 2026-07-09: `receivedBy` (name) is REQUIRED, the signature file
+ * is OPTIONAL. Auth + role + driver-assignment gating unchanged. The receiver
+ * name (and signature URL when present) are upserted onto the standalone
+ * `deliveries` row, which the PICKED_UP gate reads.
  */
 
 jest.mock('@/utils/prismaDB');
@@ -22,18 +24,26 @@ const mockedCreateClient = jest.mocked(createClient);
 const mockedUpload = uploadPickupSignatureImage as jest.Mock;
 const mockedSentry = Sentry as unknown as { captureException: jest.Mock };
 
-const SIG_URL = 'https://cdn.example.com/signatures/sig.png';
+const SIG_URL = 'https://cdn.example.com/deliveries/pickup-signature.png';
 
 const makeFile = () =>
   ({ name: 'pickup-signature.png', type: 'image/png', size: 512 } as unknown as File);
 
-const createPostRequest = (orderNumber = 'CAT-001', file: File | null = makeFile()) => {
+const createPostRequest = (
+  orderNumber = 'CAT-001',
+  file: File | null = makeFile(),
+  receivedBy: string | null = 'Maria Lopez',
+) => {
   const req = new NextRequest(
     `http://localhost:3000/api/orders/${orderNumber}/signature`,
     { method: 'POST' },
   );
   (req as any).formData = jest.fn().mockResolvedValue({
-    get: (k: string) => (k === 'file' ? file : null),
+    get: (k: string) => {
+      if (k === 'file') return file;
+      if (k === 'receivedBy') return receivedBy;
+      return null;
+    },
   });
   return req;
 };
@@ -52,20 +62,25 @@ const setupMocks = (opts: { role?: string; user?: any } = {}) => {
   (mockedPrisma.cateringRequest.findFirst as jest.Mock).mockResolvedValue({
     id: 'order-123',
     orderNumber: 'CAT-001',
+    deliveryAddress: { street1: '123 Client St' },
   });
   (mockedPrisma.onDemand.findFirst as jest.Mock).mockResolvedValue(null);
   (mockedPrisma.dispatch.findFirst as jest.Mock).mockResolvedValue({ id: 'dispatch-1' });
   (mockedPrisma.fileUpload.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
   (mockedPrisma.fileUpload.create as jest.Mock).mockResolvedValue({ id: 'file-1' });
-  (mockedPrisma.$executeRawUnsafe as jest.Mock).mockResolvedValue(1);
+  (mockedPrisma.delivery.upsert as jest.Mock).mockResolvedValue({ id: 'delivery-1' });
 
-  mockedUpload.mockResolvedValue({ url: SIG_URL, path: 'signatures/sig.png', error: null });
+  mockedUpload.mockResolvedValue({
+    url: SIG_URL,
+    path: 'deliveries/order-123/pickup-signature.png',
+    error: null,
+  });
 };
 
 const importRoute = async () => import('../route');
 const params = (order_number: string) => ({ params: Promise.resolve({ order_number }) });
 
-describe('pickup signature POST', () => {
+describe('pickup confirmation POST', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     setupMocks();
@@ -102,7 +117,19 @@ describe('pickup signature POST', () => {
     expect(res.status).toBe(403);
   });
 
-  it('uploads + mirrors the signature URL onto the deliveries row', async () => {
+  it('returns 400 when receivedBy is missing or blank', async () => {
+    const { POST } = await importRoute();
+    const missing = await POST(createPostRequest('CAT-001', makeFile(), null), params('CAT-001'));
+    expect(missing.status).toBe(400);
+
+    setupMocks();
+    const blank = await POST(createPostRequest('CAT-001', makeFile(), '   '), params('CAT-001'));
+    expect(blank.status).toBe(400);
+    expect(mockedUpload).not.toHaveBeenCalled();
+    expect(mockedPrisma.delivery.upsert as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it('uploads the signature and upserts name + URL onto the deliveries row', async () => {
     const { POST } = await importRoute();
     const res = await POST(createPostRequest('CAT-001'), params('CAT-001'));
 
@@ -110,6 +137,7 @@ describe('pickup signature POST', () => {
     const data = await res.json();
     expect(data.success).toBe(true);
     expect(data.url).toBe(SIG_URL);
+    expect(data.receivedBy).toBe('Maria Lopez');
 
     expect(mockedPrisma.fileUpload.create as jest.Mock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -120,18 +148,55 @@ describe('pickup signature POST', () => {
       }),
     );
 
-    const [sql, urlArg, orderArg] = (mockedPrisma.$executeRawUnsafe as jest.Mock).mock.calls[0];
-    expect(sql).toContain('UPDATE deliveries');
-    expect(sql).toContain('pickup_signature_url');
-    expect(sql).toContain('LOWER(order_number) = LOWER($2)');
-    expect(sql).toContain('deleted_at IS NULL');
-    expect(urlArg).toBe(SIG_URL);
-    expect(orderArg).toBe('CAT-001');
+    expect(mockedPrisma.delivery.upsert as jest.Mock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { orderNumber: 'CAT-001' },
+        update: expect.objectContaining({
+          pickupReceivedBy: 'Maria Lopez',
+          pickupSignatureUrl: SIG_URL,
+        }),
+        create: expect.objectContaining({
+          orderNumber: 'CAT-001',
+          deliveryAddress: '123 Client St',
+          pickupReceivedBy: 'Maria Lopez',
+          pickupSignatureUrl: SIG_URL,
+        }),
+      }),
+    );
   });
 
-  it('still succeeds when the deliveries mirror throws (non-fatal)', async () => {
+  it('accepts a name-only confirmation (no signature file)', async () => {
+    const { POST } = await importRoute();
+    const res = await POST(createPostRequest('CAT-001', null), params('CAT-001'));
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(data.url).toBeNull();
+    expect(data.receivedBy).toBe('Maria Lopez');
+
+    expect(mockedUpload).not.toHaveBeenCalled();
+    expect(mockedPrisma.fileUpload.create as jest.Mock).not.toHaveBeenCalled();
+    expect(mockedPrisma.delivery.upsert as jest.Mock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: { pickupReceivedBy: 'Maria Lopez' },
+      }),
+    );
+  });
+
+  it('returns 500 when the upsert fails on a name-only confirmation (name is the gating artifact)', async () => {
     setupMocks();
-    (mockedPrisma.$executeRawUnsafe as jest.Mock).mockRejectedValue(new Error('no deliveries row'));
+    (mockedPrisma.delivery.upsert as jest.Mock).mockRejectedValue(new Error('db down'));
+    const { POST } = await importRoute();
+    const res = await POST(createPostRequest('CAT-001', null), params('CAT-001'));
+
+    expect(res.status).toBe(500);
+    expect(mockedSentry.captureException).toHaveBeenCalled();
+  });
+
+  it('stays non-fatal when the upsert fails but a signature was stored (gate passes via file_uploads)', async () => {
+    setupMocks();
+    (mockedPrisma.delivery.upsert as jest.Mock).mockRejectedValue(new Error('db down'));
     const { POST } = await importRoute();
     const res = await POST(createPostRequest('CAT-001'), params('CAT-001'));
 
@@ -140,13 +205,13 @@ describe('pickup signature POST', () => {
     expect(mockedSentry.captureException).toHaveBeenCalled();
   });
 
-  it('returns 500 and skips the mirror when the upload fails', async () => {
+  it('returns 500 and records nothing when the upload fails', async () => {
     setupMocks();
     mockedUpload.mockResolvedValue({ url: null, path: null, error: 'storage down' });
     const { POST } = await importRoute();
     const res = await POST(createPostRequest('CAT-001'), params('CAT-001'));
 
     expect(res.status).toBe(500);
-    expect(mockedPrisma.$executeRawUnsafe as jest.Mock).not.toHaveBeenCalled();
+    expect(mockedPrisma.delivery.upsert as jest.Mock).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/orders/[order_number]/signature/route.ts
+++ b/src/app/api/orders/[order_number]/signature/route.ts
@@ -5,12 +5,15 @@ import { uploadPickupSignatureImage } from '@/utils/supabase/storage';
 import * as Sentry from '@sentry/nextjs';
 
 /**
- * POST - Upload a pickup-stage signature for an order.
+ * POST - Record the pickup confirmation for an order.
  *
- * Mirrors the POD route (`../pod/route.ts`): a manual capture of the restaurant
- * staff member's signature when the driver picks up the food (NOT DocuSign).
- * Creates a FileUpload (category = 'pickup_signature') linked to the catering /
- * on-demand order, then mirrors the URL onto the standalone `deliveries` row.
+ * Policy since 2026-07-09 (live-drive feedback): the NAME of the vendor-side
+ * person who handed over / confirmed the order is REQUIRED (`receivedBy` form
+ * field); the signature image (`file`) is OPTIONAL. When a signature is
+ * provided it is stored as a FileUpload (category = 'pickup_signature') exactly
+ * as before. The receiver name (and signature URL, when present) are persisted
+ * on the standalone `deliveries` row — the orders PATCH gate accepts either
+ * artifact before allowing PICKED_UP.
  */
 export async function POST(
   request: NextRequest,
@@ -53,37 +56,52 @@ export async function POST(
       );
     }
 
-    // Find the order (try catering first, then on-demand)
+    // Find the order (try catering first, then on-demand). The delivery street
+    // is selected for the deliveries upsert's create branch (NOT NULL column).
     let orderId: string | null = null;
     let orderType: 'catering' | 'on_demand' | null = null;
+    let dbOrderNumber: string | null = null;
+    let deliveryStreet: string | null = null;
 
     const cateringRequest = await prisma.cateringRequest.findFirst({
       where: {
         orderNumber: { equals: orderNumber, mode: 'insensitive' },
         deletedAt: null,
       },
-      select: { id: true, orderNumber: true },
+      select: {
+        id: true,
+        orderNumber: true,
+        deliveryAddress: { select: { street1: true } },
+      },
     });
 
     if (cateringRequest) {
       orderId = cateringRequest.id;
       orderType = 'catering';
+      dbOrderNumber = cateringRequest.orderNumber;
+      deliveryStreet = cateringRequest.deliveryAddress?.street1 ?? null;
     } else {
       const onDemandOrder = await prisma.onDemand.findFirst({
         where: {
           orderNumber: { equals: orderNumber, mode: 'insensitive' },
           deletedAt: null,
         },
-        select: { id: true, orderNumber: true },
+        select: {
+          id: true,
+          orderNumber: true,
+          deliveryAddress: { select: { street1: true } },
+        },
       });
 
       if (onDemandOrder) {
         orderId = onDemandOrder.id;
         orderType = 'on_demand';
+        dbOrderNumber = onDemandOrder.orderNumber;
+        deliveryStreet = onDemandOrder.deliveryAddress?.street1 ?? null;
       }
     }
 
-    if (!orderId || !orderType) {
+    if (!orderId || !orderType || !dbOrderNumber) {
       return NextResponse.json(
         { success: false, error: 'Order not found' },
         { status: 404 }
@@ -109,100 +127,137 @@ export async function POST(
       }
     }
 
-    // Parse form data
+    // Parse form data: `receivedBy` is required, the signature file is optional.
     const formData = await request.formData();
     const file = formData.get('file') as File | null;
+    const receivedByRaw = formData.get('receivedBy');
+    const receivedBy =
+      typeof receivedByRaw === 'string' ? receivedByRaw.trim() : '';
 
-    if (!file) {
+    if (!receivedBy) {
       return NextResponse.json(
-        { success: false, error: 'No file provided' },
+        { success: false, error: 'Enter the name of the person who handed over the order.' },
+        { status: 400 }
+      );
+    }
+    if (receivedBy.length > 255) {
+      return NextResponse.json(
+        { success: false, error: 'Receiver name is too long (max 255 characters).' },
         { status: 400 }
       );
     }
 
-    // Validate file type (signature pad exports PNG)
-    const allowedTypes = ['image/png', 'image/jpeg', 'image/webp'];
-    if (!allowedTypes.includes(file.type)) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: 'Invalid file type. Only PNG, JPEG, and WebP images are allowed.',
+    let signatureUrl: string | null = null;
+    let signaturePath: string | null = null;
+    let fileUploadId: string | null = null;
+
+    if (file) {
+      // Validate file type (signature pad exports PNG)
+      const allowedTypes = ['image/png', 'image/jpeg', 'image/webp'];
+      if (!allowedTypes.includes(file.type)) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: 'Invalid file type. Only PNG, JPEG, and WebP images are allowed.',
+          },
+          { status: 400 }
+        );
+      }
+
+      // Validate file size (max 2MB — a signature PNG is tiny)
+      const maxSize = 2 * 1024 * 1024;
+      if (file.size > maxSize) {
+        return NextResponse.json(
+          { success: false, error: 'File too large. Maximum size is 2MB.' },
+          { status: 400 }
+        );
+      }
+
+      // Upload to Supabase Storage
+      const uploadResult = await uploadPickupSignatureImage(file, orderId);
+
+      if (uploadResult.error) {
+        return NextResponse.json(
+          { success: false, error: uploadResult.error },
+          { status: 500 }
+        );
+      }
+      signatureUrl = uploadResult.url;
+      signaturePath = uploadResult.path ?? null;
+
+      // Replace any existing pickup signature for this order
+      await prisma.fileUpload.deleteMany({
+        where: {
+          category: 'pickup_signature',
+          ...(orderType === 'catering'
+            ? { cateringRequestId: orderId }
+            : { onDemandId: orderId }),
         },
-        { status: 400 }
-      );
+      });
+
+      // Create FileUpload record (the canonical store for the image)
+      const fileUpload = await prisma.fileUpload.create({
+        data: {
+          userId: user.id,
+          fileName: file.name || 'pickup-signature.png',
+          fileType: file.type,
+          fileSize: file.size,
+          fileUrl: signatureUrl,
+          filePath: signaturePath,
+          category: 'pickup_signature',
+          isTemporary: false,
+          ...(orderType === 'catering'
+            ? { cateringRequestId: orderId }
+            : { onDemandId: orderId }),
+        },
+      });
+      fileUploadId = fileUpload.id;
     }
 
-    // Validate file size (max 2MB — a signature PNG is tiny)
-    const maxSize = 2 * 1024 * 1024;
-    if (file.size > maxSize) {
-      return NextResponse.json(
-        { success: false, error: 'File too large. Maximum size is 2MB.' },
-        { status: 400 }
-      );
-    }
-
-    // Upload to Supabase Storage
-    const uploadResult = await uploadPickupSignatureImage(file, orderId);
-
-    if (uploadResult.error) {
-      return NextResponse.json(
-        { success: false, error: uploadResult.error },
-        { status: 500 }
-      );
-    }
-
-    // Replace any existing pickup signature for this order
-    await prisma.fileUpload.deleteMany({
-      where: {
-        category: 'pickup_signature',
-        ...(orderType === 'catering'
-          ? { cateringRequestId: orderId }
-          : { onDemandId: orderId }),
-      },
-    });
-
-    // Create FileUpload record (the canonical store)
-    const fileUpload = await prisma.fileUpload.create({
-      data: {
-        userId: user.id,
-        fileName: file.name || 'pickup-signature.png',
-        fileType: file.type,
-        fileSize: file.size,
-        fileUrl: uploadResult.url,
-        filePath: uploadResult.path,
-        category: 'pickup_signature',
-        isTemporary: false,
-        ...(orderType === 'catering'
-          ? { cateringRequestId: orderId }
-          : { onDemandId: orderId }),
-      },
-    });
-
-    // Mirror the signature URL onto the standalone `deliveries` row so the admin
-    // tracking surface (which reads pickup_signature_url) sees it too. Non-fatal:
-    // a missing deliveries row (created on the first stage advance) must not fail
-    // the capture — the FileUpload above is the source of truth.
+    // Persist the receiver name (and signature URL, when present) on the
+    // standalone `deliveries` row — the orders PATCH gate reads
+    // pickup_received_by from here before allowing PICKED_UP. Upsert because
+    // the row normally appears on the first status advance but may not exist
+    // yet. When no signature was stored, this write IS the gating artifact, so
+    // a failure here must surface to the driver (they'd otherwise hit an
+    // unexplainable 422 at pickup); with a signature stored the gate passes via
+    // file_uploads, so the mirror stays non-fatal.
     try {
-      await prisma.$executeRawUnsafe(
-        `UPDATE deliveries
-           SET pickup_signature_url = $1, updated_at = NOW()
-         WHERE LOWER(order_number) = LOWER($2) AND deleted_at IS NULL`,
-        uploadResult.url,
-        orderNumber,
-      );
+      await prisma.delivery.upsert({
+        where: { orderNumber: dbOrderNumber },
+        update: {
+          pickupReceivedBy: receivedBy,
+          ...(signatureUrl ? { pickupSignatureUrl: signatureUrl } : {}),
+        },
+        create: {
+          orderNumber: dbOrderNumber,
+          deliveryAddress: deliveryStreet ?? '',
+          pickupReceivedBy: receivedBy,
+          ...(signatureUrl ? { pickupSignatureUrl: signatureUrl } : {}),
+        },
+      });
     } catch (mirrorErr) {
       Sentry.captureException(mirrorErr, {
-        tags: { operation: 'pickup_signature_mirror_deliveries', route: 'orders' },
-        extra: { orderNumber },
+        tags: { operation: 'pickup_confirmation_deliveries_upsert', route: 'orders' },
+        extra: { orderNumber, hasSignature: !!signatureUrl },
       });
+      if (!signatureUrl) {
+        return NextResponse.json(
+          { success: false, error: 'Failed to record the pickup confirmation. Please try again.' },
+          { status: 500 }
+        );
+      }
     }
 
     return NextResponse.json({
       success: true,
-      url: uploadResult.url,
-      path: uploadResult.path,
-      fileUploadId: fileUpload.id,
-      message: 'Pickup signature uploaded successfully',
+      receivedBy,
+      url: signatureUrl,
+      path: signaturePath,
+      fileUploadId,
+      message: signatureUrl
+        ? 'Pickup confirmed with signature'
+        : 'Pickup confirmed',
     });
   } catch (error) {
     Sentry.captureException(error, {

--- a/src/components/Driver/SignatureCapture.tsx
+++ b/src/components/Driver/SignatureCapture.tsx
@@ -11,8 +11,9 @@ interface SignatureCaptureProps {
   orderNumber: string;
   /** Endpoint override (defaults to /api/orders/[order_number]/signature). */
   uploadEndpoint?: string;
-  /** Called with the stored signature URL once capture + upload succeeds. */
-  onUploadComplete: (url: string) => void;
+  /** Called once the confirmation is stored. `url` is the signature image URL
+   *  when one was drawn, or null for a name-only confirmation. */
+  onUploadComplete: (url: string | null) => void;
   onCancel: () => void;
   className?: string;
 }
@@ -28,9 +29,10 @@ function dataURLToBlob(dataURL: string): Blob {
 }
 
 /**
- * In-app signature pad for the vendor pickup step. Captures a manual signature
- * from the restaurant staff (not DocuSign), exports a PNG, and uploads it to the
- * orders signature endpoint. Mandatory before a driver can mark a pickup done.
+ * In-app pickup confirmation for the vendor pickup step. The NAME of the person
+ * who handed over the order is required (2026-07-09 policy); the signature pad
+ * is optional. Posts both to the orders signature endpoint, which records the
+ * confirmation the PICKED_UP gate checks.
  */
 export function SignatureCapture({
   orderNumber,
@@ -42,6 +44,7 @@ export function SignatureCapture({
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const padRef = useRef<SignaturePad | null>(null);
   const [hasInk, setHasInk] = useState(false);
+  const [receivedBy, setReceivedBy] = useState("");
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -87,20 +90,26 @@ export function SignatureCapture({
   }, []);
 
   const handleConfirm = useCallback(async () => {
-    const pad = padRef.current;
-    if (!pad || pad.isEmpty()) {
-      setError("Please capture a signature first.");
+    const name = receivedBy.trim();
+    if (!name) {
+      setError("Please enter who handed over the order.");
       return;
     }
     setUploading(true);
     setError(null);
     try {
-      const blob = dataURLToBlob(pad.toDataURL("image/png"));
-      const file = new File([blob], "pickup-signature.png", {
-        type: "image/png",
-      });
       const formData = new FormData();
-      formData.append("file", file, file.name);
+      formData.append("receivedBy", name);
+
+      // The signature is optional — attach it only when the pad has ink.
+      const pad = padRef.current;
+      if (pad && !pad.isEmpty()) {
+        const blob = dataURLToBlob(pad.toDataURL("image/png"));
+        const file = new File([blob], "pickup-signature.png", {
+          type: "image/png",
+        });
+        formData.append("file", file, file.name);
+      }
 
       const endpoint =
         uploadEndpoint ??
@@ -111,8 +120,8 @@ export function SignatureCapture({
         throw new Error(body.error || "Upload failed");
       }
       const result = await res.json();
-      toast.success("Signature captured");
-      onUploadComplete(result.url);
+      toast.success("Pickup confirmed");
+      onUploadComplete(result.url ?? null);
     } catch (err) {
       const message = err instanceof Error ? err.message : "Upload failed";
       setError(message);
@@ -120,23 +129,44 @@ export function SignatureCapture({
     } finally {
       setUploading(false);
     }
-  }, [orderNumber, uploadEndpoint, onUploadComplete]);
+  }, [orderNumber, uploadEndpoint, onUploadComplete, receivedBy]);
 
   return (
     <div className={cn("flex flex-col gap-3", className)}>
       <p className="text-[13.5px] font-semibold text-driver-muted">
-        Ask the restaurant staff to sign below to confirm pickup.
+        Enter the name of the person who handed over the order. Signature is
+        optional.
       </p>
+
+      <label className="flex flex-col gap-1.5">
+        <span className="text-[12.5px] font-semibold text-driver-muted">
+          Received / confirmed by
+        </span>
+        <input
+          type="text"
+          value={receivedBy}
+          onChange={(e) => {
+            setReceivedBy(e.target.value);
+            if (error) setError(null);
+          }}
+          placeholder="Name of restaurant staff"
+          maxLength={255}
+          autoComplete="off"
+          disabled={uploading}
+          className="w-full rounded-2xl border-[1.5px] border-driver-border bg-driver-surface-alt px-4 py-3 text-[15px] font-semibold text-driver-text placeholder:text-driver-subtle focus:outline-none focus:ring-2 focus:ring-driver-brand disabled:opacity-50"
+          aria-label="Received / confirmed by"
+        />
+      </label>
 
       <div className="relative overflow-hidden rounded-2xl border-[1.5px] border-driver-border bg-driver-surface-alt">
         <canvas
           ref={canvasRef}
           className="h-48 w-full touch-none"
-          aria-label="Signature pad"
+          aria-label="Signature pad (optional)"
         />
         {!hasInk ? (
           <span className="pointer-events-none absolute inset-0 flex items-center justify-center text-[13px] font-semibold text-driver-subtle">
-            Sign here
+            Sign here (optional)
           </span>
         ) : null}
       </div>
@@ -161,12 +191,12 @@ export function SignatureCapture({
           variant="brand"
           full
           loading={uploading}
-          disabled={uploading || !hasInk}
+          disabled={uploading || !receivedBy.trim()}
           onClick={handleConfirm}
           className="flex-1"
         >
           {!uploading ? <Check className="h-4 w-4" strokeWidth={2.6} /> : null}
-          Confirm signature
+          Confirm pickup
         </DriverButton>
       </div>
 

--- a/src/components/Driver/__tests__/SignatureCapture.test.tsx
+++ b/src/components/Driver/__tests__/SignatureCapture.test.tsx
@@ -26,7 +26,15 @@ jest.mock("react-hot-toast", () => ({
 
 import { SignatureCapture } from "../SignatureCapture";
 
-const SIG_URL = "https://cdn.example.com/signatures/sig.png";
+const SIG_URL = "https://cdn.example.com/deliveries/pickup-signature.png";
+
+const typeName = (name = "Maria Lopez") =>
+  fireEvent.change(screen.getByLabelText(/received \/ confirmed by/i), {
+    target: { value: name },
+  });
+
+const lastFormData = (): FormData =>
+  (global.fetch as jest.Mock).mock.calls[0][1].body as FormData;
 
 describe("SignatureCapture", () => {
   beforeEach(() => {
@@ -35,32 +43,61 @@ describe("SignatureCapture", () => {
     mockPad.isEmpty.mockReturnValue(false);
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ success: true, url: SIG_URL }),
+      json: async () => ({ success: true, url: SIG_URL, receivedBy: "Maria Lopez" }),
     }) as unknown as typeof fetch;
   });
 
-  it("disables Confirm until a stroke is drawn", () => {
+  it("disables Confirm until a receiver name is entered (ink not required)", () => {
+    mockPad.isEmpty.mockReturnValue(true);
     render(
       <SignatureCapture orderNumber="CAT-001" onUploadComplete={jest.fn()} onCancel={jest.fn()} />,
     );
-    expect(screen.getByRole("button", { name: /confirm signature/i })).toBeDisabled();
+    const confirm = screen.getByRole("button", { name: /confirm pickup/i });
+    expect(confirm).toBeDisabled();
+
+    typeName();
+    expect(confirm).toBeEnabled();
   });
 
-  it("uploads the signature and reports the stored URL", async () => {
+  it("uploads name + signature when the pad has ink", async () => {
     const onComplete = jest.fn();
     render(
       <SignatureCapture orderNumber="CAT-001" onUploadComplete={onComplete} onCancel={jest.fn()} />,
     );
 
+    typeName();
     // Simulate the driver completing a stroke.
     act(() => mockPad._handlers["endStroke"]?.());
 
-    fireEvent.click(screen.getByRole("button", { name: /confirm signature/i }));
+    fireEvent.click(screen.getByRole("button", { name: /confirm pickup/i }));
 
     await waitFor(() => expect(onComplete).toHaveBeenCalledWith(SIG_URL));
     expect(global.fetch).toHaveBeenCalledWith(
       "/api/orders/CAT-001/signature",
       expect.objectContaining({ method: "POST" }),
     );
+    const fd = lastFormData();
+    expect(fd.get("receivedBy")).toBe("Maria Lopez");
+    expect(fd.get("file")).not.toBeNull();
+  });
+
+  it("confirms with name only when the pad is empty (signature optional)", async () => {
+    mockPad.isEmpty.mockReturnValue(true);
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, url: null, receivedBy: "Maria Lopez" }),
+    });
+    const onComplete = jest.fn();
+    render(
+      <SignatureCapture orderNumber="CAT-001" onUploadComplete={onComplete} onCancel={jest.fn()} />,
+    );
+
+    typeName();
+    fireEvent.click(screen.getByRole("button", { name: /confirm pickup/i }));
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledWith(null));
+    const fd = lastFormData();
+    expect(fd.get("receivedBy")).toBe("Maria Lopez");
+    expect(fd.get("file")).toBeNull();
   });
 });

--- a/src/components/Driver/ui/DriverSignatureSheet.tsx
+++ b/src/components/Driver/ui/DriverSignatureSheet.tsx
@@ -16,8 +16,9 @@ interface DriverSignatureSheetProps {
   orderNumber: string;
   /** Endpoint override (defaults to /api/orders/[order_number]/signature). */
   uploadEndpoint?: string;
-  /** Called with the stored signature URL once capture + upload succeeds. */
-  onComplete: (url: string) => void;
+  /** Called once the confirmation is stored. `url` is the signature image URL
+   *  when one was drawn, or null for a name-only confirmation. */
+  onComplete: (url: string | null) => void;
 }
 
 /** Bottom-sheet wrapper around the pickup SignatureCapture flow. Mirrors
@@ -43,7 +44,7 @@ export function DriverSignatureSheet({
         <div className="mx-auto w-full max-w-2xl">
           <SheetHeader className="items-start">
             <SheetTitle className="text-[18px] font-semibold text-driver-text">
-              Vendor pickup signature
+              Confirm pickup
             </SheetTitle>
           </SheetHeader>
           <div className="mt-4">

--- a/src/utils/supabase/storage.ts
+++ b/src/utils/supabase/storage.ts
@@ -125,8 +125,11 @@ export async function uploadPODImage(
 /**
  * Upload a pickup-stage signature image (a PNG from the in-app signature pad).
  *
- * Reuses the delivery-proofs bucket but a distinct `signatures/` path prefix so
- * pickup signatures are easy to tell apart from POD photos in storage.
+ * Reuses the delivery-proofs bucket under the `deliveries/` path prefix — the
+ * bucket's INSERT policy only allows that first folder segment
+ * (supabase/migrations/20251127000000_create_delivery_proofs_bucket.sql), so any
+ * other prefix is rejected with an RLS violation. The `pickup-signature-` filename
+ * keeps signatures distinguishable from POD photos.
  *
  * @param file - The signature image (File or Blob)
  * @param orderId - The order UUID (catering or on-demand)
@@ -153,7 +156,7 @@ export async function uploadPickupSignatureImage(
     }
 
     const timestamp = Date.now();
-    const filename = `signatures/${orderId}/pickup-signature-${orderId}-${timestamp}.png`;
+    const filename = `deliveries/${orderId}/pickup-signature-${timestamp}.png`;
 
     const { data, error } = await supabase.storage
       .from(POD_BUCKET_NAME)


### PR DESCRIPTION
## Context

The 2026-07-09 live drive test (CDMX, WALK-TEST-NIGHT) hit **"new row violates row-level security policy"** when confirming the vendor pickup signature — combined with the #475 server gate, drivers are **hard-blocked at pickup**. This affects production too (v2.4.0 shipped the gate; same bucket policy).

## Root cause

`uploadPickupSignatureImage` writes to the `delivery-proofs` bucket under `signatures/{orderId}/…`, but the bucket's INSERT policy (`supabase/migrations/20251127000000_create_delivery_proofs_bucket.sql`) only allows the `deliveries/` first folder segment. POD photos work because they write under `deliveries/`.

## Changes

1. **Storage fix (1 line):** signatures now write to `deliveries/{orderId}/pickup-signature-{ts}.png` — passes the existing policy, no DB/storage migration anywhere.
2. **Policy change (field feedback from the drive test):** the required artifact is now the **name of the person who handed over the order**; the signature is **optional**.
   - New nullable `deliveries.pickup_received_by` column (migration `20260709000000_add_pickup_received_by`, idempotent).
   - `POST /api/orders/[order_number]/signature` accepts required `receivedBy` + optional `file`; upserts the deliveries row (name + signature URL when present). Name-only upsert failures are fatal (the name is the gating artifact); with a signature stored the mirror stays non-fatal.
   - PICKED_UP gate accepts **name OR signature**; new code `PICKUP_CONFIRMATION_REQUIRED` (nothing keyed off the old code). Admin/helpdesk exemption unchanged.
   - Sheet retitled "Confirm pickup": required name input, pad marked optional.

## Tests

- Signature route: 10 cases (blank-name 400, name-only success, name-only upsert-fail 500, name+file upsert-fail non-fatal, upload-fail 500, auth/role/ownership unchanged).
- Orders PATCH gate: name-only allows, whitespace-name rejects, signature-only allows, HELPDESK exempt.
- SignatureCapture: confirm gated on name not ink; name-only posts without a file part.
- `pnpm pre-push-check` green; affected suites 85/85.

## Ops

- rs-dev: migration auto-applies on deploy.
- **Prod:** at next sync run `prisma migrate status` first (July drift incident), then apply/record `20260709000000_add_pickup_received_by`. The storage fix needs no prod SQL.
- **This PR is a candidate for an expedited dev→main sync** — prod pickup is likely hard-blocked today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)