### PR TITLE
ci: raise Unit Tests job timeout 25 → 40 min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,11 @@ jobs:
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # 2026-07-29: runtime crept past the old 25-min cap after the 7/28 merge batch
+    # (was ~12 min on 7/10). The suite is healthy — 8346 tests pass locally in
+    # ~2.7 min on 10 cores (~27 core-min), which is ~14 min ideal on a 2-core
+    # runner before overhead. Raise the cap instead of masking a hang.
+    timeout-minutes: 40
     # REA-285: Threshold-based enforcement at 95%
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,18 +181,23 @@ jobs:
       - name: Upload coverage reports
         uses: actions/upload-artifact@v4
         if: always()
+        # Non-fatal: the org artifact-storage quota being full must not fail a
+        # green test run (it currently does, repo-wide). 7-day retention — the
+        # 3280-file coverage tree on every run is the main quota pressure.
+        continue-on-error: true
         with:
           name: coverage-report
           path: coverage/
-          retention-days: 30
+          retention-days: 7
 
       - name: Upload Jest results
         uses: actions/upload-artifact@v4
         if: always()
+        continue-on-error: true
         with:
           name: jest-results
           path: jest-results.json
-          retention-days: 30
+          retention-days: 7
 
       - name: Generate test summary
         if: always()


### PR DESCRIPTION
Unit Tests has blown the 25-minute job cap on **every** run since the 7/28 merge batch — including on `development` itself (run [30383394236](https://github.com/ReadySet1/ready-set/actions/runs/30383394236)) — which cancels the job mid-run and turns CI red on unrelated PRs (e.g. #491, #493).

**Why raising the cap is safe (this is creep, not a hang):**
- The full suite passes locally: **8346 passed / 278 skipped in 161 s** with coverage (10 cores).
- ~27 core-minutes of work ≈ ~14 min ideal on GitHub's 2-core runner; the last green CI run (7/10) already took ~12 min, i.e. the cap had almost no headroom.
- The CI jest cache is warm (12 MB, hit today) — cold cache ruled out.

The 7/28 batch (#479/#487/#488) added enough work (new Try Hungry calculator suites + dependency changes) to push real runtime past 25. Follow-up worth considering separately: `jest --shard` across 2 runners to bring wall-clock back down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)