### PR TITLE
fix: remove redundant #vendor-hero URL fragment from CTA links

### DIFF
--- a/src/components/FlowersDelivery/FlowersAbout.tsx
+++ b/src/components/FlowersDelivery/FlowersAbout.tsx
@@ -106,7 +106,7 @@ const FlowersAbout: React.FC = () => {
               transition={{ duration: 0.6, delay: 0.8 }}
             >
               <Link
-                href="/vendor-hero#vendor-hero"
+                href="/vendor-hero"
                 className="inline-block rounded-full bg-yellow-400 px-12 py-4 text-lg font-extrabold text-gray-900 transition-all hover:-translate-y-0.5 hover:bg-yellow-500 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400 focus-visible:ring-offset-2"
               >
                 How Our Service Works

--- a/src/components/FlowersDelivery/__tests__/FlowersAbout.test.tsx
+++ b/src/components/FlowersDelivery/__tests__/FlowersAbout.test.tsx
@@ -121,7 +121,7 @@ describe("FlowersAbout", () => {
         name: /how our service works/i,
       });
       expect(link).toBeInTheDocument();
-      expect(link).toHaveAttribute("href", "/vendor-hero#vendor-hero");
+      expect(link).toHaveAttribute("href", "/vendor-hero");
     });
   });
 

--- a/src/components/FoodDelivery/CateringAbout.tsx
+++ b/src/components/FoodDelivery/CateringAbout.tsx
@@ -145,7 +145,7 @@ const CateringAbout: React.FC = () => {
               transition={{ duration: 0.6, delay: 0.8 }}
             >
               <Link
-                href="/vendor-hero#vendor-hero"
+                href="/vendor-hero"
                 className="inline-block rounded-lg bg-yellow-400 px-12 py-4 font-[Montserrat] text-lg font-extrabold text-gray-800 shadow-md transition-all hover:-translate-y-0.5 hover:bg-yellow-500 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-500 focus-visible:ring-offset-2"
               >
                 How Our Service Works

--- a/src/components/FoodDelivery/__tests__/CateringAbout.test.tsx
+++ b/src/components/FoodDelivery/__tests__/CateringAbout.test.tsx
@@ -299,7 +299,7 @@ describe("CateringAbout", () => {
       render(<CateringAbout />);
 
       const link = screen.getByRole("link", { name: "How Our Service Works" });
-      expect(link).toHaveAttribute("href", "/vendor-hero#vendor-hero");
+      expect(link).toHaveAttribute("href", "/vendor-hero");
     });
 
     it("renders the link with correct text and styling", () => {


### PR DESCRIPTION
## Summary

- Remove the redundant `#vendor-hero` fragment from two cross-page "How Our Service Works" CTA links that navigate to `/vendor-hero`
- The fragment duplicated the route slug, producing `readysetllc.com/vendor-hero#vendor-hero` in the address bar — it was not a shareable deep-link and served no navigation purpose
- Update corresponding test assertions to match the corrected href

## Changed files

| File | Change |
|---|---|
| `src/components/FoodDelivery/CateringAbout.tsx` | `href="/vendor-hero#vendor-hero"` → `href="/vendor-hero"` |
| `src/components/FlowersDelivery/FlowersAbout.tsx` | `href="/vendor-hero#vendor-hero"` → `href="/vendor-hero"` |
| `src/components/FoodDelivery/__tests__/CateringAbout.test.tsx` | Update expected href in assertion |
| `src/components/FlowersDelivery/__tests__/FlowersAbout.test.tsx` | Update expected href in assertion |

## What is NOT changed

- `src/app/(site)/vendor-hero/page.tsx` — `<VendorHero id="vendor-hero" />` remains untouched; the `id` is load-bearing for the `aria-labelledby` → `#vendor-hero-heading` association in the hero section
- `alternates.canonical` in the page metadata is already `"/vendor-hero"` (correct)
- No className, animation props, or motion.div wrappers were modified

## Testing performed

- **Unit tests**: `pnpm test:ci` — `CateringAbout.test.tsx` and `FlowersAbout.test.tsx` both pass with updated assertions (8345 tests passed, 415 suites passed)
- **Pre-push checks**: `pnpm pre-push-check` — typecheck, lint, prisma validate all pass with no new errors
- **Grep verification**:
  - `rg "#vendor-hero" src/` → 0 results (fragment fully removed)
  - `rg 'id="vendor-hero"' src/` → still present in `vendor-hero/page.tsx` (accessibility preserved)

## Database migrations

None — this is a front-end-only href fix.

## Breaking changes

None.

## Reviewer checklist

- [ ] Verify the `id="vendor-hero"` prop on `<VendorHero>` was **not** removed (accessibility concern)
- [ ] Confirm no other links in the codebase still use `#vendor-hero` as a fragment
- [ ] Check that the two updated test assertions match the new href value exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)