### PR TITLE
fix: resolve issues found in Fernando's 2026-08-06 test drive

### DIFF
--- a/src/app/actions/tracking/__tests__/driver-actions-delivery-count.test.ts
+++ b/src/app/actions/tracking/__tests__/driver-actions-delivery-count.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for the delivery_count recompute in endDriverShift.
+ *
+ * The AFTER trigger on `deliveries` only fires on delivery writes, so shifts
+ * whose deliveries were mirrored before shift linkage existed (or with the
+ * uppercase status casing the orders PATCH writes, e.g. 'COMPLETED') would
+ * close with a stale count. Ending a shift must recompute delivery_count
+ * directly from the deliveries table, case-insensitively, counting both
+ * 'delivered' and 'completed'.
+ */
+
+jest.mock("@/utils/prismaDB", () => ({
+  prisma: {
+    $queryRawUnsafe: jest.fn(),
+    $executeRawUnsafe: jest.fn(),
+  },
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("@/lib/auth-middleware", () => ({ withAuth: jest.fn() }));
+jest.mock("@/lib/auth/driver-ownership", () => ({
+  callerMayActOnDriver: jest.fn(),
+  getActionCaller: jest.fn(),
+}));
+jest.mock("@/services/tracking/tracking-settings", () => ({
+  getTrackingSettings: jest.fn(),
+}));
+jest.mock("@/services/tracking/mileage", () => ({
+  calculateShiftMileage: jest.fn(),
+  calculateShiftMileageWithBreakdown: jest.fn(),
+  calculateShiftMileageWithValidation: jest.fn(),
+}));
+jest.mock("@/lib/rate-limiting/location-rate-limiter", () => ({
+  locationRateLimiter: {
+    configure: jest.fn(),
+    checkAndRecordLimit: jest.fn(),
+  },
+  RateLimitExceededError: class RateLimitExceededError extends Error {},
+}));
+jest.mock("@/lib/cache/driver-metadata-cache", () => ({
+  driverMetadataCache: { get: jest.fn(), set: jest.fn() },
+}));
+jest.mock("@/lib/logging/realtime-logger", () => ({
+  realtimeLogger: {
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    rateLimit: jest.fn(),
+  },
+}));
+jest.mock("@/lib/realtime/stale-detection", () => ({
+  staleLocationDetector: { recordLocation: jest.fn(), setStaleThreshold: jest.fn() },
+}));
+
+import { endDriverShift } from "../driver-actions";
+import { prisma } from "@/utils/prismaDB";
+import {
+  callerMayActOnDriver,
+  getActionCaller,
+} from "@/lib/auth/driver-ownership";
+import { getTrackingSettings } from "@/services/tracking/tracking-settings";
+import { calculateShiftMileage } from "@/services/tracking/mileage";
+import { TRACKING_SETTINGS_DEFAULTS } from "@/types/tracking-settings";
+
+const mockQueryRaw = prisma.$queryRawUnsafe as jest.Mock;
+const mockExecuteRaw = prisma.$executeRawUnsafe as jest.Mock;
+const mockMayAct = callerMayActOnDriver as jest.Mock;
+const mockGetCaller = getActionCaller as jest.Mock;
+const mockGetSettings = getTrackingSettings as jest.Mock;
+const mockMileage = calculateShiftMileage as jest.Mock;
+
+const SHIFT_ID = "22222222-2222-4222-8222-222222222222";
+const DRIVER_ID = "11111111-1111-4111-8111-111111111111";
+
+const endLocation = {
+  driverId: DRIVER_ID,
+  coordinates: { lat: 37.77, lng: -122.41 },
+  accuracy: 10,
+  speed: 0,
+  heading: 0,
+  isMoving: false,
+  activityType: "stationary" as const,
+  timestamp: new Date(),
+} as any;
+
+/** Route the two $queryRawUnsafe calls endDriverShift makes. */
+function mockEndShiftQueries(blockingCount: bigint) {
+  mockQueryRaw.mockImplementation((sql: string) => {
+    if (sql.includes("FROM driver_shifts")) {
+      return Promise.resolve([{ driver_id: DRIVER_ID, status: "active" }]);
+    }
+    if (sql.includes("AS n")) {
+      return Promise.resolve([{ n: blockingCount }]);
+    }
+    return Promise.resolve([]);
+  });
+}
+
+const findRecomputeCall = () =>
+  mockExecuteRaw.mock.calls.find(
+    ([sql]) => typeof sql === "string" && sql.includes("delivery_count"),
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockMayAct.mockResolvedValue(true);
+  mockGetCaller.mockResolvedValue({ isPrivileged: false });
+  mockExecuteRaw.mockResolvedValue(undefined);
+  mockGetSettings.mockResolvedValue(TRACKING_SETTINGS_DEFAULTS);
+  mockMileage.mockResolvedValue({
+    totalMiles: 12,
+    gpsDistanceMiles: 12,
+    mileageSource: "gps",
+    warnings: [],
+  });
+});
+
+describe("endDriverShift delivery_count recompute", () => {
+  it("recomputes delivery_count from the deliveries table when closing", async () => {
+    mockEndShiftQueries(0n);
+
+    const res = await endDriverShift(SHIFT_ID, endLocation);
+    expect(res.success).toBe(true);
+
+    const recompute = findRecomputeCall();
+    expect(recompute).toBeDefined();
+    const [sql, ...params] = recompute!;
+    // Case-insensitive, counts both terminal spellings, honors soft delete,
+    // and scopes to this shift via a bound parameter.
+    expect(sql).toContain("LOWER(status) IN ('delivered','completed')");
+    expect(sql).toContain("deleted_at IS NULL");
+    expect(sql).toContain("shift_id = $1::uuid");
+    expect(params).toEqual([SHIFT_ID]);
+  });
+
+  it("does not recompute when the end-shift guard blocks", async () => {
+    mockEndShiftQueries(2n);
+
+    const res = await endDriverShift(SHIFT_ID, endLocation);
+    expect(res.success).toBe(false);
+
+    expect(findRecomputeCall()).toBeUndefined();
+  });
+
+  it("does not recompute when the shift is not active", async () => {
+    mockQueryRaw.mockResolvedValue([]);
+
+    const res = await endDriverShift(SHIFT_ID, endLocation);
+    expect(res.success).toBe(false);
+
+    expect(findRecomputeCall()).toBeUndefined();
+  });
+});

--- a/src/app/actions/tracking/driver-actions.ts
+++ b/src/app/actions/tracking/driver-actions.ts
@@ -214,6 +214,26 @@ export async function endDriverShift(
       }
     }
 
+    // Recompute delivery_count from the deliveries table before closing. The
+    // AFTER trigger on `deliveries` only fires on delivery writes, so rows
+    // mirrored before shift linkage existed — or with the uppercase status
+    // casing the orders PATCH writes (e.g. 'COMPLETED') — would otherwise
+    // close the shift with a stale count. Case-insensitive, and both
+    // 'delivered' and 'completed' count as a completed delivery.
+    await prisma.$executeRawUnsafe(`
+      UPDATE driver_shifts
+      SET
+        delivery_count = (
+          SELECT COUNT(*)
+          FROM deliveries
+          WHERE shift_id = $1::uuid
+            AND LOWER(status) IN ('delivered','completed')
+            AND deleted_at IS NULL
+        ),
+        updated_at = NOW()
+      WHERE id = $1::uuid
+    `, shiftId);
+
     // Always record the end location in the database first so that the
     // mileage calculation window has a proper closing point.
     await prisma.$executeRawUnsafe(`

--- a/src/app/api/orders/[order_number]/files/route.ts
+++ b/src/app/api/orders/[order_number]/files/route.ts
@@ -3,6 +3,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
 import { STORAGE_BUCKETS } from '@/utils/file-service';
+import { POD_BUCKET_NAME } from '@/utils/supabase/storage';
+import { mergeSignedUrlMaps, splitFilePathsByBucket } from '@/utils/file-bucket-split';
 import { DEFAULT_SIGNED_URL_EXPIRATION } from '@/config/file-config';
 import { prisma } from '@/utils/prismaDB';
 import { UserType } from "@/types/prisma";
@@ -156,17 +158,31 @@ export async function GET(
     const { getSignedUrlCache } = await import('@/lib/signed-url-cache');
     const cache = getSignedUrlCache();
 
-    // Get all file paths that need signed URLs
-    const filePathsNeeded = files
-      .filter(file => file.filePath)
-      .map(file => file.filePath as string);
+    // POD photos and pickup signatures live in the dedicated
+    // 'delivery-proofs' bucket; everything else lives in the default
+    // 'fileUploader' bucket. Split per bucket, sign each non-empty group
+    // against its own bucket, then merge so the path -> URL lookup (and the
+    // response shape) is unchanged.
+    const { podPaths, defaultPaths } = splitFilePathsByBucket(files);
 
-    // Batch fetch signed URLs with caching
-    const signedUrlMap = await cache.getBatchSignedUrls(
-      STORAGE_BUCKETS.DEFAULT,
-      filePathsNeeded,
-      DEFAULT_SIGNED_URL_EXPIRATION
-    );
+    const emptyMap = new Map<string, string>();
+    const [defaultUrls, podUrls] = await Promise.all([
+      defaultPaths.length > 0
+        ? cache.getBatchSignedUrls(
+            STORAGE_BUCKETS.DEFAULT,
+            defaultPaths,
+            DEFAULT_SIGNED_URL_EXPIRATION
+          )
+        : Promise.resolve(emptyMap),
+      podPaths.length > 0
+        ? cache.getBatchSignedUrls(
+            POD_BUCKET_NAME,
+            podPaths,
+            DEFAULT_SIGNED_URL_EXPIRATION
+          )
+        : Promise.resolve(emptyMap),
+    ]);
+    const signedUrlMap = mergeSignedUrlMaps(defaultUrls, podUrls);
 
     // Map signed URLs back to files
     const filesWithSignedUrls = files.map(file => {

--- a/src/app/api/orders/[order_number]/route.ts
+++ b/src/app/api/orders/[order_number]/route.ts
@@ -30,6 +30,7 @@ import {
   DRIVER_STATUS_TO_PARTNER_LIFECYCLE,
 } from '@/lib/services/partnerWebhookService';
 import { runAfterResponse } from '@/lib/api/after-response';
+import { resolveActiveShiftIdForDriver } from '@/services/tracking/active-shift';
 
 // Map DriverStatus to dispatch notification status
 const DRIVER_STATUS_TO_DISPATCH_STATUS: Record<string, string> = {
@@ -663,7 +664,13 @@ export async function PATCH(
     // here (from existingOrder — the update never changes dispatch).
     const dbOrderNumber = (existingOrder as any).orderNumber as string;
     let mirror:
-      | { field: string; now: Date; driverId: string | null; deliveryAddress: string }
+      | {
+          field: string;
+          now: Date;
+          driverId: string | null;
+          shiftId: string | null;
+          deliveryAddress: string;
+        }
       | null = null;
     if (driverStatus) {
       const timestampField = getDeliveryTimestampField(driverStatus);
@@ -680,10 +687,16 @@ export async function PATCH(
           });
           deliveryDriverId = driverRecord?.id ?? null;
         }
+        // Stamp the driver's ACTIVE shift on the mirror so the
+        // delivery-count trigger can attribute the delivery to the shift.
+        // driver_shifts.driver_id references drivers.id (same as
+        // deliveries.driver_id), NOT the dispatch's profile id.
+        const deliveryShiftId = await resolveActiveShiftIdForDriver(deliveryDriverId);
         mirror = {
           field: timestampField,
           now,
           driverId: deliveryDriverId,
+          shiftId: deliveryShiftId,
           deliveryAddress: (existingOrder as any).deliveryAddress?.street1 ?? '',
         };
         justSetTimestamp = { field: timestampField, value: now };
@@ -740,11 +753,15 @@ export async function PATCH(
             [mirror.field]: mirror.now,
             status: driverStatus,
             ...(mirror.driverId ? { driverId: mirror.driverId } : {}),
+            // Only stamp the shift when resolved — never clear an existing
+            // linkage on a later transition where the shift already ended.
+            ...(mirror.shiftId ? { shiftId: mirror.shiftId } : {}),
           },
           create: {
             orderNumber: dbOrderNumber,
             deliveryAddress: mirror.deliveryAddress,
             driverId: mirror.driverId,
+            shiftId: mirror.shiftId,
             status: driverStatus,
             [mirror.field]: mirror.now,
           },

--- a/src/hooks/tracking/__tests__/useTrackingSettings.test.tsx
+++ b/src/hooks/tracking/__tests__/useTrackingSettings.test.tsx
@@ -1,11 +1,28 @@
 import React, { ReactNode } from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useTrackingSettings } from '../useTrackingSettings';
 import { TRACKING_SETTINGS_DEFAULTS } from '@/types/tracking-settings';
 
 const mockFetch = jest.fn();
 global.fetch = mockFetch as unknown as typeof fetch;
+
+// Supabase browser client — the hook must attach the session's bearer token
+// to its request and must not poll at all when there is no session.
+const mockGetSession = jest.fn();
+const mockUnsubscribe = jest.fn();
+const mockOnAuthStateChange = jest.fn(() => ({
+  data: { subscription: { unsubscribe: mockUnsubscribe } },
+}));
+
+jest.mock('@/utils/supabase/client', () => ({
+  createClient: () => ({
+    auth: {
+      getSession: (...args: unknown[]) => mockGetSession(...args),
+      onAuthStateChange: (...args: unknown[]) => mockOnAuthStateChange(...args),
+    },
+  }),
+}));
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -26,6 +43,12 @@ const serverSettings = {
 describe('useTrackingSettings', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetSession.mockResolvedValue({
+      data: { session: { access_token: 'test-token' } },
+    });
+    mockOnAuthStateChange.mockReturnValue({
+      data: { subscription: { unsubscribe: mockUnsubscribe } },
+    });
   });
 
   it('returns the defaults immediately (placeholder), then server values', async () => {
@@ -44,6 +67,43 @@ describe('useTrackingSettings', () => {
     await waitFor(() => expect(result.current.isLoaded).toBe(true));
     expect(result.current.settings).toEqual(serverSettings);
     expect(result.current.isServerData).toBe(true);
+  });
+
+  it('sends the session bearer token and includes credentials', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ success: true, data: serverSettings }),
+    });
+
+    const { result } = renderHook(() => useTrackingSettings(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+    expect(mockFetch).toHaveBeenCalledWith('/api/tracking/settings', {
+      credentials: 'include',
+      headers: { Authorization: 'Bearer test-token' },
+    });
+  });
+
+  it('does not fetch at all when there is no session', async () => {
+    mockGetSession.mockResolvedValue({ data: { session: null } });
+
+    const { result } = renderHook(() => useTrackingSettings(), {
+      wrapper: createWrapper(),
+    });
+
+    // Let the session check and any (incorrect) query settle.
+    await waitFor(() => expect(mockGetSession).toHaveBeenCalled());
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    // Fail-open: readers still get a fully-populated settings object.
+    expect(result.current.settings).toEqual(TRACKING_SETTINGS_DEFAULTS);
+    expect(result.current.isServerData).toBe(false);
   });
 
   it('merges a driver-scoped partial payload over the defaults', async () => {

--- a/src/hooks/tracking/useTrackingSettings.ts
+++ b/src/hooks/tracking/useTrackingSettings.ts
@@ -10,11 +10,18 @@
  * values actually came from the server. An editor must never seed its form
  * from the fail-open defaults — saving that form would silently reset every
  * customized setting fleet-wide.
+ *
+ * AUTH: the settings endpoint requires an authenticated caller, so the query
+ * sends the Supabase session's bearer token (plus cookies) and is gated on a
+ * session being present — an unauthenticated page must not poll the endpoint
+ * every minute just to collect 401s.
  */
 
 'use client';
 
+import { useEffect, useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { createClient } from '@/utils/supabase/client';
 import {
   TRACKING_SETTINGS_DEFAULTS,
   TrackingSettingsPartialSchema,
@@ -27,9 +34,22 @@ interface TrackingSettingsResult {
   fromServer: boolean;
 }
 
-async function fetchTrackingSettings(): Promise<TrackingSettingsResult> {
+type SupabaseBrowserClient = ReturnType<typeof createClient>;
+
+async function fetchTrackingSettings(
+  supabase: SupabaseBrowserClient,
+): Promise<TrackingSettingsResult> {
   try {
-    const response = await fetch('/api/tracking/settings');
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    if (!session?.access_token) {
+      return { settings: TRACKING_SETTINGS_DEFAULTS, fromServer: false };
+    }
+    const response = await fetch('/api/tracking/settings', {
+      credentials: 'include',
+      headers: { Authorization: `Bearer ${session.access_token}` },
+    });
     if (!response.ok) {
       return { settings: TRACKING_SETTINGS_DEFAULTS, fromServer: false };
     }
@@ -60,9 +80,36 @@ export function useTrackingSettings(): {
   /** True only when the current values were fetched and validated from the server. */
   isServerData: boolean;
 } {
+  const supabase = useMemo(() => createClient(), []);
+
+  // Gate the query (and its 60s polling) on an actual session — an
+  // unauthenticated visitor gets the fail-open defaults with zero requests.
+  const [hasSession, setHasSession] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    supabase.auth
+      .getSession()
+      .then(({ data: { session } }) => {
+        if (!cancelled) setHasSession(!!session);
+      })
+      .catch(() => {
+        if (!cancelled) setHasSession(false);
+      });
+    const { data: listener } = supabase.auth.onAuthStateChange(
+      (_event, session) => {
+        setHasSession(!!session);
+      },
+    );
+    return () => {
+      cancelled = true;
+      listener?.subscription?.unsubscribe?.();
+    };
+  }, [supabase]);
+
   const { data, isFetched } = useQuery({
     queryKey: TRACKING_SETTINGS_QUERY_KEY,
-    queryFn: fetchTrackingSettings,
+    queryFn: () => fetchTrackingSettings(supabase),
+    enabled: hasSession,
     staleTime: 60 * 1000,
     // Long-lived screens (driver portal mid-shift) must converge on admin
     // changes without a remount — matches the server's 60s resolver TTL and

--- a/src/lib/realtime/__tests__/sanitize-text.test.ts
+++ b/src/lib/realtime/__tests__/sanitize-text.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for the dependency-free realtime plain-text sanitizer.
+ *
+ * Regression context: `schemas.ts` used to import `InputSanitizer` from
+ * `@/lib/validation`, which top-level imported `isomorphic-dompurify` and
+ * constructed a JSDOM window at module evaluation. jsdom is a webpack
+ * external, and its html-encoding-sniffer dependency CJS-requires an
+ * ESM-only package — so merely importing the realtime schemas broke every
+ * /driver SSR with ERR_REQUIRE_ESM. The schemas must sanitize without
+ * touching @/lib/validation at all.
+ */
+
+// If `../schemas` (or anything it imports) pulls in @/lib/validation again,
+// this hoisted mock factory throws and the regression test below fails.
+jest.mock('@/lib/validation', () => {
+  throw new Error(
+    'REGRESSION: @/lib/realtime must not import @/lib/validation (jsdom in the driver SSR graph)',
+  );
+});
+
+import { sanitizePlainText } from '../sanitize-text';
+
+describe('sanitizePlainText', () => {
+  it('passes plain realtime payload strings through unchanged', () => {
+    expect(sanitizePlainText('123 Main St, San Francisco')).toBe(
+      '123 Main St, San Francisco',
+    );
+    expect(sanitizePlainText('EN_ROUTE_TO_CLIENT')).toBe('EN_ROUTE_TO_CLIENT');
+    expect(sanitizePlainText('Driver dropped keys at front desk.')).toBe(
+      'Driver dropped keys at front desk.',
+    );
+  });
+
+  it('strips HTML tags but keeps their text content', () => {
+    expect(sanitizePlainText('<b>urgent</b> delivery')).toBe('urgent delivery');
+    expect(sanitizePlainText('<img src=x onerror=alert(1)>note')).toBe('note');
+  });
+
+  it('removes script and style blocks including their content', () => {
+    expect(sanitizePlainText('<script>alert("xss")</script>hello')).toBe('hello');
+    expect(sanitizePlainText('before<style>.x{color:red}</style>after')).toBe(
+      'beforeafter',
+    );
+  });
+
+  it('removes HTML comments', () => {
+    expect(sanitizePlainText('a<!-- hidden -->b')).toBe('ab');
+  });
+
+  it('preserves non-tag angle brackets', () => {
+    expect(sanitizePlainText('1 < 2 > 0')).toBe('1 < 2 > 0');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(sanitizePlainText('  padded  ')).toBe('padded');
+  });
+
+  it('handles null, undefined, and empty input', () => {
+    expect(sanitizePlainText(null)).toBe('');
+    expect(sanitizePlainText(undefined)).toBe('');
+    expect(sanitizePlainText('')).toBe('');
+  });
+
+  it('is idempotent', () => {
+    const inputs = [
+      '<b>urgent</b> delivery',
+      '<script>alert(1)</script>ok',
+      '<<b>script>alert(1)<</b>/script>',
+      'plain text',
+    ];
+    for (const input of inputs) {
+      const once = sanitizePlainText(input);
+      expect(sanitizePlainText(once)).toBe(once);
+    }
+  });
+
+  it('does not let nested markup reassemble into a tag', () => {
+    expect(sanitizePlainText('<<b>script>alert(1)<</b>/script>')).not.toContain(
+      '<script>',
+    );
+  });
+});
+
+describe('realtime schemas import graph (ERR_REQUIRE_ESM regression)', () => {
+  it('imports @/lib/realtime/schemas without loading @/lib/validation', () => {
+    // The jest.mock factory above throws if @/lib/validation is required.
+    expect(() => require('../schemas')).not.toThrow();
+  });
+
+  it('still sanitizes string payload fields through the schemas', () => {
+    const { AdminMessagePayloadSchema } = require('../schemas');
+    const parsed = AdminMessagePayloadSchema.parse({
+      message: '<b>Return</b> to depot <script>alert(1)</script>now',
+    });
+    expect(parsed.message).toBe('Return to depot now');
+  });
+});

--- a/src/lib/realtime/sanitize-text.ts
+++ b/src/lib/realtime/sanitize-text.ts
@@ -1,0 +1,44 @@
+/**
+ * Dependency-free plain-text sanitizer for realtime payload strings.
+ *
+ * Mirrors the observable behavior of `InputSanitizer.sanitizeText`
+ * (src/lib/validation.ts — DOMPurify with ALLOWED_TAGS: [], KEEP_CONTENT:
+ * true, then trim) for the simple strings realtime payloads carry (driver
+ * names, statuses, addresses, notes): strip every HTML tag, drop the content
+ * of dangerous container tags, keep the surrounding text, trim.
+ *
+ * Deliberately NOT DOMPurify: isomorphic-dompurify constructs a JSDOM window
+ * at module evaluation, and jsdom is a webpack external whose
+ * html-encoding-sniffer dependency CJS-requires an ESM-only package —
+ * importing it from the realtime schemas broke every /driver SSR with
+ * ERR_REQUIRE_ESM. Realtime payloads are never rendered as HTML, so a
+ * tag-stripper is sufficient here.
+ */
+
+/** Container tags whose text content must be dropped, not kept. */
+const BLOCK_CONTENT_TAGS =
+  /<(script|style|iframe|object|embed)\b[^>]*>[\s\S]*?<\/\1\s*>/gi;
+
+const HTML_COMMENTS = /<!--[\s\S]*?-->/g;
+
+/**
+ * Anything that looks like an HTML tag: `<name ...>` or `</name ...>`.
+ * Requires a letter after `<` so comparisons like "1 < 2" survive.
+ */
+const HTML_TAGS = /<\/?[a-zA-Z][^>]*>/g;
+
+export function sanitizePlainText(input: string | null | undefined): string {
+  if (input == null) return '';
+  let output = String(input);
+  // Loop until stable so stripping one tag can never reassemble fragments
+  // into a new tag (e.g. "<<b>script>...") that would survive a single pass.
+  let previous: string;
+  do {
+    previous = output;
+    output = output
+      .replace(BLOCK_CONTENT_TAGS, '')
+      .replace(HTML_COMMENTS, '')
+      .replace(HTML_TAGS, '');
+  } while (output !== previous);
+  return output.trim();
+}

--- a/src/lib/realtime/schemas.ts
+++ b/src/lib/realtime/schemas.ts
@@ -6,7 +6,9 @@
  */
 
 import { z } from 'zod';
-import { InputSanitizer } from '@/lib/validation';
+// IMPORTANT: keep this module free of @/lib/validation — that module pulls in
+// isomorphic-dompurify/jsdom, which breaks /driver SSR (ERR_REQUIRE_ESM).
+import { sanitizePlainText } from './sanitize-text';
 import { REALTIME_EVENTS } from './types';
 import { PAYLOAD_CONFIG } from '@/constants/realtime-config';
 
@@ -44,7 +46,7 @@ const LocationSchema = CoordinateSchema.extend({
     .string()
     .min(1, 'Address is required')
     .max(PAYLOAD_CONFIG.MAX_ADDRESS_LENGTH, `Address must not exceed ${PAYLOAD_CONFIG.MAX_ADDRESS_LENGTH} characters`)
-    .transform((val) => InputSanitizer.sanitizeText(val)),
+    .transform((val) => sanitizePlainText(val)),
 });
 
 /**
@@ -70,7 +72,7 @@ const SanitizedStringSchema = (maxLength: number = PAYLOAD_CONFIG.MAX_STRING_LEN
     .string()
     .min(1, 'String cannot be empty')
     .max(maxLength, `String must not exceed ${maxLength} characters`)
-    .transform((val) => InputSanitizer.sanitizeText(val));
+    .transform((val) => sanitizePlainText(val));
 
 // ============================================================================
 // Driver Location Schemas

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,7 +1,25 @@
 // src/lib/validation.ts
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
-import DOMPurify from 'isomorphic-dompurify';
+
+/**
+ * DOMPurify is loaded lazily: isomorphic-dompurify constructs a JSDOM window
+ * at module evaluation, and jsdom is a webpack external (next.config.js)
+ * whose html-encoding-sniffer dependency CJS-requires an ESM-only package —
+ * an eager top-level import made merely importing this module throw
+ * ERR_REQUIRE_ESM during SSR. Deferring (and memoizing) the require means
+ * only code paths that actually sanitize HTML evaluate jsdom.
+ */
+type DOMPurifyInstance = typeof import('isomorphic-dompurify').default;
+let domPurify: DOMPurifyInstance | null = null;
+function getDOMPurify(): DOMPurifyInstance {
+  if (!domPurify) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require('isomorphic-dompurify');
+    domPurify = (mod.default ?? mod) as DOMPurifyInstance;
+  }
+  return domPurify;
+}
 
 // Common validation patterns
 export const ValidationPatterns = {
@@ -129,7 +147,7 @@ export class InputSanitizer {
    * Sanitize HTML content to prevent XSS
    */
   static sanitizeHtml(input: string): string {
-    return DOMPurify.sanitize(input, {
+    return getDOMPurify().sanitize(input, {
       ALLOWED_TAGS: [], // No HTML tags allowed by default
       ALLOWED_ATTR: [],
       KEEP_CONTENT: true
@@ -142,7 +160,7 @@ export class InputSanitizer {
    */
   static sanitizeText(input: string): string {
     // Use DOMPurify with strict settings to remove all HTML tags and malicious content
-    return DOMPurify.sanitize(input, {
+    return getDOMPurify().sanitize(input, {
       ALLOWED_TAGS: [], // Strip all HTML tags
       ALLOWED_ATTR: [], // Strip all attributes
       KEEP_CONTENT: true, // Keep the text content

--- a/src/services/tracking/__tests__/active-shift.test.ts
+++ b/src/services/tracking/__tests__/active-shift.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for resolveActiveShiftIdForDriver — the shift lookup the orders PATCH
+ * uses to stamp `deliveries.shift_id` on the mirror upsert so the
+ * delivery-count trigger has a shift to count against.
+ *
+ * NOTE: the input is the `drivers.id` (the same id `deliveries.driver_id`
+ * references), NOT the profile id that dispatches carry.
+ */
+
+jest.mock('@/utils/prismaDB', () => ({
+  prisma: {
+    driverShift: {
+      findFirst: jest.fn(),
+    },
+  },
+}));
+
+import { resolveActiveShiftIdForDriver } from '../active-shift';
+import { prisma } from '@/utils/prismaDB';
+
+const mockFindFirst = prisma.driverShift.findFirst as jest.Mock;
+
+const DRIVER_ID = '11111111-1111-4111-8111-111111111111';
+const SHIFT_ID = '22222222-2222-4222-8222-222222222222';
+
+describe('resolveActiveShiftIdForDriver', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the most recent ACTIVE, non-deleted shift for the driver', async () => {
+    mockFindFirst.mockResolvedValue({ id: SHIFT_ID });
+
+    const result = await resolveActiveShiftIdForDriver(DRIVER_ID);
+
+    expect(result).toBe(SHIFT_ID);
+    expect(mockFindFirst).toHaveBeenCalledWith({
+      where: { driverId: DRIVER_ID, status: 'active', deletedAt: null },
+      orderBy: { shiftStart: 'desc' },
+      select: { id: true },
+    });
+  });
+
+  it('returns null when the driver has no active shift', async () => {
+    mockFindFirst.mockResolvedValue(null);
+
+    await expect(resolveActiveShiftIdForDriver(DRIVER_ID)).resolves.toBeNull();
+  });
+
+  it('returns null without querying when the driver id is missing', async () => {
+    await expect(resolveActiveShiftIdForDriver(null)).resolves.toBeNull();
+    await expect(resolveActiveShiftIdForDriver(undefined)).resolves.toBeNull();
+    expect(mockFindFirst).not.toHaveBeenCalled();
+  });
+
+  it('fails open to null when the lookup throws', async () => {
+    mockFindFirst.mockRejectedValue(new Error('db down'));
+
+    await expect(resolveActiveShiftIdForDriver(DRIVER_ID)).resolves.toBeNull();
+  });
+});

--- a/src/services/tracking/active-shift.ts
+++ b/src/services/tracking/active-shift.ts
@@ -1,0 +1,37 @@
+/**
+ * Active-shift resolution for the deliveries mirror.
+ *
+ * The orders status PATCH mirrors driver progress into the standalone
+ * `deliveries` table; stamping `shift_id` there is what lets the
+ * `update_shift_delivery_count()` trigger attribute a completed delivery to
+ * the driver's shift. Without it, `driver_shifts.delivery_count` never moves.
+ *
+ * IMPORTANT id linkage: dispatches carry the driver's PROFILE id, while both
+ * `deliveries.driver_id` and `driver_shifts.driver_id` reference the
+ * `drivers.id` row (see src/lib/auth/driver-ownership.ts for the
+ * profile_id/user_id linkage). Callers must pass the resolved `drivers.id`.
+ */
+
+import { prisma } from '@/utils/prismaDB';
+
+/**
+ * Resolve the most recent ACTIVE shift for a driver (`drivers.id`).
+ * Fails open to null — a shift-lookup hiccup must never block a status
+ * update; the mirror row simply stays unattributed like before the fix.
+ */
+export async function resolveActiveShiftIdForDriver(
+  driverId: string | null | undefined,
+): Promise<string | null> {
+  if (!driverId) return null;
+  try {
+    const shift = await prisma.driverShift.findFirst({
+      where: { driverId, status: 'active', deletedAt: null },
+      orderBy: { shiftStart: 'desc' },
+      select: { id: true },
+    });
+    return shift?.id ?? null;
+  } catch (error) {
+    console.error('Failed to resolve active shift for driver:', error);
+    return null;
+  }
+}

--- a/src/utils/__tests__/file-bucket-split.test.ts
+++ b/src/utils/__tests__/file-bucket-split.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for the pure bucket-split helpers used by the order files route.
+ *
+ * POD artifacts (proof-of-delivery photos, pickup signatures) live in the
+ * 'delivery-proofs' bucket while every other upload lives in the default
+ * 'fileUploader' bucket. Signing a POD path against the default bucket
+ * produces a broken URL — the route must split paths per bucket and merge
+ * the signed-URL maps back together.
+ */
+
+import {
+  isPodFileCategory,
+  mergeSignedUrlMaps,
+  splitFilePathsByBucket,
+} from '../file-bucket-split';
+
+describe('isPodFileCategory', () => {
+  it('matches the exact stored categories', () => {
+    // Exact values written by prisma.fileUpload.create in the pod and
+    // signature routes.
+    expect(isPodFileCategory('proof_of_delivery')).toBe(true);
+    expect(isPodFileCategory('pickup_signature')).toBe(true);
+  });
+
+  it('matches case-insensitively and ignores surrounding whitespace', () => {
+    expect(isPodFileCategory('Proof_Of_Delivery')).toBe(true);
+    expect(isPodFileCategory(' PICKUP_SIGNATURE ')).toBe(true);
+  });
+
+  it('rejects non-POD categories and missing values', () => {
+    expect(isPodFileCategory('catering-order')).toBe(false);
+    expect(isPodFileCategory('on-demand')).toBe(false);
+    expect(isPodFileCategory('')).toBe(false);
+    expect(isPodFileCategory(null)).toBe(false);
+    expect(isPodFileCategory(undefined)).toBe(false);
+  });
+});
+
+describe('splitFilePathsByBucket', () => {
+  it('routes POD categories to podPaths and everything else to defaultPaths', () => {
+    const files = [
+      { filePath: 'catering/menu.pdf', category: 'catering-order' },
+      { filePath: 'pod/order-1/photo.jpg', category: 'proof_of_delivery' },
+      { filePath: 'pod/order-1/signature.png', category: 'pickup_signature' },
+      { filePath: 'misc/invoice.pdf', category: null },
+    ];
+
+    expect(splitFilePathsByBucket(files)).toEqual({
+      podPaths: ['pod/order-1/photo.jpg', 'pod/order-1/signature.png'],
+      defaultPaths: ['catering/menu.pdf', 'misc/invoice.pdf'],
+    });
+  });
+
+  it('skips files without a filePath', () => {
+    const files = [
+      { filePath: null, category: 'proof_of_delivery' },
+      { filePath: '', category: 'catering-order' },
+    ];
+
+    expect(splitFilePathsByBucket(files)).toEqual({
+      podPaths: [],
+      defaultPaths: [],
+    });
+  });
+
+  it('returns empty groups for an empty list', () => {
+    expect(splitFilePathsByBucket([])).toEqual({
+      podPaths: [],
+      defaultPaths: [],
+    });
+  });
+});
+
+describe('mergeSignedUrlMaps', () => {
+  it('merges maps so the response lookup shape is unchanged', () => {
+    const defaults = new Map([['a.pdf', 'https://signed/a']]);
+    const pods = new Map([['pod/b.jpg', 'https://signed/b']]);
+
+    const merged = mergeSignedUrlMaps(defaults, pods);
+
+    expect(merged.size).toBe(2);
+    expect(merged.get('a.pdf')).toBe('https://signed/a');
+    expect(merged.get('pod/b.jpg')).toBe('https://signed/b');
+  });
+
+  it('handles empty maps', () => {
+    expect(mergeSignedUrlMaps(new Map(), new Map()).size).toBe(0);
+  });
+});

--- a/src/utils/file-bucket-split.ts
+++ b/src/utils/file-bucket-split.ts
@@ -1,0 +1,67 @@
+/**
+ * Pure helpers for routing file_uploads rows to the correct storage bucket
+ * when generating signed URLs.
+ *
+ * POD artifacts (proof-of-delivery photos and pickup signatures) are uploaded
+ * to the dedicated 'delivery-proofs' bucket (POD_BUCKET_NAME in
+ * src/utils/supabase/storage.ts); every other upload lives in the default
+ * 'fileUploader' bucket (STORAGE_BUCKETS.DEFAULT in src/utils/file-service.ts).
+ * Signing a POD path against the default bucket yields a URL that 404s, so
+ * callers must split paths per bucket, sign each group against its own
+ * bucket, and merge the results.
+ *
+ * Kept dependency-free so it can be unit tested without mocking Supabase.
+ */
+
+/**
+ * Categories written by the POD and pickup-signature upload routes
+ * (`prisma.fileUpload.create` in src/app/api/orders/[order_number]/pod and
+ * .../signature). Matched case-insensitively for safety.
+ */
+export const POD_FILE_CATEGORIES = ['proof_of_delivery', 'pickup_signature'] as const;
+
+export function isPodFileCategory(category: string | null | undefined): boolean {
+  if (!category) return false;
+  return (POD_FILE_CATEGORIES as readonly string[]).includes(
+    category.trim().toLowerCase(),
+  );
+}
+
+export interface BucketPathSplit {
+  /** filePaths stored in the POD bucket ('delivery-proofs'). */
+  podPaths: string[];
+  /** filePaths stored in the default bucket ('fileUploader'). */
+  defaultPaths: string[];
+}
+
+export function splitFilePathsByBucket(
+  files: ReadonlyArray<{ filePath: string | null; category: string | null }>,
+): BucketPathSplit {
+  const podPaths: string[] = [];
+  const defaultPaths: string[] = [];
+  for (const file of files) {
+    if (!file.filePath) continue;
+    if (isPodFileCategory(file.category)) {
+      podPaths.push(file.filePath);
+    } else {
+      defaultPaths.push(file.filePath);
+    }
+  }
+  return { podPaths, defaultPaths };
+}
+
+/**
+ * Merge per-bucket signed-URL maps (keyed by filePath) into one lookup so the
+ * caller's path -> URL mapping is unchanged from the single-bucket days.
+ */
+export function mergeSignedUrlMaps(
+  ...maps: ReadonlyArray<ReadonlyMap<string, string>>
+): Map<string, string> {
+  const merged = new Map<string, string>();
+  for (const map of maps) {
+    for (const [path, url] of map) {
+      merged.set(path, url);
+    }
+  }
+  return merged;
+}

--- a/supabase/migrations/20260806000000_fix_shift_delivery_count_status.sql
+++ b/supabase/migrations/20260806000000_fix_shift_delivery_count_status.sql
@@ -1,0 +1,66 @@
+-- ============================================================================
+-- Migration: Fix update_shift_delivery_count() status matching
+-- Date: 2026-08-06
+--
+-- The original function (20251127000000_add_mileage_columns_miles.sql L95-148)
+-- counted only rows with status = 'delivered' (exact, lowercase). The orders
+-- PATCH mirrors driver progress into `deliveries` using the DriverStatus
+-- enum's UPPERCASE values and terminates at 'COMPLETED', so the trigger never
+-- matched anything and driver_shifts.delivery_count never incremented.
+--
+-- Fix: make the comparison case-insensitive and count both 'delivered' and
+-- 'completed'. Everything else in the function is unchanged. The existing
+-- trigger (trigger_update_shift_delivery_count) references the function by
+-- name, so CREATE OR REPLACE is sufficient — no trigger recreation needed.
+-- ============================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION update_shift_delivery_count()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Update delivery count when a delivery's shift_id changes or delivery is completed
+  IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+    IF NEW.shift_id IS NOT NULL THEN
+      UPDATE driver_shifts
+      SET delivery_count = (
+        SELECT COUNT(*)
+        FROM deliveries
+        WHERE shift_id = NEW.shift_id
+          AND LOWER(status) IN ('delivered','completed')
+          AND deleted_at IS NULL
+      )
+      WHERE id = NEW.shift_id;
+    END IF;
+
+    -- Handle case where delivery moved from one shift to another
+    IF TG_OP = 'UPDATE' AND OLD.shift_id IS NOT NULL AND OLD.shift_id != NEW.shift_id THEN
+      UPDATE driver_shifts
+      SET delivery_count = (
+        SELECT COUNT(*)
+        FROM deliveries
+        WHERE shift_id = OLD.shift_id
+          AND LOWER(status) IN ('delivered','completed')
+          AND deleted_at IS NULL
+      )
+      WHERE id = OLD.shift_id;
+    END IF;
+  END IF;
+
+  IF TG_OP = 'DELETE' AND OLD.shift_id IS NOT NULL THEN
+    UPDATE driver_shifts
+    SET delivery_count = (
+      SELECT COUNT(*)
+      FROM deliveries
+      WHERE shift_id = OLD.shift_id
+        AND LOWER(status) IN ('delivered','completed')
+        AND deleted_at IS NULL
+    )
+    WHERE id = OLD.shift_id;
+  END IF;
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Fernando's web-mobile driver test drive on `development.readysetllc.com` (order "Destino Cater Cow 1") completed successfully, but Vercel logs + rs-dev DB inspection surfaced four defects. One commit per fix:

1. **POD signed URLs 404** — the order files route signed every path against the `fileUploader` bucket, but POD photos and pickup signatures live in `delivery-proofs`. Paths are now split per bucket by category and the signed-URL maps merged (verified: both of Fernando's objects exist in `delivery-proofs` at the recorded paths).
2. **Tracking-settings 401 loop** — `useTrackingSettings` polled with no credentials/bearer every 60s and never stopped. It now sends the Supabase session bearer token + cookies and is disabled until a session exists.
3. **ERR_REQUIRE_ESM on every /driver SSR** — `realtime/schemas.ts` pulled `isomorphic-dompurify`/jsdom into the driver graph; html-encoding-sniffer@6 CJS-requires the ESM-only @exodus/bytes. Realtime schemas now use a dependency-free plain-text sanitizer, and DOMPurify is lazy-loaded in `lib/validation` for its remaining consumers.
4. **delivery_count stuck at 0** — the deliveries mirror never stamped `shift_id` and the trigger only matched lowercase `'delivered'`. The mirror now resolves the driver's active shift, the trigger matches case-insensitively incl. `'completed'` (migration `20260806000000`), and `endDriverShift` recomputes the count before closing.

## Testing

- TDD: 5 new/extended test suites; touched suites 156 tests green, consumer suites 105 tests green
- `pnpm pre-push-check` passes (typecheck + lint + prisma validate)

## Post-merge

- Migration `20260806000000_fix_shift_delivery_count_status.sql` needs applying to rs-dev (and prod at next promotion)
- Follow-up (not this PR): `jsdom` is devDependency-only but required at prod runtime by isomorphic-dompurify