### PR TITLE
design: improve ServedPartners logo sizing, copy, and mobile layout

### DIFF
--- a/src/components/FoodDelivery/ServedPartners.tsx
+++ b/src/components/FoodDelivery/ServedPartners.tsx
@@ -72,8 +72,9 @@ const ServedPartners: React.FC = () => {
           viewport={{ once: true }}
           transition={{ duration: 0.6 }}
         >
-          <h2 className="mb-3 font-[Montserrat] text-3xl font-black text-gray-800 md:text-4xl lg:text-5xl">
-            We've Proudly Served Top Marketplaces and Companies
+          <h2 className="mb-6 font-[Montserrat] text-3xl leading-[1.8] font-black text-gray-800 md:mb-8 md:text-4xl md:leading-normal lg:text-5xl">
+            We've Proudly Served Top Marketplaces and
+            <span className="mt-1 block md:mt-4">Companies</span>
           </h2>
           <p className="font-[Montserrat] text-base font-medium text-gray-600 md:text-lg">
             ZeroCater, EzCater, Google, Netflix, Apple

--- a/src/components/FoodDelivery/ServedPartners.tsx
+++ b/src/components/FoodDelivery/ServedPartners.tsx
@@ -22,22 +22,28 @@ interface PartnerLogo {
 const ServedPartners: React.FC = () => {
   const partners: PartnerLogo[] = [
     {
-      name: "Zerocater",
+      name: "ZeroCater",
       // Use fit to scale up logo while adding white background to remove borders
+      // Horizontal wordmark scaled up to match visual weight of square icon logos
       image: `${getCloudinaryUrl("food/served/zerocater").replace("/f_auto,q_auto/", "/f_auto,q_auto,b_white,w_600,h_600,c_fit/")}`,
-      alt: "Zerocater logo",
+      alt: "ZeroCater logo",
+      containerClassName: "scale-150",
     },
     {
       name: "EzCater",
       // Use fit to scale up logo while adding white background to remove borders
+      // Horizontal wordmark scaled up to match visual weight of square icon logos
       image: `${getCloudinaryUrl("food/served/ezcater").replace("/f_auto,q_auto/", "/f_auto,q_auto,b_white,w_600,h_600,c_fit/")}`,
       alt: "EzCater logo",
+      containerClassName: "scale-150",
     },
     {
       name: "Google",
       // Use fit with consistent dimensions for uniform sizing
+      // Horizontal wordmark scaled up to match visual weight of square icon logos
       image: `${getCloudinaryUrl("food/served/google").replace("/f_auto,q_auto/", "/f_auto,q_auto,w_600,h_600,c_fit/")}`,
       alt: "Google logo",
+      containerClassName: "scale-150",
     },
     {
       name: "Netflix",
@@ -45,7 +51,7 @@ const ServedPartners: React.FC = () => {
       // Square icon needs constrained height to match horizontal wordmarks
       image: `${getCloudinaryUrl("food/served/netflix").replace("/f_auto,q_auto/", "/f_auto,q_auto,w_600,h_600,c_fit/")}`,
       alt: "Netflix logo",
-      containerClassName: "max-h-16 sm:max-h-20 md:max-h-24 lg:max-h-28",
+      containerClassName: "max-h-20 sm:max-h-24 md:max-h-32 lg:max-h-36",
     },
     {
       name: "Apple",
@@ -67,10 +73,10 @@ const ServedPartners: React.FC = () => {
           transition={{ duration: 0.6 }}
         >
           <h2 className="mb-3 font-[Montserrat] text-3xl font-black text-gray-800 md:text-4xl lg:text-5xl">
-            We Served the Top Marketplace and Company
+            We've Proudly Served Top Marketplaces and Companies
           </h2>
           <p className="font-[Montserrat] text-base font-medium text-gray-600 md:text-lg">
-            Zerocater, EzCater, Google, Netflix, Apple
+            ZeroCater, EzCater, Google, Netflix, Apple
           </p>
         </motion.div>
 
@@ -80,7 +86,7 @@ const ServedPartners: React.FC = () => {
             {partners.map((partner, index) => (
               <motion.div
                 key={partner.name}
-                className="flex items-center justify-center px-2 py-4 sm:px-4"
+                className={`flex items-center justify-center px-2 py-4 sm:px-4 ${index === partners.length - 1 ? "col-span-2 md:col-span-1" : ""}`}
                 initial={{ opacity: 0, scale: 0.9 }}
                 whileInView={{ opacity: 1, scale: 1 }}
                 viewport={{ once: true }}
@@ -90,7 +96,7 @@ const ServedPartners: React.FC = () => {
                 }}
               >
                 <div
-                  className={`relative h-28 w-full min-w-[160px] max-w-[240px] sm:h-32 md:h-40 lg:h-44 ${partner.containerClassName || ""}`}
+                  className={`relative h-36 w-full min-w-[180px] max-w-[280px] sm:h-40 md:h-48 lg:h-52 ${partner.containerClassName || ""}`}
                 >
                   <Image
                     src={partner.image}

--- a/src/components/FoodDelivery/__tests__/ServedPartners.test.tsx
+++ b/src/components/FoodDelivery/__tests__/ServedPartners.test.tsx
@@ -46,11 +46,9 @@ describe("ServedPartners", () => {
     it("renders the main title with correct styling", () => {
       render(<ServedPartners />);
 
-      const title = screen.getByText(
-        "We've Proudly Served Top Marketplaces and Companies",
-      );
+      const title = screen.getByRole("heading", { level: 2 });
       expect(title).toHaveClass(
-        "mb-3",
+        "mb-6",
         "text-3xl",
         "font-black",
         "text-gray-800",
@@ -85,9 +83,7 @@ describe("ServedPartners", () => {
     it("uses Montserrat font for title and subtitle", () => {
       render(<ServedPartners />);
 
-      const title = screen.getByText(
-        "We've Proudly Served Top Marketplaces and Companies",
-      );
+      const title = screen.getByRole("heading", { level: 2 });
       const subtitle = screen.getByText(
         /zerocater, ezcater, google, netflix, apple/i,
       );
@@ -302,7 +298,7 @@ describe("ServedPartners", () => {
       render(<ServedPartners />);
 
       const titleSection = screen
-        .getByText("We've Proudly Served Top Marketplaces and Companies")
+        .getByRole("heading", { level: 2 })
         .closest("div");
       expect(titleSection).toHaveClass("mb-4", "text-center");
     });
@@ -322,8 +318,9 @@ describe("ServedPartners", () => {
       const heading = screen.getByRole("heading", { level: 2 });
       expect(heading).toBeInTheDocument();
       expect(heading).toHaveTextContent(
-        "We've Proudly Served Top Marketplaces and Companies",
+        /we've proudly served top marketplaces and/i,
       );
+      expect(heading).toHaveTextContent(/companies/i);
     });
 
     it("all images have descriptive alt text", () => {
@@ -397,9 +394,7 @@ describe("ServedPartners", () => {
     it("applies responsive title sizing", () => {
       render(<ServedPartners />);
 
-      const title = screen.getByText(
-        "We've Proudly Served Top Marketplaces and Companies",
-      );
+      const title = screen.getByRole("heading", { level: 2 });
       expect(title).toHaveClass("text-3xl", "md:text-4xl", "lg:text-5xl");
     });
 
@@ -466,7 +461,7 @@ describe("ServedPartners", () => {
       render(<ServedPartners />);
 
       const titleSection = screen
-        .getByText("We've Proudly Served Top Marketplaces and Companies")
+        .getByRole("heading", { level: 2 })
         .closest("div");
       expect(titleSection).toHaveClass("mb-4");
 
@@ -522,9 +517,7 @@ describe("ServedPartners", () => {
     it("uses correct font weights for title", () => {
       render(<ServedPartners />);
 
-      const title = screen.getByText(
-        "We've Proudly Served Top Marketplaces and Companies",
-      );
+      const title = screen.getByRole("heading", { level: 2 });
       expect(title).toHaveClass("font-black");
     });
 
@@ -540,9 +533,7 @@ describe("ServedPartners", () => {
     it("applies correct text colors", () => {
       render(<ServedPartners />);
 
-      const title = screen.getByText(
-        "We've Proudly Served Top Marketplaces and Companies",
-      );
+      const title = screen.getByRole("heading", { level: 2 });
       const subtitle = screen.getByText(
         /zerocater, ezcater, google, netflix, apple/i,
       );

--- a/src/components/FoodDelivery/__tests__/ServedPartners.test.tsx
+++ b/src/components/FoodDelivery/__tests__/ServedPartners.test.tsx
@@ -38,7 +38,7 @@ describe("ServedPartners", () => {
 
       const title = screen.getByRole("heading", {
         level: 2,
-        name: /we served the top marketplace and company/i,
+        name: /we've proudly served top marketplaces and companies/i,
       });
       expect(title).toBeInTheDocument();
     });
@@ -47,7 +47,7 @@ describe("ServedPartners", () => {
       render(<ServedPartners />);
 
       const title = screen.getByText(
-        "We Served the Top Marketplace and Company",
+        "We've Proudly Served Top Marketplaces and Companies",
       );
       expect(title).toHaveClass(
         "mb-3",
@@ -86,7 +86,7 @@ describe("ServedPartners", () => {
       render(<ServedPartners />);
 
       const title = screen.getByText(
-        "We Served the Top Marketplace and Company",
+        "We've Proudly Served Top Marketplaces and Companies",
       );
       const subtitle = screen.getByText(
         /zerocater, ezcater, google, netflix, apple/i,
@@ -125,7 +125,7 @@ describe("ServedPartners", () => {
       render(<ServedPartners />);
 
       const expectedPartners = [
-        "Zerocater logo",
+        "ZeroCater logo",
         "EzCater logo",
         "Google logo",
         "Netflix logo",
@@ -154,10 +154,10 @@ describe("ServedPartners", () => {
       });
     });
 
-    it("applies Cloudinary transformations to Zerocater logo", () => {
+    it("applies Cloudinary transformations to ZeroCater logo", () => {
       render(<ServedPartners />);
 
-      const zerocaterImg = screen.getByAltText("Zerocater logo");
+      const zerocaterImg = screen.getByAltText("ZeroCater logo");
       // The component applies b_white,w_600,h_600,c_fit transformations
       // Since we're mocking getCloudinaryUrl, we just verify the image is present
       expect(zerocaterImg).toBeInTheDocument();
@@ -213,7 +213,7 @@ describe("ServedPartners", () => {
 
       const images = screen.getAllByRole("img");
       const expectedOrder = [
-        "Zerocater logo",
+        "ZeroCater logo",
         "EzCater logo",
         "Google logo",
         "Netflix logo",
@@ -251,20 +251,20 @@ describe("ServedPartners", () => {
       render(<ServedPartners />);
 
       const imageContainers = document.querySelectorAll(
-        ".relative.h-28.w-full",
+        ".relative.h-36.w-full",
       );
       expect(imageContainers.length).toBeGreaterThan(0);
 
       imageContainers.forEach((container) => {
         expect(container).toHaveClass(
           "relative",
-          "h-28",
+          "h-36",
           "w-full",
-          "min-w-[160px]",
-          "max-w-[240px]",
-          "sm:h-32",
-          "md:h-40",
-          "lg:h-44",
+          "min-w-[180px]",
+          "max-w-[280px]",
+          "sm:h-40",
+          "md:h-48",
+          "lg:h-52",
         );
       });
     });
@@ -302,7 +302,7 @@ describe("ServedPartners", () => {
       render(<ServedPartners />);
 
       const titleSection = screen
-        .getByText("We Served the Top Marketplace and Company")
+        .getByText("We've Proudly Served Top Marketplaces and Companies")
         .closest("div");
       expect(titleSection).toHaveClass("mb-4", "text-center");
     });
@@ -322,7 +322,7 @@ describe("ServedPartners", () => {
       const heading = screen.getByRole("heading", { level: 2 });
       expect(heading).toBeInTheDocument();
       expect(heading).toHaveTextContent(
-        "We Served the Top Marketplace and Company",
+        "We've Proudly Served Top Marketplaces and Companies",
       );
     });
 
@@ -398,7 +398,7 @@ describe("ServedPartners", () => {
       render(<ServedPartners />);
 
       const title = screen.getByText(
-        "We Served the Top Marketplace and Company",
+        "We've Proudly Served Top Marketplaces and Companies",
       );
       expect(title).toHaveClass("text-3xl", "md:text-4xl", "lg:text-5xl");
     });
@@ -415,9 +415,9 @@ describe("ServedPartners", () => {
     it("applies responsive height to image containers", () => {
       render(<ServedPartners />);
 
-      const imageContainers = document.querySelectorAll(".relative.h-28");
+      const imageContainers = document.querySelectorAll(".relative.h-36");
       imageContainers.forEach((container) => {
-        expect(container).toHaveClass("h-28", "sm:h-32", "md:h-40", "lg:h-44");
+        expect(container).toHaveClass("h-36", "sm:h-40", "md:h-48", "lg:h-52");
       });
     });
 
@@ -466,7 +466,7 @@ describe("ServedPartners", () => {
       render(<ServedPartners />);
 
       const titleSection = screen
-        .getByText("We Served the Top Marketplace and Company")
+        .getByText("We've Proudly Served Top Marketplaces and Companies")
         .closest("div");
       expect(titleSection).toHaveClass("mb-4");
 
@@ -495,7 +495,7 @@ describe("ServedPartners", () => {
     it("includes marketplace partners", () => {
       render(<ServedPartners />);
 
-      const marketplaces = ["Zerocater", "EzCater"];
+      const marketplaces = ["ZeroCater", "EzCater"];
       marketplaces.forEach((marketplace) => {
         expect(screen.getByAltText(`${marketplace} logo`)).toBeInTheDocument();
       });
@@ -523,7 +523,7 @@ describe("ServedPartners", () => {
       render(<ServedPartners />);
 
       const title = screen.getByText(
-        "We Served the Top Marketplace and Company",
+        "We've Proudly Served Top Marketplaces and Companies",
       );
       expect(title).toHaveClass("font-black");
     });
@@ -541,7 +541,7 @@ describe("ServedPartners", () => {
       render(<ServedPartners />);
 
       const title = screen.getByText(
-        "We Served the Top Marketplace and Company",
+        "We've Proudly Served Top Marketplaces and Companies",
       );
       const subtitle = screen.getByText(
         /zerocater, ezcater, google, netflix, apple/i,


### PR DESCRIPTION
## Summary

- **Scale up horizontal wordmark logos** (ZeroCater, EzCater, Google) with CSS `scale-150` transform to match the visual weight of the square icon logos (Netflix, Apple)
- **Center Apple logo on mobile** — the 5th logo in a 2-column grid was left-aligned; now uses `col-span-2 md:col-span-1` to center it on mobile while preserving the 3-col/5-col layout on larger screens
- **Restore Netflix logo sizing** to its original `max-h` constraints (`max-h-20 sm:max-h-24 md:max-h-32 lg:max-h-36`)
- **Enlarge base logo containers** from `h-28`→`h-36`, `min-w-[160px]`→`min-w-[180px]`, `max-w-[240px]`→`max-w-[280px]` (with proportional responsive bumps)
- **Fix ZeroCater casing** — "Zerocater" → "ZeroCater" in partner name, alt text, and subtitle
- **Update section heading** — "We Served the Top Marketplace and Company" → "We've Proudly Served Top Marketplaces and Companies"
- **Improve heading line spacing** — break "Companies" onto its own line with a block `<span>` and explicit `mt-1 md:mt-4` margin, plus `leading-[1.8]` on mobile (reset via `md:leading-normal`) so all wrapped heading lines have consistent breathing room and the "i" dot is clearly visible
- **Increase heading-to-subtitle gap** — `mb-3` → `mb-6` / `md:mb-8` for better visual separation

## Changed files

| File | What changed |
|---|---|
| `src/components/FoodDelivery/ServedPartners.tsx` | Logo sizing, copy, casing, mobile layout, heading line spacing |
| `src/components/FoodDelivery/__tests__/ServedPartners.test.tsx` | Tests updated to match new copy, casing, container dimensions, and heading markup |

## Testing performed

- **Unit tests**: All 52 tests in `ServedPartners.test.tsx` pass (`pnpm test -- src/components/FoodDelivery/__tests__/ServedPartners.test.tsx`)
- **TypeScript**: `pnpm typecheck` passes
- **Lint**: `pnpm lint` passes (no new warnings)
- **Prisma**: Schema validation passes
- **Manual testing**: Verified logo visual weight balance, Apple centering on mobile, and heading line spacing on both mobile and desktop viewports

## Database migrations

None — this is a UI-only change.

## Breaking changes

None.

## Reviewer checklist

- [ ] Verify horizontal wordmark logos (ZeroCater, EzCater, Google) look visually balanced with Netflix/Apple at desktop, tablet, and mobile breakpoints
- [ ] Verify Apple logo centers properly on mobile (2-column grid) and sits normally at md+ breakpoints
- [ ] Confirm `scale-150` doesn't cause logo overflow or clipping issues at small viewports
- [ ] Verify heading line spacing — "i" dot in "Companies" and "Marketplaces" is clearly visible on mobile
- [ ] Verify heading spacing resets to normal on desktop (`md:leading-normal`)
- [ ] Verify the updated heading copy reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)