### PR TITLE
fix(driver): walk-test follow-ups — signature pad reliability + fullscreen, sign-in bounce, end-shift guard

### DIFF
--- a/src/app/(site)/(auth)/sign-in/page.tsx
+++ b/src/app/(site)/(auth)/sign-in/page.tsx
@@ -2,7 +2,12 @@ import Signin from "@/components/Auth/SignIn";
 import Breadcrumb from "@/components/Common/Breadcrumb";
 import { Metadata } from "next";
 import { Suspense } from "react";
+import { redirect } from "next/navigation";
 import AuthErrorRecovery from "@/components/Auth/SignIn/AuthErrorRecovery";
+import { createClient } from "@/utils/supabase/server";
+import { prisma } from "@/utils/prismaDB";
+import { getDashboardRouteByRole } from "@/utils/routing";
+import type { UserType } from "@/types/user";
 
 export const metadata: Metadata = {
   title:
@@ -22,9 +27,36 @@ const SigninPage = async ({
   searchParams: Promise<SearchParams | null>
 }) => {
   const params = await searchParams;
-  
+
   // Show error recovery if cookie error is detected
   const showErrorRecovery = params?.cookieError === 'true';
+
+  // Already-authenticated visitors don't belong on the sign-in page — bounce
+  // them to their dashboard (or a same-origin returnTo). This also self-heals
+  // the native driver shell: when the WebView lands here despite a live
+  // session (the "looks logged-out" divergence), it now returns to /driver
+  // instead of stranding the driver on the marketing chrome.
+  if (!showErrorRecovery) {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (user?.id) {
+      const profile = await prisma.profile.findUnique({
+        where: { id: user.id },
+        select: { type: true, deletedAt: true },
+      });
+      if (profile && !profile.deletedAt) {
+        const returnTo = params?.returnTo;
+        // Same-origin paths only — never redirect off-site.
+        const safeReturnTo =
+          returnTo && returnTo.startsWith("/") && !returnTo.startsWith("//")
+            ? returnTo
+            : null;
+        redirect(safeReturnTo ?? getDashboardRouteByRole(profile.type as UserType));
+      }
+    }
+  }
 
   // Extract only the props that Signin component expects
   const signinParams = params ? {
@@ -36,7 +68,7 @@ const SigninPage = async ({
   return (
     <>
       <Breadcrumb pageName="Sign In Page" />
-      
+
       {showErrorRecovery ? (
         <div className="container mx-auto py-8">
           <AuthErrorRecovery />

--- a/src/app/actions/tracking/driver-actions.ts
+++ b/src/app/actions/tracking/driver-actions.ts
@@ -148,8 +148,10 @@ export async function endDriverShift(
     // Guard: a driver may not end a shift while they still have active
     // deliveries — doing so would strand an in-progress order. Admins may
     // override by passing metadata.force. "Active" = a non-terminal row in the
-    // `deliveries` table (what the live portal shows), or a catering/on-demand
-    // order the driver has actually started (driverStatus in a movement stage).
+    // `deliveries` table (what the live portal shows), a catering/on-demand
+    // order the driver has actually started (driverStatus in a movement stage),
+    // or — 2026-07-09 drive-test feedback — an ASSIGNED order whose pickup is
+    // imminent (≤2h) or overdue. Future-dated assignments don't trap the driver.
     const caller = await getActionCaller();
     const force = metadata?.force === true && (caller?.isPrivileged ?? false);
     if (!force) {
@@ -170,9 +172,19 @@ export async function endDriverShift(
             WHERE di."driverId" = (SELECT profile_id FROM drivers WHERE id = $1::uuid)
               AND (
                 (cr.id IS NOT NULL AND cr."deletedAt" IS NULL
-                  AND cr."driverStatus" IN ('EN_ROUTE_TO_VENDOR','ARRIVED_AT_VENDOR','PICKED_UP','EN_ROUTE_TO_CLIENT','ARRIVED_TO_CLIENT'))
+                  AND (
+                    cr."driverStatus" IN ('EN_ROUTE_TO_VENDOR','ARRIVED_AT_VENDOR','PICKED_UP','EN_ROUTE_TO_CLIENT','ARRIVED_TO_CLIENT')
+                    OR (cr."driverStatus" = 'ASSIGNED'
+                      AND cr."pickupDateTime" IS NOT NULL
+                      AND cr."pickupDateTime" <= NOW() + interval '2 hours')
+                  ))
                 OR (od.id IS NOT NULL AND od."deletedAt" IS NULL
-                  AND od."driverStatus" IN ('EN_ROUTE_TO_VENDOR','ARRIVED_AT_VENDOR','PICKED_UP','EN_ROUTE_TO_CLIENT','ARRIVED_TO_CLIENT'))
+                  AND (
+                    od."driverStatus" IN ('EN_ROUTE_TO_VENDOR','ARRIVED_AT_VENDOR','PICKED_UP','EN_ROUTE_TO_CLIENT','ARRIVED_TO_CLIENT')
+                    OR (od."driverStatus" = 'ASSIGNED'
+                      AND od."pickupDateTime" IS NOT NULL
+                      AND od."pickupDateTime" <= NOW() + interval '2 hours')
+                  ))
               )
           ) AS n
       `, shift?.driver_id);
@@ -181,7 +193,7 @@ export async function endDriverShift(
       if (activeCount > 0) {
         return {
           success: false,
-          error: `You still have ${activeCount} active ${activeCount === 1 ? 'delivery' : 'deliveries'}. Complete or cancel ${activeCount === 1 ? 'it' : 'them'} before ending your shift.`,
+          error: `You still have ${activeCount} active or due ${activeCount === 1 ? 'delivery' : 'deliveries'}. Complete ${activeCount === 1 ? 'it' : 'them'} (or ask dispatch to reassign) before ending your shift.`,
           activeDeliveries: activeCount,
         };
       }

--- a/src/components/Driver/DriverTrackingPortal.tsx
+++ b/src/components/Driver/DriverTrackingPortal.tsx
@@ -41,6 +41,28 @@ import {
 } from "@/lib/driver/geofence";
 import type { DeliveryTracking } from "@/types/tracking";
 
+/** Movement stages: the delivery has been started and MUST block ending the
+ *  shift. Mirrors the server-side guard in endDriverShift. */
+const IN_FLIGHT_STATUSES: DriverStatus[] = [
+  DriverStatus.EN_ROUTE_TO_VENDOR,
+  DriverStatus.ARRIVED_AT_VENDOR,
+  DriverStatus.PICKED_UP,
+  DriverStatus.EN_ROUTE_TO_CLIENT,
+  DriverStatus.ARRIVED_TO_CLIENT,
+];
+
+/** True when this delivery should block ending the shift: it's mid-flight, or
+ *  it's ASSIGNED with a pickup that is imminent (≤2h) or overdue. Mirrors the
+ *  server guard so the button state matches what the API will say. */
+function blocksEndShift(delivery: DeliveryTracking): boolean {
+  if (IN_FLIGHT_STATUSES.includes(delivery.status)) return true;
+  if (delivery.status === DriverStatus.ASSIGNED && delivery.scheduledPickupAt) {
+    const pickup = new Date(delivery.scheduledPickupAt).getTime();
+    return pickup <= Date.now() + 2 * 60 * 60 * 1000;
+  }
+  return false;
+}
+
 /** Geofence only the "arrived" steps: block advancing when the driver is
  *  demonstrably far from the relevant stop (fail-open on unknown GPS/coords). */
 function arrivalGeofence(
@@ -159,8 +181,17 @@ export default function DriverTrackingPortal() {
     if (ok) startTracking();
   };
 
+  const endShiftBlockers = activeDeliveries.filter(blocksEndShift).length;
+
   const handleEndShift = async () => {
     if (!currentShift?.id) return;
+    // Backstop for the disabled button (mirrors the server guard).
+    if (endShiftBlockers > 0) {
+      toast.error(
+        `You still have ${endShiftBlockers} active or due ${endShiftBlockers === 1 ? "delivery" : "deliveries"}. Complete ${endShiftBlockers === 1 ? "it" : "them"} before ending your shift.`,
+      );
+      return;
+    }
     let location = currentLocation;
     if (!location) {
       location = {
@@ -177,6 +208,13 @@ export default function DriverTrackingPortal() {
     const ok = await endShift(currentShift.id, location);
     if (ok) stopTracking();
   };
+
+  // Surface shift failures (e.g. the server's active-delivery guard) instead
+  // of a button that silently does nothing. Effect-based so it reads the
+  // freshly-set error, not the render-time closure value.
+  useEffect(() => {
+    if (shiftError) toast.error(shiftError);
+  }, [shiftError]);
 
   const advanceStatus = async (deliveryId: string, status: DriverStatus) => {
     setUpdatingId(deliveryId);
@@ -375,12 +413,20 @@ export default function DriverTrackingPortal() {
                       })
                     : ""}
                 </div>
+                {endShiftBlockers > 0 ? (
+                  <div className="mt-0.5 text-[11px] font-semibold text-driver-subtle">
+                    {endShiftBlockers === 1
+                      ? "1 delivery to finish first"
+                      : `${endShiftBlockers} deliveries to finish first`}
+                  </div>
+                ) : null}
               </div>
               <DriverButton
                 variant="danger"
                 size="md"
                 onClick={handleEndShift}
                 loading={shiftLoading}
+                disabled={endShiftBlockers > 0}
               >
                 <Square className="h-4 w-4" />
                 End shift

--- a/src/components/Driver/SignatureCapture.tsx
+++ b/src/components/Driver/SignatureCapture.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import SignaturePad from "signature_pad";
-import { AlertCircle, Check, Eraser } from "lucide-react";
+import { AlertCircle, Check, Eraser, Maximize2, Minimize2 } from "lucide-react";
 import toast from "react-hot-toast";
 import { cn } from "@/lib/utils";
 import { DriverButton } from "./ui/DriverButton";
@@ -47,8 +47,19 @@ export function SignatureCapture({
   const [receivedBy, setReceivedBy] = useState("");
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Full-screen signing mode (field feedback: the inline pad is too small).
+  const [fullscreen, setFullscreen] = useState(false);
 
   // Initialise the pad and keep the canvas crisp on high-DPI screens.
+  //
+  // Sizing is driven by a ResizeObserver (not a mount-time read + window
+  // resize listener) because BOTH of those bit us in the field:
+  //  - at mount the bottom sheet is still animating in, so offsetWidth can be
+  //    0 (especially in the native WebView) → a 0×0 canvas that ignores touch;
+  //  - the iOS keyboard (opened by the receiver-name input) fires window
+  //    resize, and the old handler cleared the pad — wiping the signature.
+  // The observer resizes only on real dimension changes and PRESERVES the ink
+  // by replaying the stroke data after rescaling.
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
@@ -61,23 +72,35 @@ export function SignatureCapture({
     });
     padRef.current = pad;
 
-    const resize = () => {
+    let lastW = 0;
+    let lastH = 0;
+    const applySize = () => {
+      const w = canvas.offsetWidth;
+      const h = canvas.offsetHeight;
+      if (w === 0 || h === 0) return; // not laid out yet — wait for the observer
+      if (w === lastW && h === lastH) return;
+      lastW = w;
+      lastH = h;
       const ratio = Math.max(window.devicePixelRatio || 1, 1);
-      canvas.width = canvas.offsetWidth * ratio;
-      canvas.height = canvas.offsetHeight * ratio;
+      const strokes = pad.toData(); // preserve ink across the resize
+      canvas.width = w * ratio; // resets the 2d transform
+      canvas.height = h * ratio;
       canvas.getContext("2d")?.scale(ratio, ratio);
-      pad.clear(); // resizing wipes the canvas — reset pad state too
-      setHasInk(false);
+      pad.clear();
+      if (strokes.length > 0) pad.fromData(strokes);
+      setHasInk(!pad.isEmpty());
     };
-    resize();
+    applySize();
+
+    const observer = new ResizeObserver(() => applySize());
+    observer.observe(canvas);
 
     const onEnd = () => setHasInk(!pad.isEmpty());
     pad.addEventListener("endStroke", onEnd);
-    window.addEventListener("resize", resize);
 
     return () => {
+      observer.disconnect();
       pad.removeEventListener("endStroke", onEnd);
-      window.removeEventListener("resize", resize);
       pad.off();
       padRef.current = null;
     };
@@ -158,16 +181,65 @@ export function SignatureCapture({
         />
       </label>
 
-      <div className="relative overflow-hidden rounded-2xl border-[1.5px] border-driver-border bg-driver-surface-alt">
-        <canvas
-          ref={canvasRef}
-          className="h-48 w-full touch-none"
-          aria-label="Signature pad (optional)"
-        />
-        {!hasInk ? (
-          <span className="pointer-events-none absolute inset-0 flex items-center justify-center text-[13px] font-semibold text-driver-subtle">
-            Sign here (optional)
-          </span>
+      <div
+        className={cn(
+          fullscreen
+            ? "driver-theme fixed inset-0 z-[100] flex flex-col gap-3 bg-driver-surface p-4 pt-[max(env(safe-area-inset-top),1rem)]"
+            : "contents",
+        )}
+      >
+        {fullscreen ? (
+          <div className="flex items-center justify-between">
+            <span className="text-[15px] font-semibold text-driver-text">
+              Sign here
+            </span>
+            <button
+              type="button"
+              onClick={() => setFullscreen(false)}
+              className="flex items-center gap-1.5 rounded-xl border-[1.5px] border-driver-border px-3 py-1.5 text-[12.5px] font-semibold text-driver-muted"
+              aria-label="Exit full screen"
+            >
+              <Minimize2 className="h-4 w-4" />
+              Done
+            </button>
+          </div>
+        ) : null}
+        <div
+          className={cn(
+            "relative overflow-hidden rounded-2xl border-[1.5px] border-driver-border bg-driver-surface-alt",
+            fullscreen && "flex-1",
+          )}
+        >
+          <canvas
+            ref={canvasRef}
+            className={cn("w-full touch-none", fullscreen ? "h-full" : "h-48")}
+            aria-label="Signature pad (optional)"
+          />
+          {!hasInk ? (
+            <span className="pointer-events-none absolute inset-0 flex items-center justify-center text-[13px] font-semibold text-driver-subtle">
+              Sign here (optional)
+            </span>
+          ) : null}
+          {!fullscreen ? (
+            <button
+              type="button"
+              onClick={() => setFullscreen(true)}
+              className="absolute right-2 top-2 rounded-xl border-[1.5px] border-driver-border bg-driver-surface p-2 text-driver-muted"
+              aria-label="Sign in full screen"
+            >
+              <Maximize2 className="h-4 w-4" />
+            </button>
+          ) : null}
+        </div>
+        {fullscreen ? (
+          <DriverButton
+            variant="outline"
+            onClick={handleClear}
+            disabled={uploading || !hasInk}
+          >
+            <Eraser className="h-4 w-4" strokeWidth={2.4} />
+            Clear
+          </DriverButton>
         ) : null}
       </div>
 

--- a/src/components/Driver/__tests__/DriverTrackingPortal.test.tsx
+++ b/src/components/Driver/__tests__/DriverTrackingPortal.test.tsx
@@ -383,6 +383,63 @@ describe("DriverTrackingPortal (redesigned)", () => {
     expect(screen.getByText(/3 updates queued/i)).toBeInTheDocument();
   });
 
+  describe("end-shift guard", () => {
+    const withDelivery = (delivery: Record<string, unknown>) =>
+      baseCtx({
+        isShiftActive: true,
+        currentShift: { id: "s1", driverId: "driver-1", startTime: new Date() },
+        currentLocation: sampleLocation,
+        activeDeliveries: [
+          {
+            id: "del-1",
+            cateringRequestId: "cr-1",
+            driverId: "driver-1",
+            deliveryLocation: { coordinates: [-122.41, 37.77] },
+            ...delivery,
+          },
+        ],
+      });
+
+    it("disables End shift while a delivery is mid-flight", () => {
+      mockUseDriverTracking.mockReturnValue(
+        withDelivery({ status: DriverStatus.EN_ROUTE_TO_CLIENT }),
+      );
+      renderPortal();
+      expect(
+        screen.getByRole("button", { name: /end shift/i }),
+      ).toBeDisabled();
+      expect(screen.getByText(/1 delivery to finish first/i)).toBeInTheDocument();
+      expect(endShift).not.toHaveBeenCalled();
+    });
+
+    it("disables End shift for an ASSIGNED delivery whose pickup is overdue", () => {
+      mockUseDriverTracking.mockReturnValue(
+        withDelivery({
+          status: DriverStatus.ASSIGNED,
+          scheduledPickupAt: new Date(Date.now() - 60 * 60 * 1000), // 1h ago
+        }),
+      );
+      renderPortal();
+      expect(
+        screen.getByRole("button", { name: /end shift/i }),
+      ).toBeDisabled();
+    });
+
+    it("allows End shift when the only assignment is well in the future", async () => {
+      mockUseDriverTracking.mockReturnValue(
+        withDelivery({
+          status: DriverStatus.ASSIGNED,
+          scheduledPickupAt: new Date(Date.now() + 26 * 60 * 60 * 1000), // tomorrow
+        }),
+      );
+      renderPortal();
+      const button = screen.getByRole("button", { name: /end shift/i });
+      expect(button).toBeEnabled();
+      fireEvent.click(button);
+      await waitFor(() => expect(endShift).toHaveBeenCalled());
+    });
+  });
+
   describe("arrival geofence", () => {
     const shiftCtx = (delivery: Record<string, unknown>) =>
       baseCtx({


### PR DESCRIPTION
## Context — round 2 of the 2026-07-09 night drive test

Three field findings after #483/#484 deployed (test done in the native iOS shell):

1. **Signature pad ignored touch** and is too small.
2. **Native shell landed on the marketing sign-in page** after returning to the app — while the session was still alive (the nav menu offered "Dashboard").
3. **End shift succeeded while another drive was still assigned** for a past pickup time.

## Root causes & changes

**Signature pad (`SignatureCapture.tsx`):**
- The canvas was sized once at mount (`offsetWidth` read) — inside the still-animating bottom sheet that can be **0×0**, especially with WebView timing → a pad that ignores touch. And the `window resize` listener **cleared the ink**; the iOS keyboard (opened by the new receiver-name input) fires exactly that event.
- Now: **ResizeObserver-driven sizing** that skips zero-size layouts, only reacts to real dimension changes, and **preserves strokes** (`toData`/`fromData`) across resizes.
- New **fullscreen signing mode**: expand icon on the pad → full-device canvas with Done/Clear (same canvas node, so ink survives the toggle).

**Sign-in bounce (`sign-in/page.tsx`):** authenticated visitors are redirected server-side to `getDashboardRouteByRole()` (or a validated same-origin `returnTo`). Self-heals the native-shell divergence symptom; the underlying WebView cookie behavior remains tracked separately.

**End-shift guard (`driver-actions.ts` + portal):**
- Server SQL now also blocks on **ASSIGNED orders with pickup ≤ NOW()+2h or overdue** (future-dated assignments don't trap the driver). Privileged `force` override unchanged.
- Portal mirrors the rule client-side: End shift disabled with "N deliveries to finish first" hint; guard backstop in the handler; shift errors now surface as toasts (previously a silently dead button).

## Tests
- Portal: 3 new end-shift guard cases (mid-flight blocks, overdue-ASSIGNED blocks, future-ASSIGNED allows) + existing geofence/signature routing cases — 21/21 green with SignatureCapture suite.
- `pnpm typecheck` + lint green.

## Verify on dev
- Signature: open Confirm pickup in the native shell → draw immediately (no dead pad), type a name (ink survives keyboard), expand to fullscreen and keep drawing.
- Sign-in: visit `/sign-in` while logged in → lands on the role dashboard.
- End shift: with a due/overdue assigned order → button disabled + hint; with only a tomorrow-dated assignment → ends normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)