### PR TITLE
security: bump fast-uri override 4.1.1 → 4.1.2 (GHSA-7p8r-x3mc-p8w7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -341,7 +341,7 @@
       "protocol-buffers-schema@<3.6.1": ">=3.6.1 <4",
       "@babel/plugin-transform-modules-systemjs": ">=7.29.4 <8.0.0",
       "@grpc/grpc-js": ">=1.14.4 <2",
-      "fast-uri": ">=4.1.1 <5",
+      "fast-uri": ">=4.1.2 <5",
       "fast-xml-builder": ">=1.1.7 <2",
       "form-data@<4.0.6": ">=4.0.6 <5",
       "sanity>vite": ">=8.0.16 <9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,7 +72,7 @@ overrides:
   protocol-buffers-schema@<3.6.1: '>=3.6.1 <4'
   '@babel/plugin-transform-modules-systemjs': '>=7.29.4 <8.0.0'
   '@grpc/grpc-js': '>=1.14.4 <2'
-  fast-uri: '>=4.1.1 <5'
+  fast-uri: '>=4.1.2 <5'
   fast-xml-builder: '>=1.1.7 <2'
   form-data@<4.0.6: '>=4.0.6 <5'
   sanity>vite: '>=8.0.16 <9'
@@ -7685,8 +7685,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -18793,7 +18793,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -20566,7 +20566,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:


### PR DESCRIPTION
Clears the **high**-severity advisory blocking the `development` → `main` promotion PR #503.

## The advisory
**[GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7)** — *fast-uri vulnerable to host confusion via backslash authority introducer*, HIGH, published **2026-08-03T19:16Z**.

| | |
|---|---|
| Vulnerable range | `>=4.0.0 <4.1.2` |
| First patched | **4.1.2** |
| `main` currently resolves | `4.0.0` → **vulnerable** |
| `development` currently resolves | `4.1.1` → **vulnerable** |
| After this PR | `4.1.2` → clean |

## Why it slipped through
The phase-3 override sweep (#500) floored `fast-uri` at `>=4.1.1 <5` on 08-03. The advisory published **the same evening**, so the sweep landed on a version that turned vulnerable hours later. Nothing was done wrong — this is advisory timing, and exactly what the bounded-override strategy is supposed to make cheap to fix.

Worth being precise: **this is not a regression the sweep introduced.** `main`'s `4.0.0` sits in the same vulnerable range. Both branches were exposed; this fixes both.

## The change
One line — floor raised to `4.1.2`, the `<5` ceiling from the sweep preserved:

```diff
-      "fast-uri": ">=4.1.1 <5",
+      "fast-uri": ">=4.1.2 <5",
```

Lockfile delta is **5 lines, all `fast-uri`** — no other package changed resolution. No source changes.

## How it was caught
`Dependency Review` on PR #503 (`fail-on-severity: high`). That check earns its keep here — `NPM Security Audit` passed on the same tree.