### PR TITLE
ci: stop artifact quota and lapsed GHAS from painting every PR red

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,18 +348,22 @@ jobs:
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
         if: always()
+        # Non-fatal: the org artifact-storage quota being full must not fail a
+        # green test run. Same treatment as the unit-test uploads above.
+        continue-on-error: true
         with:
           name: playwright-report
           path: playwright-report/
-          retention-days: 30
+          retention-days: 7
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: always()
+        continue-on-error: true
         with:
           name: e2e-test-results
           path: test-results/
-          retention-days: 30
+          retention-days: 7
 
   build-check:
     name: Build Check

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -8,6 +8,15 @@ jobs:
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest
+    # dependency-review-action requires GitHub Advanced Security on private
+    # repos. The GHAS licence lapsed ~2026-07-22, so the action hard-errors
+    # ("Dependency review is not supported on this repository") on every PR,
+    # painting the whole repo red and mailing a failure for each run.
+    # Gate it on a repo variable instead of deleting the workflow: set
+    # GHAS_ENABLED=true (Settings → Secrets and variables → Actions → Variables)
+    # the moment GHAS is restored and this gate returns to enforcing.
+    # Advisory coverage meanwhile: the "NPM Security Audit" job in security.yml.
+    if: vars.GHAS_ENABLED == 'true'
     permissions:
       contents: read
 


### PR DESCRIPTION
## Why

Every PR in this repo currently shows red checks that have nothing to do with the code in the PR, which trains everyone to ignore CI signal and mails a build-failure notification per run.

Root causes, both confirmed against PR #497's run:

**1. `E2E Tests` — red on a passing test run.** Job [91011650385](https://github.com/ReadySet1/ready-set/actions/runs/30584216560/job/91011650385): step 10 `Run E2E tests` **succeeded**, secrets are configured (step 11 `E2E Tests Skipped` was skipped). The only failing step was 12, `Upload Playwright report`:

```
##[error]Failed to CreateArtifact: Artifact storage quota has been hit.
Unable to upload any new artifacts.
```

A full storage bucket is not a test failure. Note this also means the `TEST_DRIVER_EMAIL` missing-secret theory in `docs/STATUS.md` is **stale** — that secret is present and E2E passes.

**2. `Dependency Review` — fails repo-wide.** `dependency-review-action` requires GitHub Advanced Security on private repos, and the GHAS licence lapsed ~2026-07-22:

```
##[error]Dependency review is not supported on this repository.
Please ensure that Dependency graph is enabled along with GitHub Advanced Security
```

## What changed

- **`ci.yml`** — the two E2E artifact uploads get `continue-on-error: true` and `retention-days: 7`, exactly the treatment #495 already applied to the unit-test uploads. Shorter retention also lowers the quota pressure that caused this.
- **`dependency-review.yml`** — the job is gated behind `if: vars.GHAS_ENABLED == 'true'`. The variable does not exist today, so the job **skips** (grey, no email) instead of hard-failing. Deleting the workflow would have lost the gate permanently; this keeps it one variable away from returning. Advisory coverage meanwhile stays with the `NPM Security Audit` job in `security.yml`, which reads the lockfile and does not need GHAS.

## Follow-ups NOT in this PR

- **Restore GHAS** (org admin, paid) → then set repo variable `GHAS_ENABLED=true` and Dependency Review enforces again.
- **Free the artifact quota** — this repo alone holds 187 active artifacts (~0.67 GB); the quota is account-wide, so it needs a look across the org.
- **`Vercel` red** — `fersanz-87` has no Vercel org access, so his commits get a team-invite URL instead of a deployment. Needs a Vercel team invite, not a code change.

## Risk

Workflow-only; no application code touched. Worst case if the gate is wrong: Dependency Review stays skipped, which is exactly today's effective coverage — it has not produced a usable result since 7/22.